### PR TITLE
Delete null comparisons of non-null arguments

### DIFF
--- a/configurecompiler.cmake
+++ b/configurecompiler.cmake
@@ -256,7 +256,7 @@ if (MSVC)
   add_link_options($<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:/SUBSYSTEM:WINDOWS,${WINDOWS_SUBSYSTEM_VERSION}>)
 
   set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /IGNORE:4221")
-  
+
   add_link_options($<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:/DEBUG>)
   add_link_options($<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:/PDBCOMPRESS>)
   add_link_options($<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:/STACK:1572864>)
@@ -312,7 +312,7 @@ elseif (CLR_CMAKE_PLATFORM_UNIX)
       endif ()
       if (${__UBSAN_POS} GREATER -1)
         # all sanitizier flags are enabled except alignment (due to heavy use of __unaligned modifier)
-        list(APPEND CLR_CXX_SANITIZERS 
+        list(APPEND CLR_CXX_SANITIZERS
           "bool"
           bounds
           enum
@@ -513,9 +513,6 @@ if (CLR_CMAKE_PLATFORM_UNIX)
   else()
     add_compile_options(-Wno-unused-but-set-variable)
     add_compile_options(-Wno-unknown-pragmas)
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
-      add_compile_options(-Wno-nonnull-compare)
-    endif()
     if (COMPILER_SUPPORTS_F_ALIGNED_NEW)
       add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-faligned-new>)
     endif()

--- a/src/ToolBox/superpmi/superpmi-shared/lightweightmap.h
+++ b/src/ToolBox/superpmi/superpmi-shared/lightweightmap.h
@@ -373,7 +373,6 @@ public:
 
     int GetIndex(_Key key)
     {
-        AssertCodeMsg(this != nullptr, EXCEPTIONCODE_MC, "There is no such LWM (in GetIndex)");
         if (numItems == 0)
             return -1;
 

--- a/src/debug/di/module.cpp
+++ b/src/debug/di/module.cpp
@@ -4,7 +4,7 @@
 
 //*****************************************************************************
 // File: module.cpp
-// 
+//
 
 //
 //*****************************************************************************
@@ -46,7 +46,7 @@ STDAPI ReOpenMetaDataWithMemoryEx(
 
 //---------------------------------------------------------------------------------------
 // Initialize a new CordbModule around a Module in the target.
-// 
+//
 // Arguments:
 //    pProcess - process that this module lives in
 //    vmDomainFile - CLR cookie for module.
@@ -54,7 +54,7 @@ CordbModule::CordbModule(
     CordbProcess *     pProcess,
     VMPTR_Module        vmModule,
     VMPTR_DomainFile    vmDomainFile)
-: CordbBase(pProcess, vmDomainFile.IsNull() ? VmPtrToCookie(vmModule) : VmPtrToCookie(vmDomainFile), enumCordbModule), 
+: CordbBase(pProcess, vmDomainFile.IsNull() ? VmPtrToCookie(vmModule) : VmPtrToCookie(vmDomainFile), enumCordbModule),
     m_pAssembly(0),
     m_pAppDomain(0),
     m_classes(11),
@@ -89,9 +89,9 @@ CordbModule::CordbModule(
     if (!vmDomainFile.IsNull())
     {
         DomainFileInfo dfInfo;
-        
+
         pProcess->GetDAC()->GetDomainFileData(vmDomainFile, &dfInfo); // throws
-        
+
         m_pAppDomain = pProcess->LookupOrCreateAppDomain(dfInfo.vmAppDomain);
         m_pAssembly  = m_pAppDomain->LookupOrCreateAssembly(dfInfo.vmDomainAssembly);
     }
@@ -115,11 +115,11 @@ CordbModule::CordbModule(
 #ifdef _DEBUG
 //---------------------------------------------------------------------------------------
 // Callback helper for code:CordbModule::DbgAssertModuleDeleted
-// 
+//
 // Arguments
 //    vmDomainFile - domain file in the enumeration
 //    pUserData - pointer to the CordbModule that we just got an exit event for.
-//    
+//
 void DbgAssertModuleDeletedCallback(VMPTR_DomainFile vmDomainFile, void * pUserData)
 {
     CordbModule * pThis = reinterpret_cast<CordbModule *>(pUserData);
@@ -128,9 +128,9 @@ void DbgAssertModuleDeletedCallback(VMPTR_DomainFile vmDomainFile, void * pUserD
     if (!pThis->m_vmDomainFile.IsNull())
     {
         VMPTR_DomainFile vmDomainFileDeleted = pThis->m_vmDomainFile;
-        
-        CONSISTENCY_CHECK_MSGF((vmDomainFileDeleted != vmDomainFile), 
-            ("A Module Unload event was sent for a module, but it still shows up in the enumeration.\n vmDomainFileDeleted=%p\n", 
+
+        CONSISTENCY_CHECK_MSGF((vmDomainFileDeleted != vmDomainFile),
+            ("A Module Unload event was sent for a module, but it still shows up in the enumeration.\n vmDomainFileDeleted=%p\n",
             VmPtrToCookie(vmDomainFileDeleted)));
     }
 }
@@ -140,8 +140,8 @@ void DbgAssertModuleDeletedCallback(VMPTR_DomainFile vmDomainFile, void * pUserD
 //
 // Notes:
 //   See code:IDacDbiInterface#Enumeration for rules that we're asserting.
-//   This is a debug only method. It's conceptually similar to 
-//   code:CordbProcess::DbgAssertAppDomainDeleted. 
+//   This is a debug only method. It's conceptually similar to
+//   code:CordbProcess::DbgAssertAppDomainDeleted.
 //
 void CordbModule::DbgAssertModuleDeleted()
 {
@@ -179,21 +179,21 @@ void CordbModule::Neuter()
 
 //
 // Creates an IStream based off the memory described by the TargetBuffer.
-// 
+//
 // Arguments:
 //   pProcess - process that buffer is valid in.
 //   buffer - memory range in target
 //   ppStream - out parameter to receive the new stream. *ppStream == NULL on input.
 //      caller owns the new object and must call Release.
-//   
+//
 // Returns:
-//    Throws on error. 
+//    Throws on error.
 //    Common errors include if memory is missing in the target.
-//    
+//
 // Notes:
-//   This will copy the memory over from the TargetBuffer, and then create a new IStream 
-//   object around it. 
-//   
+//   This will copy the memory over from the TargetBuffer, and then create a new IStream
+//   object around it.
+//
 void GetStreamFromTargetBuffer(CordbProcess * pProcess, TargetBuffer buffer, IStream ** ppStream)
 {
     CONTRACTL
@@ -204,10 +204,10 @@ void GetStreamFromTargetBuffer(CordbProcess * pProcess, TargetBuffer buffer, ISt
 
     _ASSERTE(ppStream != NULL);
     _ASSERTE(*ppStream == NULL);
-    
+
     int cbSize = buffer.cbSize;
     NewArrayHolder<BYTE> localBuffer(new BYTE[cbSize]);
-    
+
     pProcess->SafeReadBuffer(buffer, localBuffer);
 
     HRESULT hr = E_FAIL;
@@ -218,21 +218,21 @@ void GetStreamFromTargetBuffer(CordbProcess * pProcess, TargetBuffer buffer, ISt
 
 //
 // Helper API to get in-memory symbols from the target into a host stream object.
-// 
+//
 // Arguments:
 //   ppStream - out parameter to receive the new stream. *ppStream == NULL on input.
 //      caller owns the new object and must call Release.
-//      
+//
 // Returns:
-//   kSymbolFormatNone if no PDB stream is present. This is a common case for 
-//     file-based modules, and also for dynamic modules that just aren't tracking 
-//     debug information. 
+//   kSymbolFormatNone if no PDB stream is present. This is a common case for
+//     file-based modules, and also for dynamic modules that just aren't tracking
+//     debug information.
 //   The format of the symbols stored into ppStream. This is common:
 //      - Ref.Emit modules if the debuggee generated debug symbols,
 //      - in-memory modules (such as Load(Byte[], Byte[])
 //      - hosted modules.
 //   Throws on error
-// 
+//
 IDacDbiInterface::SymbolFormat CordbModule::GetInMemorySymbolStream(IStream ** ppStream)
 {
     // @dbgtodo : add a PUBLIC_REENTRANT_API_ENTRY_FOR_SHIM contract
@@ -286,7 +286,7 @@ VMPTR_PEFile CordbModule::GetPEFile()
 // Top-level getter for the public metadata importer for this module
 //
 // Returns:
-//     metadata importer. 
+//     metadata importer.
 //     Never returns NULL. Will throw some hr (likely CORDBG_E_MISSING_METADATA) instead.
 //
 // Notes:
@@ -301,7 +301,7 @@ IMetaDataImport * CordbModule::GetMetaDataImporter()
 
 
     // If we already have it, then we're done.
-    // This is critical to do at the top of this function to avoid potential recursion. 
+    // This is critical to do at the top of this function to avoid potential recursion.
     if (m_pIMImport != NULL)
     {
         return m_pIMImport;
@@ -352,7 +352,7 @@ IMetaDataImport * CordbModule::GetMetaDataImporter()
 //
 // Notes:
 //    In profiler case, this may be referred to new rows and we may need to update the metadata
-//    This only supports StandAloneSigs. 
+//    This only supports StandAloneSigs.
 //
 void CordbModule::UpdateMetaDataCacheIfNeeded(mdToken token)
 {
@@ -368,7 +368,7 @@ void CordbModule::UpdateMetaDataCacheIfNeeded(mdToken token)
     // then we should avoid this temporary update mechanism entirely
     if(GetProcess()->GetWriteableMetadataUpdateMode() != LegacyCompatPolicy)
     {
-        return; 
+        return;
     }
 
     // the metadata in WinMD is currently static since there's no
@@ -380,23 +380,23 @@ void CordbModule::UpdateMetaDataCacheIfNeeded(mdToken token)
     }
 
     //
-    // 1) Check if in-range? Compare against tables, etc. 
-    // 
+    // 1) Check if in-range? Compare against tables, etc.
+    //
     if(CheckIfTokenInMetaData(token))
     {
         LOG((LF_CORDB,LL_INFO10000, "CM::UMCIN token was present\n"));
         return;
     }
 
-    // 
+    //
     // 2) Copy over new MetaData. From now on we assume that the profiler is
     //    modifying module metadata and that we need to serialize in process
     //    at each refresh
-    // 
+    //
     LOG((LF_CORDB,LL_INFO10000, "CM::UMCIN token was not present, refreshing\n"));
     m_fForceMetaDataSerialize = TRUE;
     RefreshMetaData();
-    
+
     // If we are dump debugging, we may still not have it. Nothing to be done.
 }
 
@@ -409,7 +409,7 @@ BOOL CordbModule::CheckIfTokenInMetaData(mdToken token)
     }
     CONTRACTL_END;
     LOG((LF_CORDB,LL_INFO10000, "CM::CITIM token=0x%x\n", token));
-    _ASSERTE(TypeFromToken(token) == mdtSignature);    
+    _ASSERTE(TypeFromToken(token) == mdtSignature);
     // we shouldn't be doing this on WinMD modules since they don't implement IID_IMetaDataTables
     _ASSERTE(!IsWinMD());
     RSExtSmartPtr<IMetaDataTables> pTable;
@@ -423,20 +423,20 @@ BOOL CordbModule::CheckIfTokenInMetaData(mdToken token)
     }
 
     ULONG cbRowsAvailable; // number of rows in the table
-    
-    hr = pTable->GetTableInfo(    
+
+    hr = pTable->GetTableInfo(
         mdtSignature >> 24,                      // [IN] Which table.
         NULL,                    // [OUT] Size of a row, bytes.
         &cbRowsAvailable,                    // [OUT] Number of rows.
         NULL,                    // [OUT] Number of columns in each row.
         NULL,                     // [OUT] Key column, or -1 if none.
         NULL);          // [OUT] Name of the table.
-    
+
     _ASSERTE(SUCCEEDED(hr));
     if (FAILED(hr))
     {
         ThrowHR(hr);
-    }    
+    }
 
 
     // Rows start counting with number 1.
@@ -455,7 +455,7 @@ public:
     TargetBuffer bufferMetaData;
     BOOL fDoCleanup;
 
-    CleanupRemoteBuffer() : 
+    CleanupRemoteBuffer() :
     fDoCleanup(FALSE) { }
 
     ~CleanupRemoteBuffer()
@@ -500,7 +500,7 @@ void CordbModule::RefreshMetaData()
     //    an error reading by file we can fall back to case #2 for these modules
     // 2) Most modules have a buffer in target memory that represents their
     //    metadata. We copy that data over the RS and construct an in-memory
-    //    importer on top of it. 
+    //    importer on top of it.
     // 3) The only modules that don't have a suitable buffer (case #2) are those
     //    modified in memory via the profiling API (or ENC). A message can be sent from
     //    the debugger to the debuggee instructing it to allocate a buffer and
@@ -543,7 +543,7 @@ void CordbModule::RefreshMetaData()
         if (remoteMDInternalRWAddr != NULL)
         {
             // we should only be doing this once to initialize, we don't support reopen with this technique
-            _ASSERTE(m_pIMImport == NULL); 
+            _ASSERTE(m_pIMImport == NULL);
             ULONG32 mdStructuresVersion;
             HRESULT hr = GetProcess()->GetDAC()->GetMDStructuresVersion(&mdStructuresVersion);
             IfFailThrow(hr);
@@ -567,7 +567,7 @@ void CordbModule::RefreshMetaData()
     if(!m_fForceMetaDataSerialize) // case 1 and 2
     {
         LOG((LF_CORDB,LL_INFO10000, "CM::RM !m_fForceMetaDataSerialize case\n"));
-        GetProcess()->GetDAC()->GetMetadata(m_vmModule, &bufferMetaData); // throws 
+        GetProcess()->GetDAC()->GetMetadata(m_vmModule, &bufferMetaData); // throws
     }
     else if (GetProcess()->GetShim() == NULL) // case 3 won't work on a dump so don't try
     {
@@ -604,7 +604,7 @@ void CordbModule::RefreshMetaData()
         cleanup.fDoCleanup = TRUE;
     }
 
-    InitMetaData(bufferMetaData, IsFileMetaDataValid()); // throws 
+    InitMetaData(bufferMetaData, IsFileMetaDataValid()); // throws
 }
 
 // Determines whether the on-disk metadata for this module is usable as the
@@ -645,16 +645,16 @@ BOOL CordbModule::IsFileMetaDataValid()
 
 //---------------------------------------------------------------------------------------
 // Accessor for Internal MetaData importer. This is lazily initialized.
-// 
+//
 // Returns:
 //     Internal MetaDataImporter, which can be handed off to DAC. Not AddRef().
 //     Should be non-null. Throws on error.
 //
 // Notes:
 //     An internal metadata importer is used extensively by DAC-ized code (And Edit-and-continue).
-//     This should not be handed out through ICorDebug. 
+//     This should not be handed out through ICorDebug.
 IMDInternalImport * CordbModule::GetInternalMD()
-{   
+{
     if (m_pInternalMetaDataImport == NULL)
     {
         UpdateInternalMetaData(); // throws
@@ -663,7 +663,7 @@ IMDInternalImport * CordbModule::GetInternalMD()
 }
 
 //---------------------------------------------------------------------------------------
-// The one-stop top-level initialization function the metadata (both public and private) for this module. 
+// The one-stop top-level initialization function the metadata (both public and private) for this module.
 //
 // Arguments:
 //    buffer - valid buffer into target containing the metadata.
@@ -675,7 +675,7 @@ IMDInternalImport * CordbModule::GetInternalMD()
 // Notes:
 //    This will initialize both the internal and public metadata from the buffer in the target.
 //    Only called as a helper from RefreshMetaData()
-// 
+//
 //    This may throw (eg, target buffer is missing).
 //
 void CordbModule::InitMetaData(TargetBuffer buffer, BOOL allowFileMappingOptimization)
@@ -685,8 +685,8 @@ void CordbModule::InitMetaData(TargetBuffer buffer, BOOL allowFileMappingOptimiz
         THROWS;
     }
     CONTRACTL_END;
-    
-    LOG((LF_CORDB,LL_INFO100000, "CM::IM: initing with remote buffer 0x%p length 0x%x\n", 
+
+    LOG((LF_CORDB,LL_INFO100000, "CM::IM: initing with remote buffer 0x%p length 0x%x\n",
         CORDB_ADDRESS_TO_PTR(buffer.pAddress), buffer.cbSize));
 
     // clear all the metadata
@@ -715,7 +715,7 @@ void CordbModule::InitMetaData(TargetBuffer buffer, BOOL allowFileMappingOptimiz
 
         if(!allowFileMappingOptimization || FAILED(hr))
         {
-            // This is where the expensive copy of all metadata content from target memory 
+            // This is where the expensive copy of all metadata content from target memory
             // that we would like to try and avoid happens.
             InitPublicMetaData(buffer);
         }
@@ -741,7 +741,7 @@ void CordbModule::InitMetaData(TargetBuffer buffer, BOOL allowFileMappingOptimiz
 //
 // Assumptions:
 //     Caller has cleared Internal metadata before even updating public metadata.
-//     This way, if the caller fails halfway through updating the public metadata, we don't have 
+//     This way, if the caller fails halfway through updating the public metadata, we don't have
 //     stale internal MetaData.
 void CordbModule::UpdateInternalMetaData()
 {
@@ -758,15 +758,15 @@ void CordbModule::UpdateInternalMetaData()
     IMetaDataImport * pImport = GetMetaDataImporter(); // throws
 
     // If both the public and the private interfaces are NULL on entry to this function, the call above will
-    // recursively call this function.  This can happen if the caller calls GetInternalMD() directly 
+    // recursively call this function.  This can happen if the caller calls GetInternalMD() directly
     // instead of InitMetaData().  In this case, the above function call will have initialized the internal
     // interface as well, so we need to check for it here.
 
     if (m_pInternalMetaDataImport == NULL)
     {
         HRESULT hr = GetMDInternalInterfaceFromPublic(
-            pImport, 
-            IID_IMDInternalImport, 
+            pImport,
+            IID_IMDInternalImport,
             reinterpret_cast<void**> (&m_pInternalMetaDataImport));
 
         if (m_pInternalMetaDataImport == NULL)
@@ -813,7 +813,7 @@ HRESULT CordbModule::InitPublicMetaDataFromFile()
         // Its possible that the debugger would still load the NGEN image sometime in the future and we will miss a sharing
         // opportunity. Its an acceptable loss from an imperfect heuristic.
         if (NULL == WszGetModuleHandle(szFullPathName))
-#endif            
+#endif
         {
             szFullPathName = NULL;
             fDebuggerLoadingNgen = false;
@@ -845,7 +845,7 @@ HRESULT CordbModule::InitPublicMetaDataFromFile()
     }
 
 
-    // @dbgtodo  metadata  - This is really a CreateFile() call which we can't do. We must offload this to 
+    // @dbgtodo  metadata  - This is really a CreateFile() call which we can't do. We must offload this to
     // the data target for the dump-debugging scenarios.
     //
     // We're opening it as "read". If we QI for an IEmit interface (which we need for EnC),
@@ -856,7 +856,7 @@ HRESULT CordbModule::InitPublicMetaDataFromFile()
     // If we know we're never going to need to write (i.e. never do EnC), then we should indicate
     // that to metadata by telling it this interface will always be read-only.  By passing read-only,
     // the metadata library will then also share the VM space for the image when the same image is
-    // opened multiple times for multiple AppDomains.  
+    // opened multiple times for multiple AppDomains.
     // We don't currently have a way to tell absolutely whether this module will support EnC, but we
     // know that NGen modules NEVER support EnC, and NGen is the common case that eats up a lot of VM.
     // So we'll use the heuristic of opening the metadata for all ngen images as read-only.  Ideally
@@ -880,11 +880,11 @@ HRESULT CordbModule::InitPublicMetaDataFromFile(const WCHAR * pszFullPathName,
                                                 DWORD dwOpenFlags,
                                                 bool validateFileInfo)
 {
-#ifdef FEATURE_PAL    
+#ifdef FEATURE_PAL
     // UNIXTODO: Some intricate details of file mapping don't work on Linux as on Windows.
-    // We have to revisit this and try to fix it for POSIX system. 
+    // We have to revisit this and try to fix it for POSIX system.
     return E_FAIL;
-#else    
+#else
     if (validateFileInfo)
     {
         // Check that we've got the right file to target.
@@ -899,7 +899,7 @@ HRESULT CordbModule::InitPublicMetaDataFromFile(const WCHAR * pszFullPathName,
         bool isNGEN = false; // unused
         StringCopyHolder filePath;
 
-        
+
         _ASSERTE(!m_vmPEFile.IsNull());
         // MetaData lookup favors the NGEN image, which is what we want here.
         if (!this->GetProcess()->GetDAC()->GetMetaDataFileInfoFromPEFile(m_vmPEFile,
@@ -914,12 +914,12 @@ HRESULT CordbModule::InitPublicMetaDataFromFile(const WCHAR * pszFullPathName,
 
         // If the timestamp and size don't match, then this is the wrong file!
         // Map the file and check them.
-        HandleHolder hMDFile = WszCreateFile(pszFullPathName, 
-                                              GENERIC_READ, 
-                                              FILE_SHARE_READ, 
+        HandleHolder hMDFile = WszCreateFile(pszFullPathName,
+                                              GENERIC_READ,
+                                              FILE_SHARE_READ,
                                               NULL,                 // default security descriptor
-                                              OPEN_EXISTING, 
-                                              FILE_ATTRIBUTE_NORMAL, 
+                                              OPEN_EXISTING,
+                                              FILE_ATTRIBUTE_NORMAL,
                                               NULL);
 
         if (hMDFile == INVALID_HANDLE_VALUE)
@@ -965,7 +965,7 @@ HRESULT CordbModule::InitPublicMetaDataFromFile(const WCHAR * pszFullPathName,
             (dwImageTimeStamp != pedecoder.GetTimeDateStamp()))
         {
             LOG((LF_CORDB,LL_WARNING, "CM::IM: Validation of \"%s\" failed.  "
-                "Expected size=%x, Expected timestamp=%x, Actual size=%x, Actual timestamp=%x\n", 
+                "Expected size=%x, Expected timestamp=%x, Actual size=%x, Actual timestamp=%x\n",
                 pszFullPathName,
                 pedecoder.GetVirtualSize(),
                 pedecoder.GetTimeDateStamp(),
@@ -988,12 +988,12 @@ HRESULT CordbModule::InitPublicMetaDataFromFile(const WCHAR * pszFullPathName,
         // This should never happen in normal scenarios.  It could happen if someone has renamed
         // the assembly after it was opened by the debugee process, but this should be rare enough
         // that we don't mind taking the perf. hit and loading from memory.
-        // @dbgtodo  metadata  - would this happen in the shadow-copy scenario? 
+        // @dbgtodo  metadata  - would this happen in the shadow-copy scenario?
         LOG((LF_CORDB,LL_WARNING, "CM::IM: Couldn't open metadata in file \"%s\" (hr=%x)\n", pszFullPathName, hr));
     }
 
     return hr;
-#endif // FEATURE_PAL     
+#endif // FEATURE_PAL
 }
 
 //---------------------------------------------------------------------------------------
@@ -1003,7 +1003,7 @@ HRESULT CordbModule::InitPublicMetaDataFromFile(const WCHAR * pszFullPathName,
 //    buffer - valid buffer into target containing the metadata.
 //
 // Assumptions:
-//    This is an internal function which should only be called once to initialize the 
+//    This is an internal function which should only be called once to initialize the
 //    metadata. Future attempts to re-initialize (in dynamic cases) should call code:CordbModule::UpdatePublicMetaDataFromRemote
 //    After the public metadata is initialized, initialize private metadata via code:CordbModule::UpdateInternalMetaData
 //
@@ -1016,14 +1016,14 @@ void CordbModule::InitPublicMetaData(TargetBuffer buffer)
     CONTRACTL_END;
 
     INTERNAL_API_ENTRY(this->GetProcess());
-    LOG((LF_CORDB,LL_INFO100000, "CM::IPM: initing with remote buffer 0x%p length 0x%x\n", 
+    LOG((LF_CORDB,LL_INFO100000, "CM::IPM: initing with remote buffer 0x%p length 0x%x\n",
         CORDB_ADDRESS_TO_PTR(buffer.pAddress), buffer.cbSize));
     ULONG nMetaDataSize = buffer.cbSize;
 
     if (nMetaDataSize == 0)
     {
-        // We should always have metadata, and if we don't, we want to know. 
-        // @dbgtodo  metadata - we know metadata from dynamic modules doesn't work in V3 
+        // We should always have metadata, and if we don't, we want to know.
+        // @dbgtodo  metadata - we know metadata from dynamic modules doesn't work in V3
         // (non-shim) cases yet.
         // But our caller should already have handled that case.
         SIMPLIFYING_ASSUMPTION(!"Error: missing the metadata");
@@ -1039,8 +1039,8 @@ void CordbModule::InitPublicMetaData(TargetBuffer buffer)
 
     CoTaskMemHolder<VOID> pMetaDataCopy;
     CopyRemoteMetaData(buffer, pMetaDataCopy.GetAddr());
-    
-    
+
+
     //
     // Setup our metadata import object, m_pIMImport
     //
@@ -1067,12 +1067,12 @@ void CordbModule::InitPublicMetaData(TargetBuffer buffer)
     // MetaData has taken ownership -don't free the memory
     pMetaDataCopy.SuppressRelease();
 
-    // Immediately restore the old setting. 
+    // Immediately restore the old setting.
     HRESULT hrRestore = pDisp->SetOption(MetaDataSetUpdate, &valueOld);
     SIMPLIFYING_ASSUMPTION(!FAILED(hrRestore));
 
     // Throw on errors.
-    IfFailThrow(hr);    
+    IfFailThrow(hr);
     IfFailThrow(hrRestore);
 
     // Done!
@@ -1092,11 +1092,11 @@ void CordbModule::InitPublicMetaData(TargetBuffer buffer)
 //     it can OpenScopeOnMemory().
 //
 void CordbModule::UpdatePublicMetaDataFromRemote(TargetBuffer bufferRemoteMetaData)
-{    
+{
     CONTRACTL
     {
-        // @dbgtodo  metadata  - think about the error semantics here. These fails during dispatching an event; so 
-        // address this during event pipeline. 
+        // @dbgtodo  metadata  - think about the error semantics here. These fails during dispatching an event; so
+        // address this during event pipeline.
         THROWS;
     }
     CONTRACTL_END;
@@ -1105,9 +1105,9 @@ void CordbModule::UpdatePublicMetaDataFromRemote(TargetBuffer bufferRemoteMetaDa
     {
         ThrowHR(E_INVALIDARG);
     }
-    
+
     INTERNAL_API_ENTRY(this->GetProcess()); //
-    LOG((LF_CORDB,LL_INFO100000, "CM::UPMFR: updating with remote buffer 0x%p length 0x%x\n", 
+    LOG((LF_CORDB,LL_INFO100000, "CM::UPMFR: updating with remote buffer 0x%p length 0x%x\n",
         CORDB_ADDRESS_TO_PTR(bufferRemoteMetaData.pAddress), bufferRemoteMetaData.cbSize));
     // We're re-initializing existing metadata.
     _ASSERTE(m_pIMImport != NULL);
@@ -1121,7 +1121,7 @@ void CordbModule::UpdatePublicMetaDataFromRemote(TargetBuffer bufferRemoteMetaDa
     CoTaskMemHolder<VOID> pLocalMetaDataPtr;
     CopyRemoteMetaData(bufferRemoteMetaData, pLocalMetaDataPtr.GetAddr());
 
-    IMetaDataDispenserEx *  pDisp = GetProcess()->GetDispenser();    
+    IMetaDataDispenserEx *  pDisp = GetProcess()->GetDispenser();
     _ASSERTE(pDisp != NULL); // throws on error.
 
     LOG((LF_CORDB,LL_INFO100000, "CM::RI: converting to new metadata\n"));
@@ -1147,7 +1147,7 @@ void CordbModule::UpdatePublicMetaDataFromRemote(TargetBuffer bufferRemoteMetaDa
     IfFailThrow(hr);
 
     // Success.  MetaData now owns the metadata memory
-    pLocalMetaDataPtr.SuppressRelease();   
+    pLocalMetaDataPtr.SuppressRelease();
 }
 
 //---------------------------------------------------------------------------------------
@@ -1156,11 +1156,11 @@ void CordbModule::UpdatePublicMetaDataFromRemote(TargetBuffer bufferRemoteMetaDa
 // Arguments:
 //    pRemoteMetaDataPtr - pointer to remote buffer
 //    dwMetaDataSize - size of buffer.
-//    pLocalBuffer - holder to get local buffer. 
+//    pLocalBuffer - holder to get local buffer.
 //
 // Returns:
 //    pLocalBuffer may be allocated.
-//    Throws on error (pLocalBuffer may contain garbage). 
+//    Throws on error (pLocalBuffer may contain garbage).
 //    Else if successful, pLocalBuffer contains local copy of metadata.
 //
 // Notes:
@@ -1188,7 +1188,7 @@ void CordbModule::CopyRemoteMetaData(
     }
 
     pLocalBuffer->Assign(pRawBuffer);
-    
+
 
 
     // Copy the metadata from the left side
@@ -1317,7 +1317,7 @@ HRESULT CordbModule::GetName(ULONG32 cchName, ULONG32 *pcchName, __out_ecount_pa
 
 //---------------------------------------------------------------------------------------
 // Gets the module pretty name (may be filename or faked up name)
-// 
+//
 // Arguments:
 //   cchName - count of characters in the szName buffer on input.
 //   *pcchName - Optional Out parameter, which gets set to the fully requested size
@@ -1328,7 +1328,7 @@ HRESULT CordbModule::GetName(ULONG32 cchName, ULONG32 *pcchName, __out_ecount_pa
 //   S_OK on success.
 //   S_FALSE if we fabricate the name.
 //   Return failing HR (on common errors) or Throw on exceptional errors.
-// 
+//
 // Note:
 //    Filename isn't necessarily the same as the module name in the metadata.
 //
@@ -1389,7 +1389,7 @@ HRESULT CordbModule::GetNameWorker(ULONG32 cchName, ULONG32 *pcchName, __out_eco
             hr = HRESULT_FROM_WIN32(ERROR_PARTIAL_COPY);
 
             // Tempting to use the metadata-scope name, but that's a regression from Whidbey. For manifest modules,
-            // the metadata scope name is not initialized with the string the user supplied to create the 
+            // the metadata scope name is not initialized with the string the user supplied to create the
             // dynamic assembly. So we call into the runtime to use CLR heuristics to get a more accurate name.
             m_pProcess->GetDAC()->GetModuleSimpleName(m_vmModule, &buffer);
             _ASSERTE(buffer.IsSet());
@@ -1409,21 +1409,21 @@ HRESULT CordbModule::GetNameWorker(ULONG32 cchName, ULONG32 *pcchName, __out_eco
 //---------------------------------------------------------------------------------------
 // Gets actual name of loaded module. (no faked names)
 //
-// Returns: 
+// Returns:
 //    string for full path to module name. This is a file that can be opened.
 //    NULL if name is not available (such as in some dynamic module cases)
 //    Throws if failed accessing target
 //
 // Notes:
 //    We avoid using the method name "GetModuleFileName" because winbase.h #defines that
-//    token (along with many others) to have an A or W suffix. 
+//    token (along with many others) to have an A or W suffix.
 const WCHAR * CordbModule::GetModulePath()
 {
-    // Lazily initialize.  Module filenames cannot change, and so once 
+    // Lazily initialize.  Module filenames cannot change, and so once
     // we've retrieved this successfully, it's stored for good.
     if (!m_strModulePath.IsSet())
     {
-        IDacDbiInterface * pDac = m_pProcess->GetDAC(); // throws 
+        IDacDbiInterface * pDac = m_pProcess->GetDAC(); // throws
         pDac->GetModulePath(m_vmModule, &m_strModulePath); // throws
         _ASSERTE(m_strModulePath.IsSet());
     }
@@ -1437,26 +1437,26 @@ const WCHAR * CordbModule::GetModulePath()
 
 //---------------------------------------------------------------------------------------
 // Get and caches ngen image path.
-// 
+//
 // Returns:
-//    Null-terminated string to ngen image path. 
+//    Null-terminated string to ngen image path.
 //    NULL if there is no ngen filename (eg, file is not ngenned).
 //    Throws on error (such as inability to read the path from the target).
 //
 // Notes:
-//    This can be used to get the path to find metadata. For ngenned images, 
-//    the IL (and associated metadata) may not be loaded, so we may want to get the 
+//    This can be used to get the path to find metadata. For ngenned images,
+//    the IL (and associated metadata) may not be loaded, so we may want to get the
 //    metadata out of the ngen image.
 const WCHAR * CordbModule::GetNGenImagePath()
 {
     HRESULT hr = S_OK;
     EX_TRY
     {
-        // Lazily initialize.  Module filenames cannot change, and so once 
+        // Lazily initialize.  Module filenames cannot change, and so once
         // we've retrieved this successfully, it's stored for good.
         if (!m_strNGenImagePath.IsSet())
         {
-            IDacDbiInterface * pDac = m_pProcess->GetDAC(); // throws 
+            IDacDbiInterface * pDac = m_pProcess->GetDAC(); // throws
             BOOL fNonEmpty = pDac->GetModuleNGenPath(m_vmModule, &m_strNGenImagePath); // throws
             (void)fNonEmpty; //prevent "unused variable" error from GCC
             _ASSERTE(m_strNGenImagePath.IsSet() && (m_strNGenImagePath.IsEmpty() == !fNonEmpty));
@@ -1464,7 +1464,7 @@ const WCHAR * CordbModule::GetNGenImagePath()
     }
     EX_CATCH_HRESULT(hr);
 
-    if (FAILED(hr) || 
+    if (FAILED(hr) ||
         m_strNGenImagePath == NULL ||
         m_strNGenImagePath.IsEmpty())
     {
@@ -1506,7 +1506,7 @@ HRESULT CordbModule::EnableClassLoadCallbacks(BOOL bClassLoadCallbacks)
     // loaded on the Left Side.)
     if (m_fDynamic && !bClassLoadCallbacks)
         return E_INVALIDARG;
-        
+
     if (m_vmDomainFile.IsNull())
         return E_UNEXPECTED;
 
@@ -1537,7 +1537,7 @@ HRESULT CordbModule::GetFunctionFromToken(mdMethodDef token,
                                           ICorDebugFunction **ppFunction)
 {
     // This is not reentrant. DBI should call code:CordbModule::LookupOrCreateFunctionLatestVersion instead.
-    PUBLIC_API_ENTRY(this); 
+    PUBLIC_API_ENTRY(this);
     ATT_ALLOW_LIVE_DO_STOPGO(GetProcess()); // @todo - can this be RequiredStop?
 
 
@@ -1639,8 +1639,8 @@ HRESULT CordbModule::GetClassFromToken(mdTypeDef token,
         IfFailThrow(hr);
 
         *ppClass = static_cast<ICorDebugClass*> (pClass);
-        pClass->ExternalAddRef();        
-    } 
+        pClass->ExternalAddRef();
+    }
     EX_CATCH_HRESULT(hr);
     return hr;
 }
@@ -1697,13 +1697,13 @@ HRESULT CordbModule::GetMetaDataInterface(REFIID riid, IUnknown **ppObj)
 }
 
 //-----------------------------------------------------------------------------
-// LookupFunctionLatestVersion finds the latest cached version of an existing CordbFunction 
+// LookupFunctionLatestVersion finds the latest cached version of an existing CordbFunction
 // in the given module. If the function doesn't exist, it returns NULL.
 //
 // Arguments:
 //     funcMetaDataToken - methoddef token for function to lookup
 //
-// 
+//
 // Notes:
 //     If no CordbFunction instance was cached, then this returns NULL.
 //     use code:CordbModule::LookupOrCreateFunctionLatestVersion to do a lookup that will
@@ -1716,13 +1716,13 @@ CordbFunction* CordbModule::LookupFunctionLatestVersion(mdMethodDef funcMetaData
 
 
 //-----------------------------------------------------------------------------
-// Lookup (or create) the CordbFunction for the latest EnC version. 
+// Lookup (or create) the CordbFunction for the latest EnC version.
 //
 // Arguments:
 //     funcMetaDataToken - methoddef token for function to lookup
 //
 // Returns:
-//     CordbFunction instance for that token. This will create an instance if needed, and so never returns null. 
+//     CordbFunction instance for that token. This will create an instance if needed, and so never returns null.
 //     Throws on critical error.
 //
 // Notes:
@@ -1747,7 +1747,7 @@ CordbFunction* CordbModule::LookupOrCreateFunctionLatestVersion(mdMethodDef func
 // LookupOrCreateFunction finds an existing version of CordbFunction in the given module.
 // If the function doesn't exist, it creates it.
 //
-// The outgoing function is not yet fully inititalized. For eg, the Class field is not set. 
+// The outgoing function is not yet fully inititalized. For eg, the Class field is not set.
 // However, ICorDebugFunction::GetClass() will check that and lazily initialize the field.
 //
 // Throws on error.
@@ -1763,7 +1763,7 @@ CordbFunction * CordbModule::LookupOrCreateFunction(mdMethodDef funcMetaDataToke
     // special case non-existance as need to add to the hash table too
     if (pFunction == NULL)
     {
-        // EnC adds each version to the hash. So if the hash lookup fails, 
+        // EnC adds each version to the hash. So if the hash lookup fails,
         // then it must not be an EnC case.
         return CreateFunction(funcMetaDataToken, enCVersion);
     }
@@ -1851,7 +1851,7 @@ CordbFunction * CordbModule::CreateFunction(mdMethodDef funcMetaDataToken, SIZE_
     INTERNAL_API_ENTRY(this);
 
     // In EnC cases, the token may not yet be valid. We may be caching the CordbFunction
-    // for a token for an added method before the metadata is updated on the RS. 
+    // for a token for an added method before the metadata is updated on the RS.
     // We rely that our caller has done token validation.
 
     // Create a new CordbFunction object or throw.
@@ -1918,7 +1918,7 @@ HRESULT CordbModule::UpdateFunction(mdMethodDef funcMetaDataToken,
         return E_OUTOFMEMORY;
 
     // Chain the 2nd most recent version onto this instance (this will internal addref).
-    pNewVersion->SetPrevVersion(pOldVersion); 
+    pNewVersion->SetPrevVersion(pOldVersion);
 
     // Add the function to the Module's hash of all functions.
     HRESULT hr = m_functions.SwapBase(pOldVersion, pNewVersion);
@@ -1945,7 +1945,7 @@ HRESULT CordbModule::LookupOrCreateClass(mdTypeDef classMetaDataToken,CordbClass
     INTERNAL_API_ENTRY(this);
     FAIL_IF_NEUTERED(this);
 
-    RSLockHolder lockHolder(GetProcess()->GetProcessLock()); // @dbgtodo  exceptions synchronization- 
+    RSLockHolder lockHolder(GetProcess()->GetProcessLock()); // @dbgtodo  exceptions synchronization-
                                                                // Push this lock up, convert to exceptions.
 
     HRESULT hr = S_OK;
@@ -1984,7 +1984,7 @@ HRESULT CordbModule::CreateClass(mdTypeDef classMetaDataToken,
     FAIL_IF_NEUTERED(this);
 
     _ASSERTE(GetProcess()->ThreadHoldsProcessLock());
-    
+
     CordbClass* pClass = new (nothrow) CordbClass(this, classMetaDataToken);
 
     if (pClass == NULL)
@@ -2008,29 +2008,29 @@ HRESULT CordbModule::CreateClass(mdTypeDef classMetaDataToken,
 
 
 // Resolve a type-ref from this module to a CordbClass
-// 
+//
 // Arguments:
 //    token - a Type Ref in this module's scope.
 //    ppClass - out parameter to get the class we resolve to.
-//    
+//
 // Returns:
 //    S_OK on success.
 //    CORDBG_E_CLASS_NOT_LOADED is the TypeRef is not yet resolved because the type it will refer
 //    to is not yet loaded.
-//    
+//
 // Notes:
 //    In general, a TypeRef refers to a type in another module. (Although as a corner case, it could
-//    refer to this module too). This resolves a TypeRef within the current module's scope to a 
+//    refer to this module too). This resolves a TypeRef within the current module's scope to a
 //    (TypeDef, metadata scope), which is in turn encapsulated as a CordbClass.
-//    
+//
 //    A TypeRef has a resolution scope (ModuleRef or AssemblyRef) and string name for the type
 //    within that scope. Resolving means:
-//    1. Determining the actual metadata scope loaded for the resolution scope. 
-//        See also code:CordbModule::ResolveAssemblyInternal 
+//    1. Determining the actual metadata scope loaded for the resolution scope.
+//        See also code:CordbModule::ResolveAssemblyInternal
 //        If the resolved module hasn't been loaded yet, the resolution will fail.
 //    2. Doing a string lookup of the TypeRef's name within that resolved scope to find the TypeDef.
-//    3. Returning the (resolved scope, TypeDef) pair. 
-//    
+//    3. Returning the (resolved scope, TypeDef) pair.
+//
 HRESULT CordbModule::ResolveTypeRef(mdTypeRef token, CordbClass **ppClass)
 {
     FAIL_IF_NEUTERED(this);
@@ -2045,7 +2045,7 @@ HRESULT CordbModule::ResolveTypeRef(mdTypeRef token, CordbClass **ppClass)
     {
         return E_INVALIDARG;
     }
-    
+
     if (m_vmDomainFile.IsNull() || m_pAppDomain == NULL)
     {
         return E_UNEXPECTED;
@@ -2067,17 +2067,17 @@ HRESULT CordbModule::ResolveTypeRef(mdTypeRef token, CordbClass **ppClass)
         IfFailThrow(pModule->LookupClassByToken(outData.typeToken, ppClass));
     }
     EX_CATCH_HRESULT(hr);
-    
+
     return hr;
-    
+
 } // CordbModule::ResolveTypeRef
 
 // Resolve a type ref or def to a CordbClass
-// 
+//
 // Arguments:
 //    token - a mdTypeDef or mdTypeRef in this module's scope to be resolved
 //    ppClass - out parameter to get the CordbClass for this type
-//     
+//
 // Notes:
 //    See code:CordbModule::ResolveTypeRef for more details.
 HRESULT CordbModule::ResolveTypeRefOrDef(mdToken token, CordbClass **ppClass)
@@ -2149,14 +2149,14 @@ HRESULT CordbModule::GetEditAndContinueSnapshot(
 //    S_OK on success, various errors on failure
 //
 // Notes:
-//    
-//   
+//
+//
 //    This applies the same changes to the RS's copy of the metadata that the left-side will apply to
 //    it's copy of the metadata. see code:EditAndContinueModule::ApplyEditAndContinue
 //
 HRESULT CordbModule::ApplyChanges(ULONG  cbMetaData,
-                                  BYTE   pbMetaData[], 
-                                  ULONG  cbIL, 
+                                  BYTE   pbMetaData[],
+                                  ULONG  cbIL,
                                   BYTE   pbIL[])
 {
     PUBLIC_API_ENTRY(this);
@@ -2165,7 +2165,7 @@ HRESULT CordbModule::ApplyChanges(ULONG  cbMetaData,
 
 #ifdef EnC_SUPPORTED
     // We enable EnC back in code:CordbModule::SetJITCompilerFlags.
-    // If EnC isn't enabled, then we'll fail in the LS when we try to ApplyChanges. 
+    // If EnC isn't enabled, then we'll fail in the LS when we try to ApplyChanges.
     // We'd expect a well-behaved debugger to never actually land here.
 
 
@@ -2203,23 +2203,23 @@ HRESULT CordbModule::ApplyChanges(ULONG  cbMetaData,
 
     // The left-side will call this same method on its copy of the metadata.
     hr = pMDImport->ApplyEditAndContinue(pbMetaData, cbMetaData, &pMDImport2);
-    if (pMDImport2 != NULL) 
+    if (pMDImport2 != NULL)
     {
         // ApplyEditAndContinue() expects IMDInternalImport**, but we give it RSExtSmartPtr<IMDInternalImport>
         // Silent cast of RSExtSmartPtr to IMDInternalImport* leads to assignment of a raw pointer
         // without calling AddRef(), thus we need to do it manually.
 
         // @todo -  ApplyEditAndContinue should probably AddRef the out parameter.
-        pMDImport2->AddRef(); 
+        pMDImport2->AddRef();
     }
     IfFailGo(hr);
 
-   
+
     // We're about to get a new importer object, so release the old one.
     m_pIMImport.Clear();
     IfFailGo(GetMDPublicInterfaceFromInternal(pMDImport2, IID_IMetaDataImport, (void **)&m_pIMImport));
     // set the new RVA value
-    
+
     // Send the delta over to the debugee and request that it apply the edit
     IfFailGo( ApplyChangesInternal(cbMetaData, pbMetaData, cbIL, pbIL) );
 
@@ -2229,7 +2229,7 @@ HRESULT CordbModule::ApplyChanges(ULONG  cbMetaData,
         m_pInternalMetaDataImport.Clear();
         UpdateInternalMetaData();
     }
-    EX_CATCH_HRESULT(hr);    
+    EX_CATCH_HRESULT(hr);
     _ASSERTE(SUCCEEDED(hr));
 
 ErrExit:
@@ -2260,9 +2260,9 @@ ErrExit:
 // Return Value:
 //    S_OK on success, various errors on failure
 //
-HRESULT CordbModule::ApplyChangesInternal(ULONG  cbMetaData, 
-                                          BYTE   pbMetaData[], 
-                                          ULONG  cbIL, 
+HRESULT CordbModule::ApplyChangesInternal(ULONG  cbMetaData,
+                                          BYTE   pbMetaData[],
+                                          ULONG  cbIL,
                                           BYTE   pbIL[])
 {
     CONTRACTL
@@ -2275,7 +2275,7 @@ HRESULT CordbModule::ApplyChangesInternal(ULONG  cbMetaData,
 
     FAIL_IF_NEUTERED(this);
     INTERNAL_SYNC_API_ENTRY(this->GetProcess()); //
-    
+
     if (m_vmDomainFile.IsNull())
         return E_UNEXPECTED;
 
@@ -2307,7 +2307,7 @@ HRESULT CordbModule::ApplyChangesInternal(ULONG  cbMetaData,
 
         GetProcess()->SafeWriteBuffer(tbMetaData, pbMetaData); // throws
         GetProcess()->SafeWriteBuffer(tbIL, pbIL); // throws
-            
+
         // Send a synchronous event requesting the debugee apply the edit
         event.ApplyChanges.pDeltaMetadata = tbMetaData.pAddress;
         event.ApplyChanges.cbDeltaMetadata = tbMetaData.cbSize;
@@ -2358,8 +2358,8 @@ HRESULT CordbModule::ApplyChangesInternal(ULONG  cbMetaData,
                 _ASSERTE(NULL != pAppDomain);
                 CordbModule* pModule = NULL;
 
-                
-                pModule = pAppDomain->LookupOrCreateModule(retEvent->EnCUpdate.vmDomainFile); // throws            
+
+                pModule = pAppDomain->LookupOrCreateModule(retEvent->EnCUpdate.vmDomainFile); // throws
                 _ASSERTE(pModule != NULL);
 
                 // update to the newest version
@@ -2369,13 +2369,13 @@ HRESULT CordbModule::ApplyChangesInternal(ULONG  cbMetaData,
                 {
                     // Update the function collection to reflect this edit
                     hr = pModule->UpdateFunction(retEvent->EnCUpdate.memberMetadataToken, retEvent->EnCUpdate.newVersionNumber, NULL);
-                        
+
                 }
                 // mark the class and relevant type as old so we update it next time we try to query it
                 if (retEvent->type == DB_IPCE_ENC_ADD_FUNCTION ||
                      retEvent->type == DB_IPCE_ENC_ADD_FIELD)
                 {
-                    RSLockHolder lockHolder(GetProcess()->GetProcessLock()); // @dbgtodo  synchronization -  push this up 
+                    RSLockHolder lockHolder(GetProcess()->GetProcessLock()); // @dbgtodo  synchronization -  push this up
                     CordbClass* pClass = pModule->LookupClass(retEvent->EnCUpdate.classMetadataToken);
                     // if don't find class, that is fine because it hasn't been loaded yet so doesn't
                     // need to be updated
@@ -2388,13 +2388,13 @@ HRESULT CordbModule::ApplyChangesInternal(ULONG  cbMetaData,
         }
 
         LOG((LF_ENC,LL_INFO100, "CordbProcess::ApplyChangesInternal complete.\n"));
-    } 
+    }
     EX_CATCH_HRESULT(hr);
-    
+
     // process may have gone away by the time we get here so don't assume is there.
     CordbProcess *pProcess = GetProcess();
     if (pProcess)
-    {        
+    {
         HRESULT hr2 = pProcess->ReleaseRemoteBuffer(&pRemoteBuf);
         TESTANDRETURNHR(hr2);
     }
@@ -2416,7 +2416,7 @@ HRESULT CordbModule::SetJMCStatus(
     PUBLIC_API_ENTRY(this);
     FAIL_IF_NEUTERED(this);
     ATT_REQUIRE_STOPPED_MAY_FAIL(GetProcess());
-    
+
     if (m_vmDomainFile.IsNull())
         return E_UNEXPECTED;
 
@@ -2498,25 +2498,25 @@ HRESULT CordbModule::ResolveAssembly(mdToken tkAssemblyRef,
 
 //---------------------------------------------------------------------------------------
 // Worker to resolve an assembly ref.
-// 
+//
 // Arguments:
 //     tkAssemblyRef - token of assembly ref to resolve
 //
 // Returns:
 //     Assembly that this token resolves to.
-//     NULL if it's a valid token but the assembly has not yet been resolved. 
+//     NULL if it's a valid token but the assembly has not yet been resolved.
 //      (This is a non-exceptional error case).
 //
 // Notes:
 //     MetaData has tokens to represent a reference to another assembly.
 //     But Loader/Fusion policy ultimately decides which specific assembly is actually loaded
-//     for that token. 
+//     for that token.
 //     This does the lookup of actual assembly and reports back to the debugger.
 
 CordbAssembly * CordbModule::ResolveAssemblyInternal(mdToken tkAssemblyRef)
 {
     INTERNAL_SYNC_API_ENTRY(GetProcess()); //
-    
+
     if (TypeFromToken(tkAssemblyRef) != mdtAssemblyRef || tkAssemblyRef == mdAssemblyRefNil)
     {
         // Not a valid token
@@ -2529,7 +2529,7 @@ CordbAssembly * CordbModule::ResolveAssemblyInternal(mdToken tkAssemblyRef)
     {
         // Get DAC to do the real work to resolve the assembly
         VMPTR_DomainAssembly vmDomainAssembly = GetProcess()->GetDAC()->ResolveAssembly(m_vmDomainFile, tkAssemblyRef);
-            
+
         // now find the ICorDebugAssembly corresponding to it
         if (!vmDomainAssembly.IsNull() && m_pAppDomain != NULL)
         {
@@ -2538,15 +2538,15 @@ CordbAssembly * CordbModule::ResolveAssemblyInternal(mdToken tkAssemblyRef)
             pAssembly = m_pAppDomain->LookupOrCreateAssembly(vmDomainAssembly);
         }
     }
-    
+
     return pAssembly;
 }
 
 //
 // CreateReaderForInMemorySymbols - create an ISymUnmanagedReader object for symbols
-// which are loaded into memory in the CLR.  See interface definition in cordebug.idl for 
+// which are loaded into memory in the CLR.  See interface definition in cordebug.idl for
 // details.
-// 
+//
 HRESULT CordbModule::CreateReaderForInMemorySymbols(REFIID riid, void** ppObj)
 {
     PUBLIC_API_ENTRY(this);
@@ -2606,17 +2606,17 @@ HRESULT CordbModule::CreateReaderForInMemorySymbols(REFIID riid, void** ppObj)
         }
 
         // In the attach or dump case, if we attach or take the dump after we have defined a dynamic module, we may
-        // have already set the symbol format to "PDB" by the time we call CreateReaderForInMemorySymbols during initialization 
-        // for loaded modules. (In the launch case, we do this initialization when the module is actually loaded, and before we 
-        // set the symbol format.) When we call CreateReaderForInMemorySymbols, we can't assume the initialization was already 
-        // performed or specifically, that we already have m_pIMImport initialized. We can't call into diasymreader with a NULL 
+        // have already set the symbol format to "PDB" by the time we call CreateReaderForInMemorySymbols during initialization
+        // for loaded modules. (In the launch case, we do this initialization when the module is actually loaded, and before we
+        // set the symbol format.) When we call CreateReaderForInMemorySymbols, we can't assume the initialization was already
+        // performed or specifically, that we already have m_pIMImport initialized. We can't call into diasymreader with a NULL
         // pointer as the value for m_pIMImport, so we need to check that here.
         if (m_pIMImport == NULL)
         {
             ThrowHR(CORDBG_E_SYMBOLS_NOT_AVAILABLE);
         }
 
-        // Now create the symbol reader from the data 
+        // Now create the symbol reader from the data
         ReleaseHolder<ISymUnmanagedReader> pReader;
         IfFailThrow(pBinder->GetReaderFromStream(m_pIMImport, pStream, &pReader));
 
@@ -2626,7 +2626,7 @@ HRESULT CordbModule::CreateReaderForInMemorySymbols(REFIID riid, void** ppObj)
         IfFailThrow(pReader->QueryInterface(riid, ppObj));
     }
     EX_CATCH_HRESULT(hr);
-    return hr; 
+    return hr;
 }
 
 /* ------------------------------------------------------------------------- *
@@ -2635,12 +2635,12 @@ HRESULT CordbModule::CreateReaderForInMemorySymbols(REFIID riid, void** ppObj)
 
 //---------------------------------------------------------------------------------------
 // Set the continue counter that marks when the module is in its Load event
-//    
+//
 // Notes:
 //    Jit flags can only be changed in the real module Load event. We may
 //    have multiple module load events on different threads coming at the
-//    same time. So each module load tracks its continue counter.  
-//    
+//    same time. So each module load tracks its continue counter.
+//
 //    This can be used by code:CordbModule::EnsureModuleIsInLoadCallback to
 //    properly return CORDBG_E_MUST_BE_IN_LOAD_MODULE
 void CordbModule::SetLoadEventContinueMarker()
@@ -2652,17 +2652,17 @@ void CordbModule::SetLoadEventContinueMarker()
 }
 
 //---------------------------------------------------------------------------------------
-// Return CORDBG_E_MUST_BE_IN_LOAD_MODULE if the module is not in the load module callback. 
-// 
+// Return CORDBG_E_MUST_BE_IN_LOAD_MODULE if the module is not in the load module callback.
+//
 // Notes:
 //   The comparison is done via continue counters. The counter of the load
-//   event is cached via code:CordbModule::SetLoadEventContinueMarker. 
-//   
+//   event is cached via code:CordbModule::SetLoadEventContinueMarker.
+//
 //   This state is currently stored on the RS. Alternatively, it could likely be retreived from the LS state as
 //   well. One disadvantage of the current model is that if we detach during the load-module callback and
 //   then reattach, the RS state is flushed and we lose the fact that we can toggle the jit flags.
 HRESULT CordbModule::EnsureModuleIsInLoadCallback()
-{    
+{
     if (this->m_nLoadEventContinueCounter < GetProcess()->m_continueCounter)
     {
         return CORDBG_E_MUST_BE_IN_LOAD_MODULE;
@@ -2677,7 +2677,7 @@ HRESULT CordbModule::EnsureModuleIsInLoadCallback()
 // See also code:CordbModule::EnableJITDebugging
 HRESULT CordbModule::SetJITCompilerFlags(DWORD dwFlags)
 {
-    PUBLIC_REENTRANT_API_ENTRY(this);    
+    PUBLIC_REENTRANT_API_ENTRY(this);
     FAIL_IF_NEUTERED(this);
 
     CordbProcess *pProcess = GetProcess();
@@ -2700,7 +2700,7 @@ HRESULT CordbModule::SetJITCompilerFlags(DWORD dwFlags)
             BOOL fEnableEnC = ((dwFlags & CORDEBUG_JIT_ENABLE_ENC) == CORDEBUG_JIT_ENABLE_ENC);
 
             // Can only change jit flags when module is first loaded and before there's any jitted code.
-            // This ensures all code in the module is jitted the same way. 
+            // This ensures all code in the module is jitted the same way.
             hr = EnsureModuleIsInLoadCallback();
 
             if (SUCCEEDED(hr))
@@ -2719,7 +2719,7 @@ HRESULT CordbModule::SetJITCompilerFlags(DWORD dwFlags)
         hr = GetProcess()->GetShim()->FilterSetJitFlagsHresult(hr);
     }
     return hr;
-    
+
 }
 
 // Implementation of ICorDebugModule2::GetJitCompilerFlags
@@ -2735,15 +2735,15 @@ HRESULT CordbModule::GetJITCompilerFlags(DWORD *pdwFlags )
 
     ATT_REQUIRE_STOPPED_MAY_FAIL(pProcess);
     HRESULT hr = S_OK;
-    
+
     EX_TRY
     {
         BOOL fAllowJitOpts;
         BOOL fEnableEnC;
 
         pProcess->GetDAC()->GetCompilerFlags (
-            GetRuntimeDomainFile(), 
-            &fAllowJitOpts, 
+            GetRuntimeDomainFile(),
+            &fAllowJitOpts,
             &fEnableEnC);
 
         if (fEnableEnC)
@@ -2772,7 +2772,7 @@ BOOL CordbModule::IsWinMD()
     {
         BOOL isWinRT;
         HRESULT hr = E_FAIL;
-        
+
         {
             RSLockHolder processLockHolder(GetProcess()->GetProcessLock());
             hr = GetProcess()->GetDAC()->IsWinRTModule(m_vmModule, isWinRT);
@@ -2891,7 +2891,7 @@ HRESULT CordbCode::GetEnCRemapSequencePoints(ULONG32 cMap, ULONG32 * pcMap, ULON
 //-----------------------------------------------------------------------------
 // CordbCode::IsIL
 // Public method to determine if this Code object represents IL or native code.
-// 
+//
 // Parameters:
 //    pbIL - OUT: on return, set to True if IL code, else False.
 //
@@ -2914,7 +2914,7 @@ HRESULT CordbCode::IsIL(BOOL *pbIL)
 // Public method to get the Function object associated with this Code object.
 // Function:Code = 1:1 for IL, and 1:n for Native. So there is always a single
 // unique Function object to return.
-// 
+//
 // Parameters:
 //   ppFunction - OUT: returns the Function object for this Code.
 //
@@ -2956,8 +2956,8 @@ HRESULT CordbCode::GetSize(ULONG32 *pcBytes)
 
 //-----------------------------------------------------------------------------
 // CordbCode::CreateBreakpoint
-// public method to create a breakpoint in the code. 
-// 
+// public method to create a breakpoint in the code.
+//
 // Parameters:
 //   offset - offset in bytes to set the breakpoint at. If this is a Native
 //      code object (IsIl == false), then units are bytes of native code. If
@@ -3015,14 +3015,14 @@ HRESULT CordbCode::CreateBreakpoint(ULONG32 offset,
 // The units of the offsets are the same as the units on the CordbCode object.
 // (eg, IL offsets for an IL code object, and native offsets for a native code object)
 // This will glue together hot + cold regions into a single blob.
-// 
-// Units are also logical (aka linear) values, which 
+//
+// Units are also logical (aka linear) values, which
 // Parameters:
-//    startOffset - linear offset in Code to start copying from. 
+//    startOffset - linear offset in Code to start copying from.
 //    endOffset - linear offset in Code to end copying from. Total bytes copied would be (endOffset - startOffset)
 //    cBufferAlloc - number of bytes in the buffer supplied by the buffer[] parameter.
 //    buffer - caller allocated storage to copy bytes into.
-//    pcBufferSize - required out-parameter, holds number of bytes copied into buffer. 
+//    pcBufferSize - required out-parameter, holds number of bytes copied into buffer.
 //
 // Returns:
 //    S_OK if copy successful. Else error.
@@ -3083,9 +3083,9 @@ HRESULT CordbCode::GetCode(ULONG32 startOffset,
 // CordbCode::GetVersionNumber
 // Public method to get the EnC version number of the code.
 //
-// Parameters: 
+// Parameters:
 //    nVersion - OUT: on return, set to the version number.
-// 
+//
 // Returns:
 //    S_OK on success.
 //-----------------------------------------------------------------------------
@@ -3130,8 +3130,8 @@ CordbFunction * CordbCode::GetFunction()
 //    Output:
 //        fields of this instance of CordbILCode have been initialized
 //-----------------------------------------------------------------------------
-CordbILCode::CordbILCode(CordbFunction * pFunction, 
-                         TargetBuffer    codeRegionInfo, 
+CordbILCode::CordbILCode(CordbFunction * pFunction,
+                         TargetBuffer    codeRegionInfo,
                          SIZE_T          nVersion,
                          mdSignature     localVarSigToken,
                          UINT_PTR        id)
@@ -3160,11 +3160,11 @@ void CordbILCode::MakeOld()
 //-----------------------------------------------------------------------------
 // CordbILCode::GetAddress
 // Public method to get the Entry address for the code.  This is the address
-// where the method first starts executing. 
+// where the method first starts executing.
 //
 // Parameters:
 //    pStart - out-parameter to hold start address.
-// 
+//
 // Returns:
 //    S_OK if *pStart is properly updated.
 //-----------------------------------------------------------------------------
@@ -3225,12 +3225,12 @@ HRESULT CordbILCode::ReadCodeBytes()
 // Since 1 CordbILCode can map to multiple CordbNativeCode due to generics, we cannot reliably return the
 // mapping information in all cases.  So we always fail with CORDBG_E_NON_NATIVE_FRAME.  The caller should
 // call code:CordbNativeCode::GetILToNativeMapping instead.
-// 
+//
 // Parameters:
 //    cMap - size of incoming map[] array (in elements).
-//    pcMap - OUT: full size of IL-->Native map (in elements). 
+//    pcMap - OUT: full size of IL-->Native map (in elements).
 //    map - caller allocated array to be filled in.
-// 
+//
 // Returns:
 //    CORDBG_E_NON_NATIVE_FRAME in all cases
 //-----------------------------------------------------------------------------
@@ -3344,12 +3344,12 @@ HRESULT CordbILCode::GetLocalVarSig(SigParser *pLocalSigParser,
 //
 // Parameters:
 //   dwIndex - 0-based index for IL local number.
-//   inst - instantiation information if this is a generic function. Eg, 
+//   inst - instantiation information if this is a generic function. Eg,
 //           if function is List<T>, inst describes T.
 //   res - out parameter, yields to CordbType of the local.
 //
 // Return:
-//   S_OK on success. 
+//   S_OK on success.
 //
 HRESULT CordbILCode::GetLocalVariableType(DWORD dwIndex,
     const Instantiation * pInst,
@@ -3499,7 +3499,7 @@ HRESULT CordbReJitILCode::Init(DacSharedReJitInfo* pSharedReJitInfo)
     {
         return CORDBG_E_TARGET_INCONSISTENT;
     }
-    
+
     m_codeRegionInfo.Init(pIlHeader + headerSize, ilCodeSize);
     m_pLocalIL = new (nothrow) BYTE[ilCodeSize];
     if (m_pLocalIL == NULL)
@@ -3601,7 +3601,7 @@ HRESULT CordbReJitILCode::Init(DacSharedReJitInfo* pSharedReJitInfo)
 //-----------------------------------------------------------------------------
 // CordbReJitILCode::GetEHClauses
 // Public method to get the EH clauses for IL code
-// 
+//
 // Parameters:
 //   cClauses - size of incoming clauses array (in elements).
 //   pcClauses - OUT param: cClauses>0 -> the number of elements written to in the clauses array.
@@ -3717,13 +3717,13 @@ HRESULT CordbReJitILCode::GetInstrumentedILMap(ULONG32 cMap, ULONG32 *pcMap, COR
 // Linear search through an array of NativeVarInfos, to find the variable of index dwIndex, valid
 // at the given ip. Returns CORDBG_E_IL_VAR_NOT_AVAILABLE if the variable isn't valid at the given ip.
 // Arguments:
-//     input:  dwIndex        - variable number    
-//             ip             - IP 
+//     input:  dwIndex        - variable number
+//             ip             - IP
 //             nativeInfoList - list of instances of NativeVarInfo
 //     output: ppNativeInfo   - the element of nativeInfoList that corresponds to the IP and variable number
-//                              if we find such an element or NULL otherwise 
-// Return value: HRESULT: returns S_OK or CORDBG_E_IL_VAR_NOT_AVAILABLE if the variable isn't found             
-//             
+//                              if we find such an element or NULL otherwise
+// Return value: HRESULT: returns S_OK or CORDBG_E_IL_VAR_NOT_AVAILABLE if the variable isn't found
+//
 HRESULT FindNativeInfoInILVariableArray(DWORD                                               dwIndex,
                                         SIZE_T                                              ip,
                                         const DacDbiArrayList<ICorDebugInfo::NativeVarInfo> * nativeInfoList,
@@ -3759,23 +3759,23 @@ HRESULT FindNativeInfoInILVariableArray(DWORD                                   
     }
 
     // workaround:
-    // 
+    //
     // We didn't find the variable. Was the endOffset of the last range for this variable
     // equal to the current IP? If so, go ahead and "lie" and report that as the
     // variable's home for now.
     //
     // Rationale:
-    // 
+    //
     // * See TODO comment in code:Compiler::siUpdate (jit\scopeinfo.cpp). In optimized
     //     code, the JIT can report var lifetimes as being one instruction too short.
     //     This workaround makes up for that.  Example code:
-    //     
+    //
     //         static void foo(int x)
     //         {
     //             int b = x; // Value of "x" would not be reported in optimized code without the workaround
     //             bar(ref b);
     //         }
-    //         
+    //
     // * Since this is the first instruction after the last range a variable was alive,
     //     we're essentially assuming that since that instruction hasn't been executed
     //     yet, and since there isn't a new home for the variable, that the last home is
@@ -3815,7 +3815,7 @@ CordbVariableHome::CordbVariableHome(CordbNativeCode *pCode,
     CordbBase(pCode->GetModule()->GetProcess(), 0)
 {
     _ASSERTE(pCode != NULL);
-    
+
     m_pCode.Assign(pCode);
     m_nativeVarInfo = nativeVarInfo;
     m_isLocal = isLocal;
@@ -3860,7 +3860,7 @@ HRESULT CordbVariableHome::QueryInterface(REFIID id, void **pInterface)
 //-----------------------------------------------------------------------------
 // CordbVariableHome::GetCode
 // Public method to get the Code object containing this variable home.
-// 
+//
 // Parameters:
 //   ppCode - OUT: returns the Code object for this variable home.
 //
@@ -3882,7 +3882,7 @@ HRESULT CordbVariableHome::GetCode(ICorDebugCode **ppCode)
 //-----------------------------------------------------------------------------
 // CordbVariableHome::GetSlotIndex
 // Public method to get the slot index for this variable home.
-// 
+//
 // Parameters:
 //   pSlotIndex - OUT: returns the managed slot-index of this variable home.
 //
@@ -3908,7 +3908,7 @@ HRESULT CordbVariableHome::GetSlotIndex(ULONG32 *pSlotIndex)
 //-----------------------------------------------------------------------------
 // CordbVariableHome::GetArgumentIndex
 // Public method to get the slot index for this variable home.
-// 
+//
 // Parameters:
 //   pSlotIndex - OUT: returns the managed argument-index of this variable home.
 //
@@ -3934,7 +3934,7 @@ HRESULT CordbVariableHome::GetArgumentIndex(ULONG32 *pArgumentIndex)
 //-----------------------------------------------------------------------------
 // CordbVariableHome::GetLiveRange
 // Public method to get the native range over which this variable is live.
-// 
+//
 // Parameters:
 //   pStartOffset - OUT: returns the logical offset at which the variable is
 //                  first live
@@ -3961,7 +3961,7 @@ HRESULT CordbVariableHome::GetLiveRange(ULONG32 *pStartOffset,
 //-----------------------------------------------------------------------------
 // CordbVariableHome::GetLocationType
 // Public method to get the type of native location for this variable home.
-// 
+//
 // Parameters:
 //   pLocationType - OUT: the type of native location
 //
@@ -3992,7 +3992,7 @@ HRESULT CordbVariableHome::GetLocationType(VariableLocationType *pLocationType)
 //-----------------------------------------------------------------------------
 // CordbVariableHome::GetRegister
 // Public method to get the register or base register for this variable hom.
-// 
+//
 // Parameters:
 //   pRegister - OUT: for VLT_REGISTER location types, gives the register.
 //                    for VLT_REGISTER_RELATIVE location types, gives the base
@@ -4008,7 +4008,7 @@ HRESULT CordbVariableHome::GetRegister(CorDebugRegister *pRegister)
     FAIL_IF_NEUTERED(this);
     VALIDATE_POINTER_TO_OBJECT(pRegister, CorDebugRegister *);
     ATT_REQUIRE_STOPPED_MAY_FAIL(m_pCode->GetProcess());
-    
+
     switch (m_nativeVarInfo.loc.vlType)
     {
     case ICorDebugInfo::VLT_REG:
@@ -4026,7 +4026,7 @@ HRESULT CordbVariableHome::GetRegister(CorDebugRegister *pRegister)
 //-----------------------------------------------------------------------------
 // CordbVariableHome::GetOffset
 // Public method to get the offset from the base register for this variable home.
-// 
+//
 // Parameters:
 //   pOffset - OUT: gives the offset from the base register
 //
@@ -4064,13 +4064,13 @@ HRESULT CordbVariableHome::GetOffset(LONG *pOffset)
 //    Input:
 //        pFunction              - the function for which this is the native code object
 //        pJitData               - the information about this code object retrieved from the DAC
-//        fIsInstantiatedGeneric - indicates whether this code object is an instantiated 
+//        fIsInstantiatedGeneric - indicates whether this code object is an instantiated
 //                                 generic
 //    Output:
 //        fields of this instance of CordbNativeCode have been initialized
 //-----------------------------------------------------------------------------
-CordbNativeCode::CordbNativeCode(CordbFunction *                pFunction, 
-                                 const NativeCodeFunctionData * pJitData, 
+CordbNativeCode::CordbNativeCode(CordbFunction *                pFunction,
+                                 const NativeCodeFunctionData * pJitData,
                                  BOOL                           fIsInstantiatedGeneric)
   : CordbCode(pFunction, (UINT_PTR)pJitData->m_rgCodeRegions[kHot].pAddress, pJitData->encVersion, FALSE),
     m_vmNativeCodeMethodDescToken(pJitData->vmNativeCodeMethodDescToken),
@@ -4078,12 +4078,12 @@ CordbNativeCode::CordbNativeCode(CordbFunction *                pFunction,
     m_fIsInstantiatedGeneric(fIsInstantiatedGeneric != FALSE)
 {
     _ASSERTE(GetVersion() >= CorDB_DEFAULT_ENC_FUNCTION_VERSION);
- 
+
     for (CodeBlobRegion region = kHot; region < MAX_REGIONS; ++region)
     {
         m_rgCodeRegions[region] = pJitData->m_rgCodeRegions[region];
     }
-} //CordbNativeCode::CordbNativeCode 
+} //CordbNativeCode::CordbNativeCode
 
 //-----------------------------------------------------------------------------
 // Public method for IUnknown::QueryInterface.
@@ -4124,11 +4124,11 @@ HRESULT CordbNativeCode::QueryInterface(REFIID id, void ** pInterface)
 //-----------------------------------------------------------------------------
 // CordbNativeCode::GetAddress
 // Public method to get the Entry address for the code.  This is the address
-// where the method first starts executing. 
+// where the method first starts executing.
 //
 // Parameters:
 //    pStart - out-parameter to hold start address.
-// 
+//
 // Returns:
 //    S_OK if *pStart is properly updated.
 //-----------------------------------------------------------------------------
@@ -4203,7 +4203,7 @@ HRESULT CordbNativeCode::ReadCodeBytes()
 
 //-----------------------------------------------------------------------------
 // CordbNativeCode::GetColdSize
-// Get the size of the cold regions in bytes. 
+// Get the size of the cold regions in bytes.
 //
 // Parameters:
 //   none--uses data member m_rgCodeRegions to compute total size.
@@ -4223,7 +4223,7 @@ ULONG32 CordbNativeCode::GetColdSize()
 
 //-----------------------------------------------------------------------------
 // CordbNativeCode::GetSize
-// Get the size of the code in bytes. 
+// Get the size of the code in bytes.
 //
 // Parameters:
 //   none--uses data member m_rgCodeRegions to compute total size.
@@ -4246,14 +4246,14 @@ ULONG32 CordbNativeCode::GetSize()
 // Public method (implements ICorDebugCode) to get the IL-->{ Native Start, Native End} mapping.
 // This can only be retrieved for native code.
 // This will copy as much of the map as can fit in the incoming buffer.
-// 
+//
 // Parameters:
 //    cMap - size of incoming map[] array (in elements).
-//    pcMap - OUT: full size of IL-->Native map (in elements). 
+//    pcMap - OUT: full size of IL-->Native map (in elements).
 //    map - caller allocated array to be filled in.
-// 
+//
 // Returns:
-//    S_OK on successful copying. 
+//    S_OK on successful copying.
 //-----------------------------------------------------------------------------
 HRESULT CordbNativeCode::GetILToNativeMapping(ULONG32                    cMap,
                                               ULONG32 *                  pcMap,
@@ -4300,12 +4300,12 @@ HRESULT CordbNativeCode::GetILToNativeMapping(ULONG32                    cMap,
 //-----------------------------------------------------------------------------
 // CordbNativeCode::GetCodeChunks
 // Public method to get the code regions of code. If the code
-// is broken into discontinuous regions (hot + cold), this lets a debugger 
+// is broken into discontinuous regions (hot + cold), this lets a debugger
 // find the number of regions, and (start,size) of each.
-// 
+//
 // Parameters:
 //   cbufSize - size of incoming chunks array (in elements).
-//   pcnumChunks - OUT param: the number of elements written to in the chunk array.// 
+//   pcnumChunks - OUT param: the number of elements written to in the chunk array.//
 //   chunks - caller allocated storage to hold the code chunks.
 //
 // Returns:
@@ -4353,16 +4353,16 @@ HRESULT CordbNativeCode::GetCodeChunks(
 //-----------------------------------------------------------------------------
 // CordbNativeCode::GetCompilerFlags
 // Public entry point to get code flags for this Code object.
-// Originally, ICDCode had this method implemented independently from the 
-// ICDModule method GetJitCompilerFlags. This was because it was considered that 
-// the flags would be per function, rather than per module. 
-// In addition, GetCompilerFlags did two different things depending on whether 
+// Originally, ICDCode had this method implemented independently from the
+// ICDModule method GetJitCompilerFlags. This was because it was considered that
+// the flags would be per function, rather than per module.
+// In addition, GetCompilerFlags did two different things depending on whether
 // the code had a native image. It turned out that was the wrong thing to do
 // .
-// 
+//
 // Parameters:
 //    pdwFlags - OUT: code gen flags (see CorDebugJITCompilerFlags)
-// 
+//
 // Return value:
 //    S_OK if pdwFlags is set properly.
 //-----------------------------------------------------------------------------
@@ -4398,7 +4398,7 @@ HRESULT CordbNativeCode::ILVariableToNative(DWORD dwIndex,
 HRESULT CordbNativeCode::GetReturnValueLiveOffset(ULONG32 ILoffset, ULONG32 bufferSize, ULONG32 *pFetched, ULONG32 *pOffsets)
 {
     HRESULT hr = S_OK;
-    
+
     PUBLIC_API_ENTRY(this);
     FAIL_IF_NEUTERED(this);
 
@@ -4418,7 +4418,7 @@ HRESULT CordbNativeCode::GetReturnValueLiveOffset(ULONG32 ILoffset, ULONG32 buff
 // Public method to get an enumeration of native variable homes. This may
 // include multiple ICorDebugVariableHomes for the same slot or argument index
 // if they have different homes at different points in the function.
-// 
+//
 // Parameters:
 //   ppEnum - OUT: returns the enum of variable homes.
 //
@@ -4431,9 +4431,9 @@ HRESULT CordbNativeCode::EnumerateVariableHomes(ICorDebugVariableHomeEnum **ppEn
     FAIL_IF_NEUTERED(this);
     VALIDATE_POINTER_TO_OBJECT(ppEnum, ICorDebugVariableHomeEnum **);
     ATT_REQUIRE_STOPPED_MAY_FAIL(GetProcess());
-    
+
     HRESULT hr = S_OK;
-    
+
     // Get the argument count
     ULONG argCount = 0;
     CordbFunction *func = GetFunction();
@@ -4450,14 +4450,14 @@ HRESULT CordbNativeCode::EnumerateVariableHomes(ICorDebugVariableHomeEnum **ppEn
     EX_CATCH_HRESULT(hr);
     IfFailRet(hr);
 #endif
-    
+
     RSSmartPtr<CordbVariableHome> *rsHomes = NULL;
-    
+
     EX_TRY
     {
         CordbProcess *pProcess = GetProcess();
         _ASSERTE(pProcess != NULL);
-        
+
         const DacDbiArrayList<ICorDebugInfo::NativeVarInfo> *pOffsetInfoList = m_nativeVarData.GetOffsetInfoList();
         _ASSERTE(pOffsetInfoList != NULL);
         DWORD countHomes = 0;
@@ -4465,7 +4465,7 @@ HRESULT CordbNativeCode::EnumerateVariableHomes(ICorDebugVariableHomeEnum **ppEn
         {
             const ICorDebugInfo::NativeVarInfo *pNativeVarInfo = &((*pOffsetInfoList)[i]);
             _ASSERTE(pNativeVarInfo != NULL);
-            
+
             // The variable information list can include variables
             // with special varNumbers representing, for instance, the
             // parameter types for generic methods. Here we are only
@@ -4488,7 +4488,7 @@ HRESULT CordbNativeCode::EnumerateVariableHomes(ICorDebugVariableHomeEnum **ppEn
             {
                 // determine whether this variable home represents and argument or local variable
                 BOOL isLocal = ((ULONG)pNativeVarInfo->varNumber >= argCount);
-                
+
                 // determine the argument-index or slot-index of this variable home
                 ULONG argOrSlotIndex;
                 if (isLocal) {
@@ -4534,7 +4534,7 @@ int CordbNativeCode::GetCallInstructionLength(BYTE *ip, ULONG32 count)
         return -1;
 
     // Skip instruction prefixes
-    do 
+    do
     {
         switch (*ip)
         {
@@ -4542,7 +4542,7 @@ int CordbNativeCode::GetCallInstructionLength(BYTE *ip, ULONG32 count)
         case 0x26: // ES
         case 0x2E: // CS
         case 0x36: // SS
-        case 0x3E: // DS 
+        case 0x3E: // DS
         case 0x64: // FS
         case 0x65: // GS
 
@@ -4690,12 +4690,12 @@ int CordbNativeCode::GetCallInstructionLength(BYTE *ip, ULONG32 count)
         return -1;
 
     // Skip instruction prefixes
-    //@TODO by euzem: 
+    //@TODO by euzem:
     //This "loop" can't be really executed more than once so if CALL can really have more than one prefix we'll crash.
     //Some of these prefixes are not allowed for CALL instruction and we should treat them as invalid code.
     //It appears that this code was mostly copy/pasted from \NDP\clr\src\Debug\EE\amd64\amd64walker.cpp
     //with very minimum fixes.
-    do 
+    do
     {
         switch (prefix)
         {
@@ -4703,7 +4703,7 @@ int CordbNativeCode::GetCallInstructionLength(BYTE *ip, ULONG32 count)
         case 0x26: // ES
         case 0x2E: // CS
         case 0x36: // SS
-        case 0x3E: // DS 
+        case 0x3E: // DS
         case 0x64: // FS
         case 0x65: // GS
 
@@ -4716,13 +4716,13 @@ int CordbNativeCode::GetCallInstructionLength(BYTE *ip, ULONG32 count)
 
             // String REP prefixes
         case 0xf2: // REPNE/REPNZ
-        case 0xf3: 
+        case 0xf3:
             ip++;
             fContainsPrefix = TRUE;
             continue;
 
             // REX register extension prefixes
-        case 0x40:            
+        case 0x40:
         case 0x41:
         case 0x42:
         case 0x43:
@@ -4738,7 +4738,7 @@ int CordbNativeCode::GetCallInstructionLength(BYTE *ip, ULONG32 count)
         case 0x4d:
         case 0x4e:
         case 0x4f:
-            // make sure to set rex to prefix, not *ip because *ip still represents the 
+            // make sure to set rex to prefix, not *ip because *ip still represents the
             // codestream which has a 0xcc in it.
             rex = prefix;
             ip++;
@@ -4792,18 +4792,18 @@ int CordbNativeCode::GetCallInstructionLength(BYTE *ip, ULONG32 count)
                      return -1;
                  }
 
-                 WORD displace = -1;
+                 SHORT displace = -1;
 
                  // See: Tables A-15,16,17 in AMD Dev Manual 3 for information
                  //      about how the ModRM/SIB/REX bytes interact.
 
-                 switch (mod) 
+                 switch (mod)
                  {
                  case 0:
                  case 1:
-                 case 2:     
+                 case 2:
                      if ((rm & 0x07) == 4) // we have an SIB byte following
-                     {   
+                     {
                          //
                          // Get values from the SIB byte
                          //
@@ -4818,38 +4818,38 @@ int CordbNativeCode::GetCallInstructionLength(BYTE *ip, ULONG32 count)
                          //
                          // Finally add in the offset
                          //
-                         if (mod == 0) 
+                         if (mod == 0)
                          {
-                             if ((base & 0x07) == 5) 
+                             if ((base & 0x07) == 5)
                                  displace = 7;
-                             else 
+                             else
                                  displace = 3;
-                         } 
-                         else if (mod == 1) 
+                         }
+                         else if (mod == 1)
                          {
                              displace = 4;
-                         } 
+                         }
                          else // mod == 2
                          {
                              displace = 7;
                          }
-                     } 
-                     else 
+                     }
+                     else
                      {
                          //
                          // Get the value we need from the register.
                          //
 
                          // Check for RIP-relative addressing mode.
-                         if ((mod == 0) && ((rm & 0x07) == 5)) 
+                         if ((mod == 0) && ((rm & 0x07) == 5))
                          {
                              displace = 6;   // 1 byte opcode + 1 byte modrm + 4 byte displacement (signed)
-                         } 
-                         else 
+                         }
+                         else
                          {
-                             if (mod == 0) 
+                             if (mod == 0)
                                  displace = 2;
-                             else if (mod == 1) 
+                             else if (mod == 1)
                                  displace = 3;
                              else // mod == 2
                                  displace = 6;
@@ -4876,7 +4876,7 @@ int CordbNativeCode::GetCallInstructionLength(BYTE *ip, ULONG32 count)
 
                  // reg == 4 or 5 means that it is not a CALL, but JMP instruction
                  // so we will fall back to ASSERT after break
-                 if ((reg != 4) && (reg != 5)) 
+                 if ((reg != 4) && (reg != 5))
                      return displace;
                  break;
     }
@@ -4977,7 +4977,7 @@ HRESULT CordbNativeCode::EnsureReturnValueAllowedWorker(Instantiation *currentIn
 
         if (returnType != ELEMENT_TYPE_VALUETYPE)
             return META_E_BAD_SIGNATURE;
-        
+
         if (currentInstantiation == NULL)
             return S_OK;  // We will check again when we have the instantiation.
 
@@ -4988,7 +4988,7 @@ HRESULT CordbNativeCode::EnsureReturnValueAllowedWorker(Instantiation *currentIn
         CordbType *pType = 0;
         IfFailRet(CordbType::SigToType(GetModule(), &original, &inst, &pType));
 
-        
+
         IfFailRet(pType->ReturnedByValue());
         if (hr == S_OK) // not S_FALSE
             return S_OK;
@@ -5041,8 +5041,8 @@ HRESULT CordbNativeCode::EnsureReturnValueAllowedWorker(Instantiation *currentIn
         // Now recurse with "generics" at the location to continue parsing.
         return EnsureReturnValueAllowedWorker(currentInstantiation, targetClass, generics, methodGenerics, genCount);
     }
-    
-    
+
+
     if (returnType == ELEMENT_TYPE_VAR)
     {
         // Get which type parameter is reference.
@@ -5070,7 +5070,7 @@ HRESULT CordbNativeCode::EnsureReturnValueAllowedWorker(Instantiation *currentIn
         IfFailRet(typeParser.GetElemType(&et));
         if (et != ELEMENT_TYPE_VALUETYPE && et != ELEMENT_TYPE_CLASS)
             return META_E_BAD_SIGNATURE;
-        
+
         IfFailRet(typeParser.GetToken(NULL));
 
         ULONG totalTypeCount = 0;
@@ -5080,7 +5080,7 @@ HRESULT CordbNativeCode::EnsureReturnValueAllowedWorker(Instantiation *currentIn
 
         while (typeParam--)
             IfFailRet(typeParser.SkipExactlyOne());
-        
+
         // This is a temporary workaround for an infinite recursion here.  ALL of this code will
         // go away when we allow struct return values, but in the mean time this avoids a corner
         // case in the type system we haven't solved yet.
@@ -5101,7 +5101,7 @@ HRESULT CordbNativeCode::SkipToReturn(SigParser &parser, ULONG *genCount)
     // Takes a method signature parser (at the beginning of a signature) and skips to the
     // return value.
     HRESULT hr = S_OK;
-    
+
     // Skip calling convention
     ULONG uCallConv;
     IfFailRet(parser.GetCallingConvInfo(&uCallConv));
@@ -5138,7 +5138,7 @@ HRESULT CordbNativeCode::GetCallSignature(ULONG32 ILoffset, mdToken *pClass, mdT
         // tail call case.  We don't allow managed return values for tailcalls.
         return CORDBG_E_INVALID_OPCODE;
     }
-    
+
     // call     - 28    (ECMA III.3.19)
     // callvirt - 6f    (ECMA III.4.2)
     if (instruction != 0x28 && instruction != 0x6f)
@@ -5162,10 +5162,10 @@ HRESULT CordbNativeCode::GetReturnValueLiveOffsetImpl(Instantiation *currentInst
 {
     if (pFetched == NULL)
         return E_INVALIDARG;
-        
+
     HRESULT hr = S_OK;
     ULONG32 found = 0;
-    
+
     // verify that the call target actually returns something we allow
     SigParser signature, generics;
     mdToken mdClass = 0;
@@ -5230,7 +5230,7 @@ HRESULT CordbNativeCode::GetReturnValueLiveOffsetImpl(Instantiation *currentInst
 
     if (pOffsets && found > bufferSize)
         return S_FALSE;
-    
+
     return S_OK;
 }
 
@@ -5245,7 +5245,7 @@ HRESULT CordbNativeCode::GetReturnValueLiveOffsetImpl(Instantiation *currentInst
 //       methodDesc - the methodDesc for the jitted method
 //       startAddress - the hot code startAddress for this method
 
-// Return value: 
+// Return value:
 //      found or created CordbNativeCode pointer
 // Assumptions: methodToken is in the metadata for this module
 //              methodDesc and startAddress should be consistent for
@@ -5263,7 +5263,7 @@ CordbNativeCode * CordbModule::LookupOrCreateNativeCode(mdMethodDef methodToken,
     NativeCodeFunctionData codeInfo;
     RSLockHolder lockHolder(GetProcess()->GetProcessLock());
 
-    // see if we already have this--if not, we'll make an instance, otherwise we'll just return the one we have. 
+    // see if we already have this--if not, we'll make an instance, otherwise we'll just return the one we have.
     pNativeCode = m_nativeCodeTable.GetBase((UINT_PTR) startAddress);
 
     if (pNativeCode == NULL)
@@ -5303,7 +5303,7 @@ CordbNativeCode * CordbModule::LookupOrCreateNativeCode(mdMethodDef methodToken,
 void CordbNativeCode::LoadNativeInfo()
 {
     THROW_IF_NEUTERED(this);
-    INTERNAL_API_ENTRY(this->GetProcess()); 
+    INTERNAL_API_ENTRY(this->GetProcess());
 
 
     // If we've either never done this before (no info), or we have, but the version number has increased, we
@@ -5325,7 +5325,7 @@ void CordbNativeCode::LoadNativeInfo()
         RSLockHolder lockHolder(pProcess->GetProcessLock());
         pProcess->GetDAC()->GetNativeCodeSequencePointsAndVarInfo(GetVMNativeCodeMethodDescToken(),
                                                                   GetAddress(),
-                                                                  m_fCodeAvailable, 
+                                                                  m_fCodeAvailable,
                                                                   &m_nativeVarData,
                                                                   &m_sequencePoints);
     }

--- a/src/debug/ee/functioninfo.cpp
+++ b/src/debug/ee/functioninfo.cpp
@@ -4,7 +4,7 @@
 // See the LICENSE file in the project root for more information.
 //*****************************************************************************
 
-// 
+//
 // File: DebuggerModule.cpp
 //
 // Stuff for tracking DebuggerModules.
@@ -153,7 +153,7 @@ void DebuggerJitInfo::InitFuncletAddress()
     }
 
     // This will get the offsets relative to the parent method start as if
-    // the funclet was in contiguous memory (i.e. not hot/cold split). 
+    // the funclet was in contiguous memory (i.e. not hot/cold split).
     g_pEEInterface->GetFuncletStartOffsets((const BYTE*)m_addrOfCode, m_rgFunclet, m_funcletCount);
 }
 
@@ -289,7 +289,7 @@ DebuggerJitInfo::DebuggerJitInfo(DebuggerMethodInfo *minfo, NativeCodeVersion na
     // We should never even be creating a DJI for one.
     _ASSERTE(!m_nativeCodeVersion.GetMethodDesc()->IsDynamicMethod());
 }
-    
+
 DebuggerILToNativeMap *DebuggerJitInfo::MapILOffsetToMapEntry(SIZE_T offset, BOOL *exact, BOOL fWantFirst)
 {
     CONTRACTL
@@ -403,8 +403,8 @@ DebuggerJitInfo::NativeOffset DebuggerJitInfo::MapILOffsetToNative(DebuggerJitIn
         }
         else
         {
-            // Initialize the funclet range. 
-            // ASSUMES that funclets are contiguous which they currently are... 
+            // Initialize the funclet range.
+            // ASSUMES that funclets are contiguous which they currently are...
             DWORD funcletStartOffset = GetFuncletOffsetByIndex(ilOffset.m_funcletIndex);
             DWORD funcletEndOffset;
             if (ilOffset.m_funcletIndex < (m_funcletCount - 1))
@@ -725,7 +725,7 @@ void DebuggerJitInfo::MapILRangeToMapEntryRange(SIZE_T startOffset,
          (*end)->nativeStartOffset, (*end)->nativeEndOffset));
 }
 
-// @dbgtodo Microsoft inspection: This function has been replicated in DacDbiStructures so 
+// @dbgtodo Microsoft inspection: This function has been replicated in DacDbiStructures so
 // this version can be deleted when inspection is complete.
 
 // DWORD DebuggerJitInfo::MapNativeOffsetToIL():   Given a native
@@ -803,7 +803,7 @@ DWORD DebuggerJitInfo::MapNativeOffsetToIL(SIZE_T nativeOffsetToMap,
                         nativeOffset = m->nativeEndOffset;
                         continue;
                     }
-                    
+
                     ilOff = 0;
                     (*map) = MAPPING_PROLOG;
                     LOG((LF_CORDB,LL_INFO10000,"DJI::MNOTI: MAPPING_PROLOG\n"));
@@ -932,7 +932,7 @@ void DebuggerJitInfo::LazyInitBounds()
 
         LOG((LF_CORDB,LL_EVERYTHING, "DJI::LazyInitBounds: this=0x%x GetBoundariesAndVars success=0x%x\n", this, fSuccess));
 
-        // SetBoundaries uses the CodeVersionManager, need to take it now for lock ordering reasons 
+        // SetBoundaries uses the CodeVersionManager, need to take it now for lock ordering reasons
         CodeVersionManager::TableLockHolder lockHolder(mdesc->GetCodeVersionManager());
         Debugger::DebuggerDataLockHolder debuggerDataLockHolder(g_pDebugger);
 
@@ -1078,7 +1078,7 @@ void DebuggerJitInfo::SetBoundaries(ULONG32 cMap, ICorDebugInfo::OffsetMapping *
         // If a ReJIT hasn't happened, check for a profiler provided map.
         mapping = m_methodInfo->GetRuntimeModule()->GetInstrumentedILOffsetMapping(m_methodInfo->m_token);
     }
-    
+
 
     //
     // <TODO>@todo perf: we could do the vast majority of this
@@ -1115,8 +1115,8 @@ void DebuggerJitInfo::SetBoundaries(ULONG32 cMap, ICorDebugInfo::OffsetMapping *
         // Since the map can only have one entry for 6 old, we remove 44 new.
         if (!mapping.IsNull())
         {
-            int ilThisOld = m_methodInfo->TranslateToInstIL(&mapping, 
-                                                            pMapEntry->ilOffset, 
+            int ilThisOld = m_methodInfo->TranslateToInstIL(&mapping,
+                                                            pMapEntry->ilOffset,
                                                             bInstrumentedToOriginal);
 
             if (ilThisOld == ilPrevOld)
@@ -1129,13 +1129,13 @@ void DebuggerJitInfo::SetBoundaries(ULONG32 cMap, ICorDebugInfo::OffsetMapping *
             m->ilOffset = ilThisOld;
             ilPrevOld = ilThisOld;
         }
-        
+
         if (m > m_sequenceMap && (m->source & call_inst) != call_inst)
         {
             DebuggerILToNativeMap *last = m-1;
             if ((last->source & call_inst) == call_inst)
                 last = (last > m_sequenceMap) ? last - 1 : NULL;
-                
+
             if (last && (last->source & call_inst) != call_inst && m->ilOffset == last->ilOffset)
             {
                 // JIT gave us an extra entry (probably zero), so mush
@@ -1145,7 +1145,7 @@ void DebuggerJitInfo::SetBoundaries(ULONG32 cMap, ICorDebugInfo::OffsetMapping *
                 continue;
             }
         }
-        
+
 
         // Move to next entry in the debugger's table
         m++;
@@ -1166,7 +1166,7 @@ void DebuggerJitInfo::SetBoundaries(ULONG32 cMap, ICorDebugInfo::OffsetMapping *
         unsigned int j = i + 1;
         while ((m_sequenceMap[j].source & call_inst) == call_inst && j < m_sequenceMapCount-1)
             j++;
-        
+
         m_sequenceMap[i].nativeEndOffset = m_sequenceMap[j].nativeStartOffset;
     }
 
@@ -1181,14 +1181,14 @@ void DebuggerJitInfo::SetBoundaries(ULONG32 cMap, ICorDebugInfo::OffsetMapping *
     isort.Sort();
 
     m_sequenceMapSorted = true;
-    
+
     m_callsiteMapCount = m_sequenceMapCount;
     while (m_sequenceMapCount > 0 && (m_sequenceMap[m_sequenceMapCount-1].source & call_inst) == call_inst)
       m_sequenceMapCount--;
 
     m_callsiteMap = m_sequenceMap + m_sequenceMapCount;
     m_callsiteMapCount -= m_sequenceMapCount;
-    
+
     LOG((LF_CORDB, LL_INFO100000, "DJI::SetBoundaries: this=0x%x boundary count is %d (%d callsites)\n",
          this, m_sequenceMapCount, m_callsiteMapCount));
 
@@ -1217,7 +1217,7 @@ void DebuggerJitInfo::SetBoundaries(ULONG32 cMap, ICorDebugInfo::OffsetMapping *
             LOG((LF_CORDB, LL_INFO1000000,
                  "D::sB: 0x%04x (Real:0x%04x) --> 0x%08x -- 0x%08x",
                  m_sequenceMap[count].ilOffset,
-                 m_methodInfo->TranslateToInstIL(&mapping, 
+                 m_methodInfo->TranslateToInstIL(&mapping,
                                                  m_sequenceMap[count].ilOffset,
                                                  bOriginalToInstrumented),
                  m_sequenceMap[count].nativeStartOffset,
@@ -1327,7 +1327,7 @@ DebuggerMethodInfo::~DebuggerMethodInfo()
 
 // Don't interpolate
 ULONG32 DebuggerMethodInfo::TranslateToInstIL(const InstrumentedILOffsetMapping * pMapping,
-                                              ULONG32 offOrig, 
+                                              ULONG32 offOrig,
                                               bool fOrigToInst)
 {
     LIMITED_METHOD_CONTRACT;
@@ -1423,7 +1423,7 @@ DebuggerMethodInfo::DebuggerMethodInfo(Module *module, mdMethodDef token) :
         CONSTRUCTOR_CHECK;
     }
     CONTRACTL_END;
- 
+
     LOG((LF_CORDB,LL_EVERYTHING, "DMI::DMI : created at 0x%p\n", this));
 
     _ASSERTE(g_pDebugger->HasDebuggerDataLock());
@@ -1501,7 +1501,7 @@ Module * DebuggerMethodInfo::GetRuntimeModule()
 // of jitted code.  This function does not create the DJI if it does not already exist.
 //
 // Arguments:
-//    pMD                 - the MD to lookup; must be non-NULL 
+//    pMD                 - the MD to lookup; must be non-NULL
 //    addrNativeStartAddr - the native start address of jitted code
 //
 // Return Value:
@@ -1525,7 +1525,7 @@ DebuggerJitInfo * DebuggerMethodInfo::FindJitInfo(MethodDesc * pMD,
     DebuggerJitInfo * pCheck = m_latestJitInfo;
     while (pCheck != NULL)
     {
-        if ( (pCheck->m_nativeCodeVersion.GetMethodDesc() == dac_cast<PTR_MethodDesc>(pMD)) && 
+        if ( (pCheck->m_nativeCodeVersion.GetMethodDesc() == dac_cast<PTR_MethodDesc>(pMD)) &&
              (pCheck->m_addrOfCode == addrNativeStartAddr) )
         {
             return pCheck;
@@ -1621,7 +1621,7 @@ DebuggerJitInfo *DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo(MethodDesc* f
     }
 
     BOOL jitInfoWasCreated;
-    return CreateInitAndAddJitInfo(nativeCodeVersion, startAddr, &jitInfoWasCreated); 
+    return CreateInitAndAddJitInfo(nativeCodeVersion, startAddr, &jitInfoWasCreated);
 }
 
 // Create a DJI around a method-desc. The EE already has all the information we need for a DJI,
@@ -1863,7 +1863,7 @@ void DebuggerMethodInfo::DJIIterator::Next(BOOL fFirst /*=FALSE*/)
         if ((m_pMethodDescFilter != NULL) && (m_pMethodDescFilter != m_pCurrent->m_nativeCodeVersion.GetMethodDesc()))
             continue;
 
-        // Skip modules that are unloaded, but still hanging around. Note that we can't use DebuggerModule for this check 
+        // Skip modules that are unloaded, but still hanging around. Note that we can't use DebuggerModule for this check
         // because of it is deleted pretty early during unloading, and we do not want to recreate it.
         if (pLoaderModule->GetLoaderAllocator()->IsUnloaded())
             continue;
@@ -2051,7 +2051,7 @@ void DebuggerMethodInfo::CreateDJIsForNativeBlobs(AppDomain * pAppDomain, Module
             if ((pLoaderModuleFilter != NULL) && (pLoaderModuleFilter != pLoaderModule))
                 continue;
 
-            // Skip modules that are unloaded, but still hanging around. Note that we can't use DebuggerModule for this check 
+            // Skip modules that are unloaded, but still hanging around. Note that we can't use DebuggerModule for this check
             // because of it is deleted pretty early during unloading, and we do not want to recreate it.
             if (pLoaderModule->GetLoaderAllocator()->IsUnloaded())
                 continue;
@@ -2257,7 +2257,7 @@ void DebuggerMethodInfoTable::ClearMethodsOfModule(Module *pModule)
 {
     WRAPPER_NO_CONTRACT;
 
-    _ASSERTE(g_pDebugger->HasDebuggerDataLock()); 
+    _ASSERTE(g_pDebugger->HasDebuggerDataLock());
 
     LOG((LF_CORDB, LL_INFO1000000, "CMOM:mod:0x%x (%S)\n", pModule
         ,pModule->GetDebugName()));
@@ -2398,16 +2398,6 @@ DebuggerMethodInfo *DebuggerMethodInfoTable::GetMethodInfo(Module *pModule, mdMe
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
 
-    //        CHECK_DMI_TABLE;
-
-    // @review.  One of the BVTs causes this to be called before the table is initialized
-    // In particular, the changes to BREAKPOINT_ADD mean that this table is now consulted
-    // to determine if we have ever seen the method, rather than a call to LookupMethodDesc,
-    // which would have just returned NULL.  In general it seems OK to consult this table
-    // when it is empty, so I've added this....
-    if (this == NULL)
-        return NULL;
-
     DebuggerMethodInfoKey dmik;
     dmik.pModule = dac_cast<PTR_Module>(pModule);
     dmik.token = token;
@@ -2488,7 +2478,7 @@ DebuggerMethodInfo *DebuggerMethodInfoTable::GetNextMethodInfo(HASHFIND *info)
 void
 DebuggerMethodInfoEntry::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 {
-    SUPPORTS_DAC; 
+    SUPPORTS_DAC;
 
     // This structure is in an array in the hash
     // so the 'this' is implicitly enumerated by the
@@ -2496,7 +2486,7 @@ DebuggerMethodInfoEntry::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 
     // For a MiniDumpNormal, what is needed for modules is already enumerated elsewhere.
     // Don't waste time doing it here an extra time. Also, this will add many MB extra into the dump.
-    if ((key.pModule.IsValid()) && 
+    if ((key.pModule.IsValid()) &&
         CLRDATA_ENUM_MEM_MINI != flags
         && CLRDATA_ENUM_MEM_TRIAGE != flags)
     {

--- a/src/debug/ildbsymlib/symwrite.cpp
+++ b/src/debug/ildbsymlib/symwrite.cpp
@@ -15,9 +15,9 @@
 #include "symwrite.h"
 
 
-// ------------------------------------------------------------------------- 
+// -------------------------------------------------------------------------
 // SymWriter class
-// ------------------------------------------------------------------------- 
+// -------------------------------------------------------------------------
 
 // This is a COM object which is called both directly from the runtime, and from managed code
 // via PInvoke (CoreSymWrapper) and IJW (ISymWrapper).  This is an unusual pattern, and it's not
@@ -26,7 +26,7 @@
 // live in a different DLL instead of being statically linked into the runtime.  But since it
 // relies on utilcode (and actually gets the runtime utilcode, not the nohost utilcode like
 // other external tools), it does have some properties of runtime code.
-// 
+//
 
 //-----------------------------------------------------------
 // NewSymWriter
@@ -115,21 +115,21 @@ SymWriter::~SymWriter()
 // SymWriter Initialize the SymWriter
 //-----------------------------------------------------------
 COM_METHOD SymWriter::Initialize
-(   
+(
     IUnknown *emitter,        // Emitter (IMetaData Emit/Import) - unused by ILDB
     const WCHAR *szFilename,  // FileName of the exe we're creating
     IStream *pIStream,        // Stream to store into
     BOOL fFullBuild           // Is this a full build or an incremental build
 )
-{    
+{
     HRESULT hr = S_OK;
-    
+
     // Incremental compile not implemented
     _ASSERTE(fFullBuild);
-    
+
     if (emitter == NULL)
         return E_INVALIDARG;
-    
+
     if (pIStream != NULL)
     {
         m_pIStream = pIStream;
@@ -142,10 +142,10 @@ COM_METHOD SymWriter::Initialize
             IfFailRet(E_INVALIDARG);
         }
     }
-    
+
     m_pStringPool = NEW(StgStringPool());
     IfFailRet(m_pStringPool->InitNew());
-    
+
     if (szFilename != NULL)
     {
         WCHAR fullpath[_MAX_PATH];
@@ -157,9 +157,9 @@ COM_METHOD SymWriter::Initialize
         if (wcsncpy_s( m_szPath, COUNTOF(m_szPath), fullpath, _TRUNCATE) == STRUNCATE)
             return HrFromWin32(ERROR_INSUFFICIENT_BUFFER);
     }
-    
+
     // Note that we don't need the emitter - ILDB is agnostic to the module metadata.
-    
+
     return hr;
 }
 
@@ -174,7 +174,7 @@ COM_METHOD SymWriter::Initialize2
     IStream *pIStream,         // Stream to store into
     BOOL fFullBuild,           // Full build or not
     const WCHAR *szFullPathName   // Final destination of the ildb
-)    
+)
 {
     HRESULT hr = S_OK;
     IfFailGo( Initialize( emitter, szTempPath, pIStream, fFullBuild ) );
@@ -187,8 +187,8 @@ ErrExit:
 //-----------------------------------------------------------
 // SymWriter GetorCreateDocument
 // creates a new symbol document writer for a specified source
-// Arguments: 
-//     input:  wcsUrl   - The source file name 
+// Arguments:
+//     input:  wcsUrl   - The source file name
 //     output: ppRetVal - The new document writer
 // Return Value: hr - S_OK if success, OOM otherwise
 //-----------------------------------------------------------
@@ -219,12 +219,12 @@ HRESULT SymWriter::GetOrCreateDocument(
     else // we already have a writer for this file
     {
         UINT32 docInfo = 0;
-        
+
         CRITSEC_COOKIE cs = ClrCreateCriticalSection(CrstLeafLock, CRST_DEFAULT);
-        
+
         ClrEnterCriticalSection(cs);
 
-        while ((docInfo < m_MethodInfo.m_documents.count()) && (m_MethodInfo.m_documents[docInfo].UrlEntry() != UrlEntry)) 
+        while ((docInfo < m_MethodInfo.m_documents.count()) && (m_MethodInfo.m_documents[docInfo].UrlEntry() != UrlEntry))
         {
             docInfo++;
         }
@@ -233,7 +233,7 @@ HRESULT SymWriter::GetOrCreateDocument(
         {
             hr = CreateDocument(wcsUrl, pLanguage, pLanguageVendor, pDocumentType, ppRetVal);
         }
-        else 
+        else
         {
             *ppRetVal = m_MethodInfo.m_documents[docInfo].DocumentWriter();
             (*ppRetVal)->AddRef();
@@ -249,8 +249,8 @@ HRESULT SymWriter::GetOrCreateDocument(
 //-----------------------------------------------------------
 // SymWriter CreateDocument
 // creates a new symbol document writer for a specified source
-// Arguments: 
-//     input:  wcsUrl   - The source file name 
+// Arguments:
+//     input:  wcsUrl   - The source file name
 //     output: ppRetVal - The new document writer
 // Return Value: hr - S_OK if success, OOM otherwise
 //-----------------------------------------------------------
@@ -425,7 +425,7 @@ COM_METHOD SymWriter::OpenMethod(mdMethodDef method)
         {
             if (m_MethodInfo.m_methods[i].MethodToken() == method)
             {
-                return E_INVALIDARG;                
+                return E_INVALIDARG;
             }
         }
     }
@@ -523,7 +523,7 @@ COM_METHOD SymWriter::CloseMethod()
 
     // All done with this method.
     m_openMethodToken = mdMethodDefNil;
-    
+
     return hr;
 }
 
@@ -532,7 +532,7 @@ COM_METHOD SymWriter::CloseMethod()
 // Define the sequence points for this function
 //-----------------------------------------------------------
 COM_METHOD SymWriter::DefineSequencePoints(
-    ISymUnmanagedDocumentWriter *document,  // 
+    ISymUnmanagedDocumentWriter *document,  //
     ULONG32 spCount,        // Count of sequence points
     ULONG32 offsets[],      // Offsets
     ULONG32 lines[],        // Beginning Lines
@@ -634,7 +634,7 @@ COM_METHOD SymWriter::CloseScope(
     // The implicit root scope is only closed internally by CloseMethod.
     if ((m_currentScope == k_noScope) || (m_MethodInfo.m_scopes[m_currentScope].ParentScope() == k_noScope))
         return E_FAIL;
-    
+
     HRESULT hr = CloseScopeInternal(endOffset);
 
     _ASSERTE(m_currentScope != k_noScope);
@@ -743,7 +743,7 @@ COM_METHOD SymWriter::DefineLocalVariable(
     var->SetName(NameEntry);
 
     // Copy the signature
-    // Note that we give this back exactly as-is, but callers typically remove any calling 
+    // Note that we give this back exactly as-is, but callers typically remove any calling
     // convention prefix.
     UINT32 i;
     IfFalseGo(m_MethodInfo.m_bytes.grab(sigLen, &i), E_OUTOFMEMORY);
@@ -960,7 +960,7 @@ COM_METHOD SymWriter::DefineField(
     ULONG32 addr1, ULONG32 addr2, ULONG32 addr3)
 {
     // This symbol store doesn't support extra random variable
-    // definitions. 
+    // definitions.
     return S_OK;
 }
 
@@ -1150,7 +1150,7 @@ COM_METHOD SymWriter::GetDebugCVInfo(
     BYTE buf[])       // [optional, out] Buffer for DebugInfo
 {
 
-    if ( m_szPath == NULL || *m_szPath == 0 )
+    if ( *m_szPath == 0 )
         return E_UNEXPECTED;
 
     // We need to change the .ildb extension to .pdb to be
@@ -1172,18 +1172,18 @@ COM_METHOD SymWriter::GetDebugCVInfo(
     DWORD dwSize = sizeof(RSDSI) + DWORD(Utf8Length);
 
     // If the caller is just checking for the size
-    if ( cbBuf == 0 && pcbBuf != NULL ) 
-    {   
+    if ( cbBuf == 0 && pcbBuf != NULL )
+    {
         *pcbBuf = dwSize;
         return S_OK;
     }
 
-    if (cbBuf < dwSize) 
-    {    
+    if (cbBuf < dwSize)
+    {
         return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
     }
 
-    if ( buf == NULL ) 
+    if ( buf == NULL )
     {
         return E_INVALIDARG;
     }
@@ -1211,8 +1211,8 @@ COM_METHOD SymWriter::GetDebugInfo(
     BYTE data[])                  // [optional] Buffer to store into
 {
     HRESULT hr = S_OK;
-    if ( cData == 0 && pcData != NULL ) 
-    {   
+    if ( cData == 0 && pcData != NULL )
+    {
         // just checking for the size
         return GetDebugCVInfo( 0, pcData, NULL );
     }
@@ -1263,7 +1263,7 @@ COM_METHOD SymWriter::RemapToken(mdToken oldToken, mdToken newToken)
                     SymMap *pMethodMap;
                     IfNullGo( pMethodMap = m_MethodMap.next() );
                     pMethodMap->m_MethodToken = newToken;
-                    pMethodMap->MethodEntry = i;                        
+                    pMethodMap->MethodEntry = i;
                     break;
                 }
             }
@@ -1413,7 +1413,7 @@ COM_METHOD SymWriter::WritePDB()
 #if _DEBUG
     // We need to make sure the Variant entry in the constants is 8 byte
     // aligned so make sure everything up to the there is aligned correctly
-    if ((ILDB_SIGNATURE_SIZE % 8) || 
+    if ((ILDB_SIGNATURE_SIZE % 8) ||
         (sizeof(PDBInfo) % 8) ||
         (sizeof(GUID) % 8))
     {
@@ -1427,7 +1427,7 @@ COM_METHOD SymWriter::WritePDB()
     SwapGuid(&ildb_guid);
     IfFailGo(Write((void *)&ildb_guid, sizeof(GUID)));
 
-    // Now we need to write the Project level 
+    // Now we need to write the Project level
     IfFailGo(Write(&ModuleLevelInfo, sizeof(PDBInfo)));
 
     // Now we have to write out each array as appropriate

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -27,7 +27,7 @@ class gc_rand
 public:
     static uint64_t x;
 
-    static uint64_t get_rand() 
+    static uint64_t get_rand()
     {
 	    x = (314159269*x+278281) & 0x7FFFFFFF;
 	    return x;
@@ -115,7 +115,7 @@ const char * const allocation_state_str[] = {
     "try_fit_new_seg",
     "try_fit_after_cg",
     "try_fit_after_bgc",
-    "try_free_full_seg_in_bgc", 
+    "try_free_full_seg_in_bgc",
     "try_free_after_bgc",
     "try_seg_end",
     "acquire_seg",
@@ -149,7 +149,7 @@ const char * const msl_take_state_str[] = {
 
 // Keep this in sync with the definition of gc_reason
 #if (defined(DT_LOG) || defined(TRACE_GC)) && !defined (DACCESS_COMPILE)
-static const char* const str_gc_reasons[] = 
+static const char* const str_gc_reasons[] =
 {
     "alloc_soh",
     "induced",
@@ -167,7 +167,7 @@ static const char* const str_gc_reasons[] =
     "lowmemory_host_blocking"
 };
 
-static const char* const str_gc_pause_modes[] = 
+static const char* const str_gc_pause_modes[] =
 {
     "batch",
     "interactive",
@@ -183,9 +183,9 @@ BOOL is_induced (gc_reason reason)
     return ((reason == reason_induced) ||
             (reason == reason_induced_noforce) ||
             (reason == reason_lowmemory) ||
-            (reason == reason_lowmemory_blocking) || 
+            (reason == reason_lowmemory_blocking) ||
             (reason == reason_induced_compacting) ||
-            (reason == reason_lowmemory_host) || 
+            (reason == reason_lowmemory_host) ||
             (reason == reason_lowmemory_host_blocking));
 }
 
@@ -193,7 +193,7 @@ inline
 BOOL is_induced_blocking (gc_reason reason)
 {
     return ((reason == reason_induced) ||
-            (reason == reason_lowmemory_blocking) || 
+            (reason == reason_lowmemory_blocking) ||
             (reason == reason_induced_compacting) ||
             (reason == reason_lowmemory_host_blocking));
 }
@@ -205,8 +205,8 @@ size_t start_time;
 size_t GetHighPrecisionTimeStamp()
 {
     int64_t ts = GCToOSInterface::QueryPerformanceCounter();
-    
-    return (size_t)(ts / (qpf / 1000));    
+
+    return (size_t)(ts / (qpf / 1000));
 }
 
 uint64_t RawGetHighPrecisionTimeStamp()
@@ -294,7 +294,7 @@ void GCStatistics::DisplayAndUpdate()
     {
         if (cntDisplay == 0)
             fprintf(logFile, "\nGCMix **** Initialize *****\n\n");
-            
+
         fprintf(logFile, "GCMix **** Summary ***** %d\n", cntDisplay);
 
         // NGC summary (total, timing info)
@@ -335,7 +335,7 @@ void GCStatistics::DisplayAndUpdate()
         for (int reason=(int)reason_alloc_soh; reason <= (int)reason_gcstress; ++reason)
         {
             if (cntReasons[reason] != 0)
-                fprintf(logFile, "%s %d (%d). ", str_gc_reasons[reason], 
+                fprintf(logFile, "%s %d (%d). ", str_gc_reasons[reason],
                     cntReasons[reason]-g_LastGCStatistics.cntReasons[reason], cntReasons[reason]);
         }
 #endif // TRACE_GC
@@ -752,10 +752,10 @@ enum gc_join_stage
     gc_join_scan_sizedref_done = 6,
     gc_join_null_dead_short_weak = 7,
     gc_join_scan_finalization = 8,
-    gc_join_null_dead_long_weak = 9, 
-    gc_join_null_dead_syncblk = 10, 
-    gc_join_decide_on_compaction = 11, 
-    gc_join_rearrange_segs_compaction = 12, 
+    gc_join_null_dead_long_weak = 9,
+    gc_join_null_dead_syncblk = 10,
+    gc_join_decide_on_compaction = 11,
+    gc_join_rearrange_segs_compaction = 12,
     gc_join_adjust_handle_age_compact = 13,
     gc_join_adjust_handle_age_sweep = 14,
     gc_join_begin_relocate_phase = 15,
@@ -772,7 +772,7 @@ enum gc_join_stage
     gc_join_restart_ee_verify = 26,
     gc_join_set_state_free = 27,
     gc_r_join_update_card_bundle = 28,
-    gc_join_after_absorb = 29, 
+    gc_join_after_absorb = 29,
     gc_join_verify_copy_table = 30,
     gc_join_after_reset = 31,
     gc_join_after_ephemeral_sweep = 32,
@@ -790,7 +790,7 @@ enum gc_join_flavor
     join_flavor_server_gc = 0,
     join_flavor_bgc = 1
 };
-  
+
 #define first_thread_arrived 2
 #pragma warning(push)
 #pragma warning(disable:4324) // don't complain if DECLSPEC_ALIGN actually pads
@@ -814,18 +814,18 @@ struct DECLSPEC_ALIGN(HS_CACHE_LINE_SIZE) join_structure
 };
 #pragma warning(pop)
 
-enum join_type 
+enum join_type
 {
-    type_last_join = 0, 
-    type_join = 1, 
-    type_restart = 2, 
-    type_first_r_join = 3, 
+    type_last_join = 0,
+    type_join = 1,
+    type_restart = 2,
+    type_first_r_join = 3,
     type_r_join = 4
 };
 
-enum join_time 
+enum join_time
 {
-    time_start = 0, 
+    time_start = 0,
     time_end = 1
 };
 
@@ -872,10 +872,10 @@ public:
                 join_struct.joined_p = FALSE;
                 dprintf (JOIN_LOG, ("Creating join event %d", i));
                 // TODO - changing this to a non OS event
-                // because this is also used by BGC threads which are 
+                // because this is also used by BGC threads which are
                 // managed threads and WaitEx does not allow you to wait
                 // for an OS event on a managed thread.
-                // But we are not sure if this plays well in the hosting 
+                // But we are not sure if this plays well in the hosting
                 // environment.
                 //join_struct.joined_event[i].CreateOSManualEventNoThrow(FALSE);
                 if (!join_struct.joined_event[i].CreateManualEventNoThrow(FALSE))
@@ -893,7 +893,7 @@ public:
 
         return TRUE;
     }
-    
+
     void destroy ()
     {
         dprintf (JOIN_LOG, ("Destroying join structure"));
@@ -921,7 +921,7 @@ public:
 
         if (Interlocked::Decrement(&join_struct.join_lock) != 0)
         {
-            dprintf (JOIN_LOG, ("join%d(%d): Join() Waiting...join_lock is now %d", 
+            dprintf (JOIN_LOG, ("join%d(%d): Join() Waiting...join_lock is now %d",
                 flavor, join_id, (int32_t)(join_struct.join_lock)));
 
             fire_event (gch->heap_number, time_start, type_join, join_id);
@@ -943,7 +943,7 @@ respin:
                 // we've spun, and if color still hasn't changed, fall into hard wait
                 if (color == join_struct.lock_color.LoadWithoutBarrier())
                 {
-                    dprintf (JOIN_LOG, ("join%d(%d): Join() hard wait on reset event %d, join_lock is now %d", 
+                    dprintf (JOIN_LOG, ("join%d(%d): Join() hard wait on reset event %d, join_lock is now %d",
                         flavor, join_id, color, (int32_t)(join_struct.join_lock)));
 
                     //Thread* current_thread = GCToEEInterface::GetThread();
@@ -964,7 +964,7 @@ respin:
                     goto respin;
                 }
 
-                dprintf (JOIN_LOG, ("join%d(%d): Join() done, join_lock is %d", 
+                dprintf (JOIN_LOG, ("join%d(%d): Join() done, join_lock is %d",
                     flavor, join_id, (int32_t)(join_struct.join_lock)));
             }
 
@@ -997,7 +997,7 @@ respin:
 
     // Reverse join - first thread gets here does the work; other threads will only proceed
     // after the work is done.
-    // Note that you cannot call this twice in a row on the same thread. Plus there's no 
+    // Note that you cannot call this twice in a row on the same thread. Plus there's no
     // need to call it twice in row - you should just merge the work.
     BOOL r_join (gc_heap* gch, int join_id)
     {
@@ -1148,7 +1148,7 @@ respin:
         start[thd] = get_ts();
 #endif //JOIN_STATS
     }
-    
+
     BOOL joined()
     {
         dprintf (JOIN_LOG, ("join%d(%d): joined, join_lock is %d", flavor, id, (int32_t)(join_struct.join_lock)));
@@ -1213,7 +1213,7 @@ class exclusive_sync
     // TODO - verify that this is the right syntax for Volatile.
     VOLATILE(uint8_t*) rwp_object;
     VOLATILE(int32_t) needs_checking;
-    
+
     int spin_count;
 
     uint8_t cache_separator[HS_CACHE_LINE_SIZE - sizeof (int) - sizeof (int32_t)];
@@ -1230,7 +1230,7 @@ class exclusive_sync
                 return i;
             }
         }
- 
+
         return -1;
     }
 
@@ -1323,8 +1323,8 @@ retry:
 
                     dprintf (3, ("loh alloc: set %Ix at %d", obj, cookie));
                     return cookie;
-                } 
-                else 
+                }
+                else
                 {
                     needs_checking = 0;
                     dprintf (3, ("loh alloc: setting %Ix will spin to acquire a free index", obj));
@@ -1350,7 +1350,7 @@ retry:
     void loh_alloc_done_with_index (int index)
     {
         dprintf (3, ("loh alloc: release lock on %Ix based on %d", (uint8_t *)alloc_objects[index], index));
-        assert ((index >= 0) && (index < max_pending_allocs)); 
+        assert ((index >= 0) && (index < max_pending_allocs));
         alloc_objects[index] = (uint8_t*)0;
     }
 
@@ -1376,7 +1376,7 @@ retry:
 };
 
 // Note that this class was written assuming just synchronization between
-// one background GC thread and multiple user threads that might request 
+// one background GC thread and multiple user threads that might request
 // an FGC - it does not take into account what kind of locks the multiple
 // user threads might be holding at the time (eg, there could only be one
 // user thread requesting an FGC because it needs to take gc_lock first)
@@ -1867,7 +1867,7 @@ void WaitLonger (int i
     // If CLR is hosted, a thread may reach here while it is in preemptive GC mode,
     // or it has no Thread object, in order to force a task to yield, or to triger a GC.
     // It is important that the thread is going to wait for GC.  Otherwise the thread
-    // is in a tight loop.  If the thread has high priority, the perf is going to be very BAD. 
+    // is in a tight loop.  If the thread has high priority, the perf is going to be very BAD.
     if (gc_heap::gc_started)
     {
         gc_heap::wait_for_gc_done();
@@ -1977,7 +1977,7 @@ void memclr ( uint8_t* mem, size_t size)
     assert (sizeof(PTR_PTR) == DATA_ALIGNMENT);
 
 #if 0
-    // The compiler will recognize this pattern and replace it with memset call. We can as well just call 
+    // The compiler will recognize this pattern and replace it with memset call. We can as well just call
     // memset directly to make it obvious what's going on.
     PTR_PTR m = (PTR_PTR) mem;
     for (size_t i = 0; i < size / sizeof(PTR_PTR); i++)
@@ -2065,7 +2065,7 @@ BOOL same_large_alignment_p (uint8_t* p1, uint8_t* p2)
 #endif //RESPECT_LARGE_ALIGNMENT
 }
 
-inline 
+inline
 size_t switch_alignment_size (BOOL already_padded_p)
 {
     if (already_padded_p)
@@ -2392,7 +2392,7 @@ void stomp_write_barrier_initialize(uint8_t* ephemeral_low, uint8_t* ephemeral_h
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
     args.card_bundle_table = g_gc_card_bundle_table;
 #endif
-    
+
     args.lowest_address = g_gc_lowest_address;
     args.highest_address = g_gc_highest_address;
     args.ephemeral_low = ephemeral_low;
@@ -2410,7 +2410,7 @@ void stomp_write_barrier_initialize(uint8_t* ephemeral_low, uint8_t* ephemeral_h
 // Things we need to manually initialize:
 // gen0 min_size - based on cache
 // gen0/1 max_size - based on segment size
-static static_data static_data_table[latency_level_last - latency_level_first + 1][NUMBERGENERATIONS] = 
+static static_data static_data_table[latency_level_last - latency_level_first + 1][NUMBERGENERATIONS] =
 {
     // latency_level_memory_footprint
     {
@@ -3067,11 +3067,11 @@ void gc_generation_data::print (int heap_num, int gen_num)
 {
 #if defined(SIMPLE_DPRINTF) && defined(DT_LOG)
     dprintf (DT_LOG_0, ("[%2d]gen%d beg %Id fl %Id fo %Id end %Id fl %Id fo %Id in %Id p %Id np %Id alloc %Id",
-                heap_num, gen_num, 
-                size_before, 
+                heap_num, gen_num,
+                size_before,
                 free_list_space_before, free_obj_space_before,
-                size_after, 
-                free_list_space_after, free_obj_space_after, 
+                size_after,
+                free_list_space_after, free_obj_space_after,
                 in, pinned_surv, npinned_surv,
                 new_allocation));
 #else
@@ -3089,7 +3089,7 @@ void gc_history_per_heap::set_mechanism (gc_mechanism_per_heap mechanism_per_hea
 
 #ifdef DT_LOG
     gc_mechanism_descr* descr = &gc_mechanisms_descr[mechanism_per_heap];
-    dprintf (DT_LOG_0, ("setting %s: %s", 
+    dprintf (DT_LOG_0, ("setting %s: %s",
             descr->name,
             (descr->descr)[value]));
 #endif //DT_LOG
@@ -3103,7 +3103,7 @@ void gc_history_per_heap::print()
         gen_data[i].print (heap_index, i);
     }
 
-    dprintf (DT_LOG_0, ("fla %Id flr %Id esa %Id ca %Id pa %Id paa %Id, rfle %d, ec %Id", 
+    dprintf (DT_LOG_0, ("fla %Id flr %Id esa %Id ca %Id pa %Id paa %Id, rfle %d, ec %Id",
                     maxgen_size_info.free_list_allocated,
                     maxgen_size_info.free_list_rejected,
                     maxgen_size_info.end_seg_allocated,
@@ -3123,9 +3123,9 @@ void gc_history_per_heap::print()
         if (mechanism >= 0)
         {
             descr = &gc_mechanisms_descr[(gc_mechanism_per_heap)i];
-            dprintf (DT_LOG_0, ("[%2d]%s%s", 
+            dprintf (DT_LOG_0, ("[%2d]%s%s",
                         heap_index,
-                        descr->name, 
+                        descr->name,
                         (descr->descr)[mechanism]));
         }
     }
@@ -3150,7 +3150,7 @@ void gc_history_global::print()
     dprintf (DT_LOG_0, ("Condemned gen%d(reason: %s; mode: %s), youngest budget %Id(%d), memload %d",
                         condemned_generation,
                         str_gc_reasons[reason],
-                        str_gc_pause_modes[pause_mode],                        
+                        str_gc_pause_modes[pause_mode],
                         final_youngest_desired,
                         gen0_reduction_count,
                         mem_pressure));
@@ -3160,9 +3160,9 @@ void gc_history_global::print()
 void gc_heap::fire_per_heap_hist_event (gc_history_per_heap* current_gc_data_per_heap, int heap_num)
 {
     maxgen_size_increase* maxgen_size_info = &(current_gc_data_per_heap->maxgen_size_info);
-    FIRE_EVENT(GCPerHeapHistory_V3, 
+    FIRE_EVENT(GCPerHeapHistory_V3,
                (void *)(maxgen_size_info->free_list_allocated),
-               (void *)(maxgen_size_info->free_list_rejected),                              
+               (void *)(maxgen_size_info->free_list_rejected),
                (void *)(maxgen_size_info->end_seg_allocated),
                (void *)(maxgen_size_info->condemned_allocated),
                (void *)(maxgen_size_info->pinned_allocated),
@@ -3187,14 +3187,14 @@ void gc_heap::fire_pevents()
     settings.record (&gc_data_global);
     gc_data_global.print();
 
-    FIRE_EVENT(GCGlobalHeapHistory_V2, 
-               gc_data_global.final_youngest_desired, 
-               gc_data_global.num_heaps, 
-               gc_data_global.condemned_generation, 
-               gc_data_global.gen0_reduction_count, 
-               gc_data_global.reason, 
-               gc_data_global.global_mechanisms_p, 
-               gc_data_global.pause_mode, 
+    FIRE_EVENT(GCGlobalHeapHistory_V2,
+               gc_data_global.final_youngest_desired,
+               gc_data_global.num_heaps,
+               gc_data_global.condemned_generation,
+               gc_data_global.gen0_reduction_count,
+               gc_data_global.reason,
+               gc_data_global.global_mechanisms_p,
+               gc_data_global.pause_mode,
                gc_data_global.mem_pressure);
 
 #ifdef MULTIPLE_HEAPS
@@ -3207,7 +3207,7 @@ void gc_heap::fire_pevents()
 #else
     gc_history_per_heap* current_gc_data_per_heap = get_gc_data_per_heap();
     fire_per_heap_hist_event (current_gc_data_per_heap, heap_number);
-#endif    
+#endif
 }
 
 inline BOOL
@@ -3229,8 +3229,8 @@ gc_heap::dt_low_ephemeral_space_p (gc_tuning_point tp)
         {
             size_t new_gen0size = approximate_new_allocation();
             ptrdiff_t plan_ephemeral_size = total_ephemeral_size;
-            
-            dprintf (GTC_LOG, ("h%d: plan eph size is %Id, new gen0 is %Id", 
+
+            dprintf (GTC_LOG, ("h%d: plan eph size is %Id, new gen0 is %Id",
                 heap_number, plan_ephemeral_size, new_gen0size));
             // If we were in no_gc_region we could have allocated a larger than normal segment,
             // and the next seg we allocate will be a normal sized seg so if we can't fit the new
@@ -3245,9 +3245,9 @@ gc_heap::dt_low_ephemeral_space_p (gc_tuning_point tp)
     return ret;
 }
 
-BOOL 
-gc_heap::dt_high_frag_p (gc_tuning_point tp, 
-                         int gen_number, 
+BOOL
+gc_heap::dt_high_frag_p (gc_tuning_point tp,
+                         int gen_number,
                          BOOL elevate_p)
 {
     BOOL ret = FALSE;
@@ -3286,7 +3286,7 @@ gc_heap::dt_high_frag_p (gc_tuning_point tp,
                     ret = (fragmentation_burden > dd_v_fragmentation_burden_limit (dd));
                 }
                 dprintf (GTC_LOG, ("h%d: gen%d, frag is %Id, alloc effi: %d%%, unusable frag is %Id, ratio is %d",
-                    heap_number, gen_number, dd_fragmentation (dd), 
+                    heap_number, gen_number, dd_fragmentation (dd),
                     (int)(100*generation_allocator_efficiency (generation_of (gen_number))),
                     fr, (int)(fragmentation_burden*100)));
             }
@@ -3299,7 +3299,7 @@ gc_heap::dt_high_frag_p (gc_tuning_point tp,
     return ret;
 }
 
-inline BOOL 
+inline BOOL
 gc_heap::dt_estimate_reclaim_space_p (gc_tuning_point tp, int gen_number)
 {
     BOOL ret = FALSE;
@@ -3335,10 +3335,10 @@ gc_heap::dt_estimate_reclaim_space_p (gc_tuning_point tp, int gen_number)
     return ret;
 }
 
-// DTREVIEW: Right now we only estimate gen2 fragmentation. 
+// DTREVIEW: Right now we only estimate gen2 fragmentation.
 // on 64-bit though we should consider gen1 or even gen0 fragmentation as
-// well 
-inline BOOL 
+// well
+inline BOOL
 gc_heap::dt_estimate_high_frag_p (gc_tuning_point tp, int gen_number, uint64_t available_mem)
 {
     BOOL ret = FALSE;
@@ -3363,9 +3363,9 @@ gc_heap::dt_estimate_high_frag_p (gc_tuning_point tp, int gen_number, uint64_t a
                 {
                     est_frag_ratio = (float)dd_fragmentation (dd) / (float)(dd_fragmentation (dd) + dd_current_size (dd));
                 }
-                
+
                 size_t est_frag = (dd_fragmentation (dd) + (size_t)((dd_desired_allocation (dd) - dd_new_allocation (dd)) * est_frag_ratio));
-                dprintf (GTC_LOG, ("h%d: gen%d: current_size is %Id, frag is %Id, est_frag_ratio is %d%%, estimated frag is %Id", 
+                dprintf (GTC_LOG, ("h%d: gen%d: current_size is %Id, frag is %Id, est_frag_ratio is %d%%, estimated frag is %Id",
                     heap_number,
                     gen_number,
                     dd_current_size (dd),
@@ -3396,7 +3396,7 @@ gc_heap::dt_estimate_high_frag_p (gc_tuning_point tp, int gen_number, uint64_t a
     return ret;
 }
 
-inline BOOL 
+inline BOOL
 gc_heap::dt_low_card_table_efficiency_p (gc_tuning_point tp)
 {
     BOOL ret = FALSE;
@@ -3710,13 +3710,13 @@ BOOL seg_mapping_table_init()
     if (seg_mapping_table)
     {
         memset (seg_mapping_table, 0, num_entries * sizeof (seg_mapping));
-        dprintf (1, ("created %d entries for heap mapping (%Id bytes)", 
+        dprintf (1, ("created %d entries for heap mapping (%Id bytes)",
                      num_entries, (num_entries * sizeof (seg_mapping))));
         return TRUE;
     }
     else
     {
-        dprintf (1, ("failed to create %d entries for heap mapping (%Id bytes)", 
+        dprintf (1, ("failed to create %d entries for heap mapping (%Id bytes)",
                      num_entries, (num_entries * sizeof (seg_mapping))));
         return FALSE;
     }
@@ -3782,10 +3782,10 @@ void gc_heap::seg_mapping_table_add_segment (heap_segment* seg, gc_heap* hp)
     size_t end_index = seg_end >> gc_heap::min_segment_size_shr;
     seg_mapping* end_entry = &seg_mapping_table[end_index];
 
-    dprintf (1, ("adding seg %Ix(%d)-%Ix(%d)", 
+    dprintf (1, ("adding seg %Ix(%d)-%Ix(%d)",
         seg, begin_index, heap_segment_reserved (seg), end_index));
 
-    dprintf (1, ("before add: begin entry%d: boundary: %Ix; end entry: %d: boundary: %Ix", 
+    dprintf (1, ("before add: begin entry%d: boundary: %Ix; end entry: %d: boundary: %Ix",
         begin_index, (seg_mapping_table[begin_index].boundary + 1),
         end_index, (seg_mapping_table[end_index].boundary + 1)));
 
@@ -3824,7 +3824,7 @@ void gc_heap::seg_mapping_table_add_segment (heap_segment* seg, gc_heap* hp)
         seg_mapping_table[entry_index].seg1 = seg;
     }
 
-    dprintf (1, ("after add: begin entry%d: boundary: %Ix; end entry: %d: boundary: %Ix", 
+    dprintf (1, ("after add: begin entry%d: boundary: %Ix; end entry: %d: boundary: %Ix",
         begin_index, (seg_mapping_table[begin_index].boundary + 1),
         end_index, (seg_mapping_table[end_index].boundary + 1)));
 #if defined(MULTIPLE_HEAPS) && defined(SIMPLE_DPRINTF)
@@ -3843,7 +3843,7 @@ void gc_heap::seg_mapping_table_remove_segment (heap_segment* seg)
     seg_mapping* begin_entry = &seg_mapping_table[begin_index];
     size_t end_index = seg_end >> gc_heap::min_segment_size_shr;
     seg_mapping* end_entry = &seg_mapping_table[end_index];
-    dprintf (1, ("removing seg %Ix(%d)-%Ix(%d)", 
+    dprintf (1, ("removing seg %Ix(%d)-%Ix(%d)",
         seg, begin_index, heap_segment_reserved (seg), end_index));
 
     assert (end_entry->boundary == (uint8_t*)seg_end);
@@ -3873,7 +3873,7 @@ void gc_heap::seg_mapping_table_remove_segment (heap_segment* seg)
         seg_mapping_table[entry_index].seg1 = 0;
     }
 
-    dprintf (1, ("after remove: begin entry%d: boundary: %Ix; end entry: %d: boundary: %Ix", 
+    dprintf (1, ("after remove: begin entry%d: boundary: %Ix; end entry: %d: boundary: %Ix",
         begin_index, (seg_mapping_table[begin_index].boundary + 1),
         end_index, (seg_mapping_table[end_index].boundary + 1)));
 #ifdef MULTIPLE_HEAPS
@@ -3893,7 +3893,7 @@ gc_heap* seg_mapping_table_heap_of_worker (uint8_t* o)
     gc_heap* hp = ((o > entry->boundary) ? entry->h1 : entry->h0);
 
     dprintf (2, ("checking obj %Ix, index is %Id, entry: boundary: %Ix, h0: %Ix, seg0: %Ix, h1: %Ix, seg1: %Ix",
-        o, index, (entry->boundary + 1), 
+        o, index, (entry->boundary + 1),
         (uint8_t*)(entry->h0), (uint8_t*)(entry->seg0),
         (uint8_t*)(entry->h1), (uint8_t*)(entry->seg1)));
 
@@ -3912,7 +3912,7 @@ gc_heap* seg_mapping_table_heap_of_worker (uint8_t* o)
         }
         else
         {
-            dprintf (2, ("found seg %Ix(-%Ix) for obj %Ix, but it's not on the seg", 
+            dprintf (2, ("found seg %Ix(-%Ix) for obj %Ix, but it's not on the seg",
                 seg, (uint8_t*)heap_segment_allocated (seg), o));
         }
     }
@@ -3962,7 +3962,7 @@ heap_segment* seg_mapping_table_segment_of (uint8_t* o)
     seg_mapping* entry = &seg_mapping_table[index];
 
     dprintf (2, ("checking obj %Ix, index is %Id, entry: boundary: %Ix, seg0: %Ix, seg1: %Ix",
-        o, index, (entry->boundary + 1), 
+        o, index, (entry->boundary + 1),
         (uint8_t*)(entry->seg0), (uint8_t*)(entry->seg1)));
 
     heap_segment* seg = ((o > entry->boundary) ? entry->seg1 : entry->seg0);
@@ -3979,7 +3979,7 @@ heap_segment* seg_mapping_table_segment_of (uint8_t* o)
         }
         else
         {
-            dprintf (2, ("found seg %Ix(-%Ix) for obj %Ix, but it's not on the seg, setting it to 0", 
+            dprintf (2, ("found seg %Ix(-%Ix) for obj %Ix, but it's not on the seg, setting it to 0",
                 (uint8_t*)heap_segment_mem(seg), (uint8_t*)heap_segment_reserved(seg), o));
             seg = 0;
         }
@@ -3990,11 +3990,11 @@ heap_segment* seg_mapping_table_segment_of (uint8_t* o)
     }
 
 #ifdef FEATURE_BASICFREEZE
-    // TODO: This was originally written assuming that the seg_mapping_table would always contain entries for ro 
-    // segments whenever the ro segment falls into the [g_gc_lowest_address,g_gc_highest_address) range.  I.e., it had an 
-    // extra "&& (size_t)(entry->seg1) & ro_in_entry" expression.  However, at the moment, grow_brick_card_table does 
-    // not correctly go through the ro segments and add them back to the seg_mapping_table when the [lowest,highest) 
-    // range changes.  We should probably go ahead and modify grow_brick_card_table and put back the 
+    // TODO: This was originally written assuming that the seg_mapping_table would always contain entries for ro
+    // segments whenever the ro segment falls into the [g_gc_lowest_address,g_gc_highest_address) range.  I.e., it had an
+    // extra "&& (size_t)(entry->seg1) & ro_in_entry" expression.  However, at the moment, grow_brick_card_table does
+    // not correctly go through the ro segments and add them back to the seg_mapping_table when the [lowest,highest)
+    // range changes.  We should probably go ahead and modify grow_brick_card_table and put back the
     // "&& (size_t)(entry->seg1) & ro_in_entry" here.
     if (!seg)
     {
@@ -4033,9 +4033,6 @@ public:
     void Validate(BOOL bDeep=TRUE, BOOL bVerifyNextHeader = TRUE)
     {
         UNREFERENCED_PARAMETER(bVerifyNextHeader);
-
-        if (this == NULL)
-            return;
 
         MethodTable * pMT = GetMethodTable();
 
@@ -4150,7 +4147,7 @@ public:
         size_t* numComponentsPtr = (size_t*) &((uint8_t*) this)[ArrayBase::GetOffsetOfNumComponents()];
         *numComponentsPtr = size - free_object_base_size;
 #ifdef VERIFY_HEAP
-        //This introduces a bug in the free list management. 
+        //This introduces a bug in the free list management.
         //((void**) this)[-1] = 0;    // clear the sync block,
         assert (*numComponentsPtr >= 0);
         if (GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC)
@@ -4211,7 +4208,7 @@ public:
 #define UNDO_EMPTY ((uint8_t*)1)
 
 #ifdef SHORT_PLUGS
-inline 
+inline
 void set_plug_padded (uint8_t* node)
 {
     header(node)->SetMarked();
@@ -4351,11 +4348,11 @@ typedef struct
     size_t current_block_normal;
     size_t current_block_large;
 
-    enum 
-    { 
-        ALLATONCE = 1, 
-        TWO_STAGE, 
-        EACH_BLOCK 
+    enum
+    {
+        ALLATONCE = 1,
+        TWO_STAGE,
+        EACH_BLOCK
     };
 
     size_t allocation_pattern;
@@ -4594,14 +4591,14 @@ void* virtual_alloc (size_t size, bool use_large_pages_p)
     }
 #endif // !FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 
-    void* prgmem = use_large_pages_p ? 
-        GCToOSInterface::VirtualReserveAndCommitLargePages(requested_size) : 
+    void* prgmem = use_large_pages_p ?
+        GCToOSInterface::VirtualReserveAndCommitLargePages(requested_size) :
         GCToOSInterface::VirtualReserve(requested_size, card_size * card_word_width, flags);
     void *aligned_mem = prgmem;
 
-    // We don't want (prgmem + size) to be right at the end of the address space 
+    // We don't want (prgmem + size) to be right at the end of the address space
     // because we'd have to worry about that everytime we do (address + size).
-    // We also want to make sure that we leave loh_size_threshold at the end 
+    // We also want to make sure that we leave loh_size_threshold at the end
     // so we allocate a small object we don't need to worry about overflow there
     // when we do alloc_ptr+size.
     if (prgmem)
@@ -4721,7 +4718,7 @@ gc_heap::compute_new_ephemeral_size()
     total_ephemeral_size += Align (DESIRED_PLUG_LENGTH);
 #endif //SHORT_PLUGS
 
-    dprintf (3, ("total ephemeral size is %Ix, padding %Ix(%Ix)", 
+    dprintf (3, ("total ephemeral size is %Ix, padding %Ix(%Ix)",
         total_ephemeral_size,
         padding_size, (total_ephemeral_size - padding_size)));
 }
@@ -4771,7 +4768,7 @@ gc_heap::soh_get_segment_to_expand()
 
             if (can_expand_into_p (seg, size/3, total_ephemeral_size, gen_alloc))
             {
-                get_gc_data_per_heap()->set_mechanism (gc_heap_expand, 
+                get_gc_data_per_heap()->set_mechanism (gc_heap_expand,
                     (use_bestfit ? expand_reuse_bestfit : expand_reuse_normal));
                 if (settings.condemned_generation == max_generation)
                 {
@@ -4782,7 +4779,7 @@ gc_heap::soh_get_segment_to_expand()
                     }
 
 #ifdef SEG_REUSE_STATS
-                    dprintf (SEG_REUSE_LOG_0, ("(gen%d)soh_get_segment_to_expand: found seg #%d to reuse", 
+                    dprintf (SEG_REUSE_LOG_0, ("(gen%d)soh_get_segment_to_expand: found seg #%d to reuse",
                         settings.condemned_generation, try_reuse));
 #endif //SEG_REUSE_STATS
                     dprintf (GTC_LOG, ("max_gen: Found existing segment to expand into %Ix", (size_t)seg));
@@ -4791,13 +4788,13 @@ gc_heap::soh_get_segment_to_expand()
                 else
                 {
 #ifdef SEG_REUSE_STATS
-                    dprintf (SEG_REUSE_LOG_0, ("(gen%d)soh_get_segment_to_expand: found seg #%d to reuse - returning", 
+                    dprintf (SEG_REUSE_LOG_0, ("(gen%d)soh_get_segment_to_expand: found seg #%d to reuse - returning",
                         settings.condemned_generation, try_reuse));
 #endif //SEG_REUSE_STATS
                     dprintf (GTC_LOG, ("max_gen-1: Found existing segment to expand into %Ix", (size_t)seg));
 
                     // If we return 0 here, the allocator will think since we are short on end
-                    // of seg we need to trigger a full compacting GC. So if sustained low latency 
+                    // of seg we need to trigger a full compacting GC. So if sustained low latency
                     // is set we should acquire a new seg instead, that way we wouldn't be short.
                     // The real solution, of course, is to actually implement seg reuse in gen1.
                     if (settings.pause_mode != pause_sustained_low_latency)
@@ -4818,7 +4815,7 @@ gc_heap::soh_get_segment_to_expand()
 #ifdef BACKGROUND_GC
         if (current_c_gc_state == c_gc_state_planning)
         {
-            // When we expand heap during bgc sweep, we set the seg to be swept so 
+            // When we expand heap during bgc sweep, we set the seg to be swept so
             // we'll always look at cards for objects on the new segment.
             result->flags |= heap_segment_flags_swept;
         }
@@ -4981,7 +4978,7 @@ gc_heap::get_segment (size_t size, BOOL loh_p)
 #ifdef BACKGROUND_GC
     if (result)
     {
-        ::record_changed_seg ((uint8_t*)result, heap_segment_reserved (result), 
+        ::record_changed_seg ((uint8_t*)result, heap_segment_reserved (result),
                             settings.gc_index, current_bgc_state,
                             seg_added);
         bgc_verify_mark_array_cleared (result);
@@ -5050,7 +5047,7 @@ gc_heap::get_large_segment (size_t size, BOOL* did_full_compact_gc)
     leave_spin_lock (&more_space_lock_loh);
     enter_spin_lock (&gc_heap::gc_lock);
     dprintf (SPINLOCK_LOG, ("[%d]Seg: Egc", heap_number));
-    // if a GC happened between here and before we ask for a segment in 
+    // if a GC happened between here and before we ask for a segment in
     // get_large_segment, we need to count that GC.
     size_t current_full_compact_gc_count = get_full_compact_gc_count();
 
@@ -5112,7 +5109,7 @@ BOOL gc_heap::unprotect_segment (heap_segment* seg)
 #else //_MSC_VER
 #error Unknown compiler
 #endif //_MSC_VER
-#elif defined(_TARGET_AMD64_) 
+#elif defined(_TARGET_AMD64_)
 #ifdef _MSC_VER
 extern "C" uint64_t __rdtsc();
 #pragma intrinsic(__rdtsc)
@@ -5142,7 +5139,7 @@ extern "C" uint64_t __rdtsc();
     }
 #endif //_TARGET_X86_
 
-// We may not be on contiguous numa nodes so need to store 
+// We may not be on contiguous numa nodes so need to store
 // the node index as well.
 struct node_heap_count
 {
@@ -5164,7 +5161,7 @@ public:
     static uint16_t proc_no_to_numa_node[MAX_SUPPORTED_CPUS];
     static uint16_t numa_node_to_heap_map[MAX_SUPPORTED_CPUS+4];
     // Note this is the total numa nodes GC heaps are on. There might be
-    // more on the machine if GC threads aren't using all of them. 
+    // more on the machine if GC threads aren't using all of them.
     static uint16_t total_numa_nodes;
     static node_heap_count heaps_on_node[MAX_SUPPORTED_NODES];
 
@@ -5202,7 +5199,7 @@ public:
         //can not enable gc numa aware, force all heaps to be in
         //one numa node by filling the array with all 0s
         if (!GCToOSInterface::CanEnableGCNumaAware())
-            memset(heap_no_to_numa_node, 0, sizeof (heap_no_to_numa_node)); 
+            memset(heap_no_to_numa_node, 0, sizeof (heap_no_to_numa_node));
 
         return TRUE;
     }
@@ -5314,7 +5311,7 @@ public:
         // Called right after GCHeap::Init() for each heap
         // For each NUMA node used by the heaps, the
         // numa_node_to_heap_map[numa_node] is set to the first heap number on that node and
-        // numa_node_to_heap_map[numa_node + 1] is set to the first heap number not on that node 
+        // numa_node_to_heap_map[numa_node + 1] is set to the first heap number not on that node
         // Set the start of the heap number range for the first NUMA node
         numa_node_to_heap_map[heap_no_to_numa_node[0]] = 0;
         total_numa_nodes = 0;
@@ -5342,17 +5339,17 @@ public:
         total_numa_nodes++;
     }
 
-    // TODO: curently this doesn't work with GCHeapAffinitizeMask/GCHeapAffinitizeRanges 
-    // because the heaps may not be on contiguous active procs. 
+    // TODO: curently this doesn't work with GCHeapAffinitizeMask/GCHeapAffinitizeRanges
+    // because the heaps may not be on contiguous active procs.
     //
-    // This is for scenarios where GCHeapCount is specified as something like 
+    // This is for scenarios where GCHeapCount is specified as something like
     // (g_num_active_processors - 2) to allow less randomization to the Server GC threads.
-    // In this case we want to assign the right heaps to those procs, ie if they share 
-    // the same numa node we want to assign local heaps to those procs. Otherwise we 
-    // let the heap balancing mechanism take over for now. 
+    // In this case we want to assign the right heaps to those procs, ie if they share
+    // the same numa node we want to assign local heaps to those procs. Otherwise we
+    // let the heap balancing mechanism take over for now.
     static void distribute_other_procs()
     {
-        if (affinity_config_specified_p) 
+        if (affinity_config_specified_p)
             return;
 
         uint16_t proc_no = 0;
@@ -5367,7 +5364,7 @@ public:
         {
             if (!GCToOSInterface::GetProcessorForHeap (i, &proc_no, &node_no))
                 break;
-            
+
             int start_heap = (int)numa_node_to_heap_map[node_no];
             int end_heap = (int)(numa_node_to_heap_map[node_no + 1]);
 
@@ -5376,7 +5373,7 @@ public:
                 if (node_no == current_node_no)
                 {
                     // We already iterated through all heaps on this node, don't add more procs to these
-                    // heaps. 
+                    // heaps.
                     if (current_heap_on_node >= end_heap)
                     {
                         continue;
@@ -5404,7 +5401,7 @@ public:
     }
 
     // This gets the next valid numa node index starting at current_index+1.
-    // It assumes that current_index is a valid node index. 
+    // It assumes that current_index is a valid node index.
     // If current_index+1 is at the end this will start at the beginning. So this will
     // always return a valid node index, along with that node's start/end heaps.
     static uint16_t get_next_numa_node (uint16_t current_index, int* start, int* end)
@@ -5452,22 +5449,22 @@ uint16_t  heap_select::total_numa_nodes;
 node_heap_count heap_select::heaps_on_node[MAX_SUPPORTED_NODES];
 
 #ifdef HEAP_BALANCE_INSTRUMENTATION
-// This records info we use to look at effect of different strategies 
+// This records info we use to look at effect of different strategies
 // for heap balancing.
 struct heap_balance_info
 {
     uint64_t timestamp;
-    // This also encodes when we detect the thread runs on 
-    // different proc during a balance attempt. Sometimes 
+    // This also encodes when we detect the thread runs on
+    // different proc during a balance attempt. Sometimes
     // I observe this happens multiple times during one attempt!
     // If this happens, I just record the last proc we observe
     // and set MSB.
     int tid;
     // This records the final alloc_heap for the thread.
-    // 
-    // This also encodes the reason why we needed to set_home_heap 
+    //
+    // This also encodes the reason why we needed to set_home_heap
     // in balance_heaps.
-    // If we set it because the home heap is not the same as the proc, 
+    // If we set it because the home heap is not the same as the proc,
     // we set MSB.
     //
     // If we set ideal proc, we set the 2nd MSB.
@@ -5477,7 +5474,7 @@ struct heap_balance_info
 
 // This means inbetween each GC we can log at most this many entries per proc.
 // This is usually enough. Most of the time we only need to log something every 128k
-// of allocations in balance_heaps and gen0 budget is <= 200mb. 
+// of allocations in balance_heaps and gen0 budget is <= 200mb.
 #define default_max_hb_heap_balance_info 4096
 
 struct heap_balance_info_proc
@@ -5498,7 +5495,7 @@ uint32_t procs_per_numa_node = 0;
 uint16_t total_numa_nodes_on_machine = 0;
 uint32_t procs_per_cpu_group = 0;
 uint16_t total_cpu_groups_on_machine = 0;
-// Note this is still on one of the numa nodes, so we'll incur a remote access 
+// Note this is still on one of the numa nodes, so we'll incur a remote access
 // no matter what.
 heap_balance_info_numa* hb_info_numa_nodes = NULL;
 
@@ -5526,7 +5523,7 @@ int get_proc_index_numa (int proc_no, int* numa_no)
     }
 }
 
-// We could consider optimizing it so we don't need to get the tid 
+// We could consider optimizing it so we don't need to get the tid
 // everytime but it's not very expensive to get.
 void add_to_hb_numa (
     int proc_no,
@@ -5561,7 +5558,7 @@ void add_to_hb_numa (
     heap_balance_info* hb_info = &(hb_info_proc->hb_info[index]);
 
     dprintf (HEAP_BALANCE_TEMP_LOG, ("TEMP[p%3d->%3d(i:%3d), N%d] #%4d: %I64d, tid %d, ah: %d, m: %d, p: %d, i: %d",
-        saved_proc_no, proc_no, ideal_proc_no, numa_no, index, 
+        saved_proc_no, proc_no, ideal_proc_no, numa_no, index,
         (timestamp - start_raw_ts), tid, alloc_heap, (int)multiple_procs_p, (int)(!alloc_count_p), (int)set_ideal_p));
 
     if (multiple_procs_p)
@@ -5716,7 +5713,7 @@ void gc_heap::hb_log_balance_activities()
 
 // The format for this is
 //
-// [GC_alloc_mb] 
+// [GC_alloc_mb]
 // h0_new_alloc, h1_new_alloc, ...
 //
 void gc_heap::hb_log_new_allocation()
@@ -6091,7 +6088,7 @@ public:
     uint8_t* first;
     size_t len;
 
-    // If we want to save space we can have a pool of plug_and_gap's instead of 
+    // If we want to save space we can have a pool of plug_and_gap's instead of
     // always having 2 allocated for each pinned plug.
     gap_reloc_pair saved_pre_plug;
     // If we decide to not compact, we need to restore the original values.
@@ -6099,18 +6096,18 @@ public:
 
     gap_reloc_pair saved_post_plug;
 
-    // Supposedly Pinned objects cannot have references but we are seeing some from pinvoke 
-    // frames. Also if it's an artificially pinned plug created by us, it can certainly 
-    // have references. 
-    // We know these cases will be rare so we can optimize this to be only allocated on demand. 
+    // Supposedly Pinned objects cannot have references but we are seeing some from pinvoke
+    // frames. Also if it's an artificially pinned plug created by us, it can certainly
+    // have references.
+    // We know these cases will be rare so we can optimize this to be only allocated on demand.
     gap_reloc_pair saved_post_plug_reloc;
 
     // We need to calculate this after we are done with plan phase and before compact
-    // phase because compact phase will change the bricks so relocate_address will no 
+    // phase because compact phase will change the bricks so relocate_address will no
     // longer work.
     uint8_t* saved_pre_plug_info_reloc_start;
 
-    // We need to save this because we will have no way to calculate it, unlike the 
+    // We need to save this because we will have no way to calculate it, unlike the
     // pre plug info start which is right before this plug.
     uint8_t* saved_post_plug_info_start;
 
@@ -6226,8 +6223,8 @@ public:
     // copy over the whole plug and their related info (mark bits/cards). But we will
     // need to set the artificial gap back so compact phase can keep reading the plug info.
     // We also need to recover the saved info because we'll need to recover it later.
-    // 
-    // So we would call swap_p*_plug_and_saved once to recover the object info; then call 
+    //
+    // So we would call swap_p*_plug_and_saved once to recover the object info; then call
     // it again to recover the artificial gap.
     void swap_pre_plug_and_saved()
     {
@@ -6264,23 +6261,23 @@ public:
     // We should think about whether it's really necessary to have to copy back the pre plug
     // info since it was already copied during compacting plugs. But if a plug doesn't move
     // by >= 3 ptr size (the size of gap_reloc_pair), it means we'd have to recover pre plug info.
-    void recover_plug_info() 
+    void recover_plug_info()
     {
         if (saved_pre_p)
         {
             if (gc_heap::settings.compaction)
             {
-                dprintf (3, ("%Ix: REC Pre: %Ix-%Ix", 
+                dprintf (3, ("%Ix: REC Pre: %Ix-%Ix",
                     first,
-                    &saved_pre_plug_reloc, 
+                    &saved_pre_plug_reloc,
                     saved_pre_plug_info_reloc_start));
                 memcpy (saved_pre_plug_info_reloc_start, &saved_pre_plug_reloc, sizeof (saved_pre_plug_reloc));
             }
             else
             {
-                dprintf (3, ("%Ix: REC Pre: %Ix-%Ix", 
+                dprintf (3, ("%Ix: REC Pre: %Ix-%Ix",
                     first,
-                    &saved_pre_plug, 
+                    &saved_pre_plug,
                     (first - sizeof (plug_and_gap))));
                 memcpy ((first - sizeof (plug_and_gap)), &saved_pre_plug, sizeof (saved_pre_plug));
             }
@@ -6290,17 +6287,17 @@ public:
         {
             if (gc_heap::settings.compaction)
             {
-                dprintf (3, ("%Ix: REC Post: %Ix-%Ix", 
+                dprintf (3, ("%Ix: REC Post: %Ix-%Ix",
                     first,
-                    &saved_post_plug_reloc, 
+                    &saved_post_plug_reloc,
                     saved_post_plug_info_start));
                 memcpy (saved_post_plug_info_start, &saved_post_plug_reloc, sizeof (saved_post_plug_reloc));
             }
             else
             {
-                dprintf (3, ("%Ix: REC Post: %Ix-%Ix", 
+                dprintf (3, ("%Ix: REC Post: %Ix-%Ix",
                     first,
-                    &saved_post_plug, 
+                    &saved_post_plug,
                     saved_post_plug_info_start));
                 memcpy (saved_post_plug_info_start, &saved_post_plug, sizeof (saved_post_plug));
             }
@@ -6380,13 +6377,13 @@ void gc_mechanisms::record (gc_history_global* history)
     // start setting the boolean values.
     if (concurrent)
         history->set_mechanism_p (global_concurrent);
-    
+
     if (compaction)
         history->set_mechanism_p (global_compaction);
 
     if (promotion)
         history->set_mechanism_p (global_promotion);
-    
+
     if (demotion)
         history->set_mechanism_p (global_demotion);
 
@@ -6422,11 +6419,11 @@ void gc_heap::fix_large_allocation_area (BOOL for_gc_p)
     UNREFERENCED_PARAMETER(for_gc_p);
 
 #ifdef _DEBUG
-    alloc_context* acontext = 
+    alloc_context* acontext =
 #endif // _DEBUG
         generation_alloc_context (large_object_generation);
     assert (acontext->alloc_ptr == 0);
-    assert (acontext->alloc_limit == 0); 
+    assert (acontext->alloc_limit == 0);
 #if 0
     dprintf (3, ("Large object alloc context: ptr: %Ix, limit %Ix",
                  (size_t)acontext->alloc_ptr, (size_t)acontext->alloc_limit));
@@ -6482,8 +6479,8 @@ void gc_heap::fix_allocation_context (alloc_context* acontext, BOOL for_gc_p,
 
     if (for_gc_p)
     {
-        // We need to update the alloc_bytes to reflect the portion that we have not used  
-        acontext->alloc_bytes -= (acontext->alloc_limit - acontext->alloc_ptr);  
+        // We need to update the alloc_bytes to reflect the portion that we have not used
+        acontext->alloc_bytes -= (acontext->alloc_limit - acontext->alloc_ptr);
         total_alloc_bytes_soh -= (acontext->alloc_limit - acontext->alloc_ptr);
 
         acontext->alloc_ptr = 0;
@@ -6765,7 +6762,7 @@ uint8_t* get_plug_start_in_saved (uint8_t* old_loc, mark* pinned_plug_entry)
 {
     uint8_t* saved_pre_plug_info = (uint8_t*)(pinned_plug_entry->get_pre_plug_reloc_info());
     uint8_t* plug_start_in_saved = saved_pre_plug_info + (old_loc - (pinned_plug (pinned_plug_entry) - sizeof (plug_and_gap)));
-    //dprintf (1, ("detected a very short plug: %Ix before PP %Ix, pad %Ix", 
+    //dprintf (1, ("detected a very short plug: %Ix before PP %Ix, pad %Ix",
     //    old_loc, pinned_plug (pinned_plug_entry), plug_start_in_saved));
     dprintf (1, ("EP: %Ix(%Ix), %Ix", old_loc, pinned_plug (pinned_plug_entry), plug_start_in_saved));
     return plug_start_in_saved;
@@ -6860,7 +6857,7 @@ void gc_heap::set_allocator_next_pin (generation* gen)
             (plug <  generation_allocation_limit (gen)))
         {
             generation_allocation_limit (gen) = pinned_plug (oldest_entry);
-            dprintf (3, ("SANP: get next pin free space in gen%d for alloc: %Ix->%Ix(%Id)", 
+            dprintf (3, ("SANP: get next pin free space in gen%d for alloc: %Ix->%Ix(%Id)",
                 gen->gen_num,
                 generation_allocation_pointer (gen), generation_allocation_limit (gen),
                 (generation_allocation_limit (gen) - generation_allocation_pointer (gen))));
@@ -7463,7 +7460,7 @@ void gc_heap::mark_array_set_marked (uint8_t* add)
     Interlocked::Or (&(mark_array [index]), val);
 #else
     mark_array [index] |= val;
-#endif 
+#endif
 }
 
 inline
@@ -7487,7 +7484,7 @@ uint32_t* translate_mark_array (uint32_t* ma)
     return (uint32_t*)((uint8_t*)ma - size_mark_array_of (0, g_gc_lowest_address));
 }
 
-// from and end must be page aligned addresses. 
+// from and end must be page aligned addresses.
 void gc_heap::clear_mark_array (uint8_t* from, uint8_t* end, BOOL check_only/*=TRUE*/
 #ifdef FEATURE_BASICFREEZE
                                 , BOOL read_only/*=FALSE*/
@@ -7655,7 +7652,7 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
     size_t bs = size_brick_of (start, end);
     size_t cs = size_card_of (start, end);
 #ifdef MARK_ARRAY
-    size_t ms = (gc_can_use_concurrent ? 
+    size_t ms = (gc_can_use_concurrent ?
                  size_mark_array_of (start, end) :
                  0);
 #else
@@ -7697,7 +7694,7 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
     size_t st = 0;
 #endif //GROWABLE_SEG_MAPPING_TABLE
 
-    // it is impossible for alloc_size to overflow due bounds on each of 
+    // it is impossible for alloc_size to overflow due bounds on each of
     // its components.
     size_t alloc_size = sizeof (uint8_t)*(sizeof(card_table_info) + cs + bs + cb + wws + st + ms);
     uint8_t* mem = (uint8_t*)GCToOSInterface::VirtualReserve (alloc_size, 0, virtual_reserve_flags);
@@ -7717,7 +7714,7 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
         GCToOSInterface::VirtualRelease (mem, alloc_size);
         return 0;
     }
-    
+
     // initialize the ref count
     uint32_t* ct = (uint32_t*)(mem+sizeof (card_table_info));
     card_table_refcount (ct) = 0;
@@ -7745,7 +7742,7 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
 
 #ifdef GROWABLE_SEG_MAPPING_TABLE
     seg_mapping_table = (seg_mapping*)(mem + st_table_offset_aligned);
-    seg_mapping_table = (seg_mapping*)((uint8_t*)seg_mapping_table - 
+    seg_mapping_table = (seg_mapping*)((uint8_t*)seg_mapping_table -
                                         size_seg_mapping_table_of (0, (align_lower_segment (g_gc_lowest_address))));
 #endif //GROWABLE_SEG_MAPPING_TABLE
 
@@ -7774,15 +7771,15 @@ void gc_heap::set_fgm_result (failure_get_memory f, size_t s, BOOL loh_p)
 
 //returns 0 for success, -1 otherwise
 // We are doing all the decommitting here because we want to make sure we have
-// enough memory to do so - if we do this during copy_brick_card_table and 
-// and fail to decommit it would make the failure case very complicated to 
-// handle. This way we can waste some decommit if we call this multiple 
+// enough memory to do so - if we do this during copy_brick_card_table and
+// and fail to decommit it would make the failure case very complicated to
+// handle. This way we can waste some decommit if we call this multiple
 // times before the next FGC but it's easier to handle the failure case.
 int gc_heap::grow_brick_card_tables (uint8_t* start,
                                      uint8_t* end,
                                      size_t size,
-                                     heap_segment* new_seg, 
-                                     gc_heap* hp, 
+                                     heap_segment* new_seg,
+                                     gc_heap* hp,
                                      BOOL loh_p)
 {
     uint8_t* la = g_gc_lowest_address;
@@ -7791,7 +7788,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
     uint8_t* saved_g_highest_address = max (end, g_gc_highest_address);
     seg_mapping* new_seg_mapping_table = nullptr;
 #ifdef BACKGROUND_GC
-    // This value is only for logging purpose - it's not necessarily exactly what we 
+    // This value is only for logging purpose - it's not necessarily exactly what we
     // would commit for mark array but close enough for diagnostics purpose.
     size_t logging_ma_commit_size = size_mark_array_of (0, (uint8_t*)size);
 #endif //BACKGROUND_GC
@@ -7857,7 +7854,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
         size_t bs = size_brick_of (saved_g_lowest_address, saved_g_highest_address);
 
 #ifdef MARK_ARRAY
-        size_t ms = (gc_heap::gc_can_use_concurrent ? 
+        size_t ms = (gc_heap::gc_can_use_concurrent ?
                     size_mark_array_of (saved_g_lowest_address, saved_g_highest_address) :
                     0);
 #else
@@ -7902,7 +7899,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
         size_t st = 0;
 #endif //GROWABLE_SEG_MAPPING_TABLE
 
-        // it is impossible for alloc_size to overflow due bounds on each of 
+        // it is impossible for alloc_size to overflow due bounds on each of
         // its components.
         size_t alloc_size = sizeof (uint8_t)*(sizeof(card_table_info) + cs + bs + cb + wws + st + ms);
         dprintf (GC_TABLE_LOG, ("card table: %Id; brick table: %Id; card bundle: %Id; sw ww table: %Id; seg table: %Id; mark array: %Id",
@@ -7919,7 +7916,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
         dprintf (GC_TABLE_LOG, ("Table alloc for %Id bytes: [%Ix, %Ix[",
                                  alloc_size, (size_t)mem, (size_t)((uint8_t*)mem+alloc_size)));
 
-        {   
+        {
             // mark array will be committed separately (per segment).
             size_t commit_size = alloc_size - ms;
 
@@ -7983,13 +7980,13 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
 
         translated_ct = translate_card_table (ct);
 
-        dprintf (GC_TABLE_LOG, ("card table: %Ix(translated: %Ix), seg map: %Ix, mark array: %Ix", 
+        dprintf (GC_TABLE_LOG, ("card table: %Ix(translated: %Ix), seg map: %Ix, mark array: %Ix",
             (size_t)ct, (size_t)translated_ct, (size_t)new_seg_mapping_table, (size_t)card_table_mark_array (ct)));
 
 #ifdef BACKGROUND_GC
         if (hp->should_commit_mark_array())
         {
-            dprintf (GC_TABLE_LOG, ("new low: %Ix, new high: %Ix, latest mark array is %Ix(translate: %Ix)", 
+            dprintf (GC_TABLE_LOG, ("new low: %Ix, new high: %Ix, latest mark array is %Ix(translate: %Ix)",
                                     saved_g_lowest_address, saved_g_highest_address,
                                     card_table_mark_array (ct),
                                     translate_mark_array (card_table_mark_array (ct))));
@@ -8092,7 +8089,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
         }
 
         return 0;
-        
+
 fail:
         //cleanup mess and return -1;
 
@@ -8166,7 +8163,7 @@ void gc_heap::copy_brick_card_range (uint8_t* la, uint32_t* old_card_table,
     {
         uint32_t* old_mark_array = card_table_mark_array (old_ct);
 
-        // We don't need to go through all the card tables here because 
+        // We don't need to go through all the card tables here because
         // we only need to copy from the GC version of the mark array - when we
         // mark (even in allocate_large_object) we always use that mark array.
         if ((card_table_highest_address (old_ct) >= start) &&
@@ -8596,10 +8593,10 @@ void rqsort1( uint8_t* *low, uint8_t* *high)
 }
 
 #ifdef USE_INTROSORT
-class introsort 
+class introsort
 {
 
-private: 
+private:
     static const int size_threshold = 64;
     static const int max_depth = 100;
 
@@ -8607,7 +8604,7 @@ private:
 inline static void swap_elements(uint8_t** i,uint8_t** j)
     {
         uint8_t* t=*i;
-        *i=*j; 
+        *i=*j;
         *j=t;
     }
 
@@ -8619,7 +8616,7 @@ public:
         insertionsort (begin, end);
     }
 
-private: 
+private:
 
     static void introsort_loop (uint8_t** lo, uint8_t** hi, int depth_limit)
     {
@@ -8634,7 +8631,7 @@ private:
             depth_limit=depth_limit-1;
             introsort_loop (p, hi, depth_limit);
             hi=p-1;
-        }        
+        }
     }
 
     static uint8_t** median_partition (uint8_t** low, uint8_t** high)
@@ -8683,7 +8680,7 @@ private:
     }
 
     static void heapsort (uint8_t** lo, uint8_t** hi)
-    { 
+    {
         size_t n = hi - lo + 1;
         for (size_t i=n / 2; i >= 1; i--)
         {
@@ -8707,7 +8704,7 @@ private:
             {
                 child++;
             }
-            if (!(d<*(lo + child - 1))) 
+            if (!(d<*(lo + child - 1)))
             {
                 break;
             }
@@ -8719,7 +8716,7 @@ private:
 
 };
 
-#endif //USE_INTROSORT    
+#endif //USE_INTROSORT
 
 #ifdef MULTIPLE_HEAPS
 #ifdef PARALLEL_MARK_LIST_SORT
@@ -9201,7 +9198,7 @@ public:
 
     BOOL alloc ()
     {
-        size_t total_prealloc_size = 
+        size_t total_prealloc_size =
             MAX_NUM_BUCKETS * sizeof (free_space_bucket) +
             MAX_NUM_FREE_SPACES * sizeof (seg_free_space);
 
@@ -9250,15 +9247,15 @@ public:
     // If we are adding a free space before a plug we pass the
     // mark stack position so we can update the length; we could
     // also be adding the free space after the last plug in which
-    // case start is the segment which we'll need to update the 
+    // case start is the segment which we'll need to update the
     // heap_segment_plan_allocated.
     void add (void* start, BOOL plug_p, BOOL first_p)
     {
-        size_t size = (plug_p ? 
-                       pinned_len ((mark*)start) : 
-                       (heap_segment_committed ((heap_segment*)start) - 
+        size_t size = (plug_p ?
+                       pinned_len ((mark*)start) :
+                       (heap_segment_committed ((heap_segment*)start) -
                            heap_segment_plan_allocated ((heap_segment*)start)));
-        
+
         if (plug_p)
         {
             dprintf (SEG_REUSE_LOG_1, ("[%d]Adding a free space before plug: %Id", heap_num, size));
@@ -9270,7 +9267,7 @@ public:
             has_end_of_seg = TRUE;
 #endif //_DEBUG
         }
-                  
+
         if (first_p)
         {
             size_t eph_gen_starts = gc_heap::eph_gen_starts_size;
@@ -9306,10 +9303,10 @@ public:
 
         ptrdiff_t index = bucket->count_add - 1;
 
-        dprintf (SEG_REUSE_LOG_1, ("[%d]Building free spaces: adding %Ix; len: %Id (2^%d)", 
-                    heap_num, 
-                    (plug_p ? 
-                        (pinned_plug ((mark*)start) - pinned_len ((mark*)start)) : 
+        dprintf (SEG_REUSE_LOG_1, ("[%d]Building free spaces: adding %Ix; len: %Id (2^%d)",
+                    heap_num,
+                    (plug_p ?
+                        (pinned_plug ((mark*)start) - pinned_len ((mark*)start)) :
                         heap_segment_plan_allocated ((heap_segment*)start)),
                     size,
                     bucket_power2));
@@ -9339,7 +9336,7 @@ public:
                 end_of_seg_count++;
             }
         }
-        
+
         if (has_end_of_seg)
         {
             assert (end_of_seg_count == 1);
@@ -9375,13 +9372,13 @@ public:
         // BARTOKTODO (4841): this code path is disabled (see can_fit_all_blocks_p) until we take alignment requirements into account
         _ASSERTE(requiredAlignment == DATA_ALIGNMENT && false);
 #endif // FEATURE_STRUCTALIGN
-        // TODO: this is also not large alignment ready. We would need to consider alignment when choosing the 
+        // TODO: this is also not large alignment ready. We would need to consider alignment when choosing the
         // the bucket.
 
         size_t plug_size_to_fit = plug_size;
 
         // best fit is only done for gen1 to gen2 and we do not pad in gen2.
-        // however we must account for requirements of large alignment. 
+        // however we must account for requirements of large alignment.
         // which may result in realignment padding.
 #ifdef RESPECT_LARGE_ALIGNMENT
         plug_size_to_fit += switch_alignment_size(FALSE);
@@ -9407,14 +9404,14 @@ retry:
             chosen_power2++;
         }
 
-        dprintf (SEG_REUSE_LOG_1, ("[%d]Fitting plug len %Id (2^%d) using 2^%d free space", 
-            heap_num, 
-            plug_size, 
-            plug_power2, 
+        dprintf (SEG_REUSE_LOG_1, ("[%d]Fitting plug len %Id (2^%d) using 2^%d free space",
+            heap_num,
+            plug_size,
+            plug_power2,
             (chosen_power2 + base_power2)));
 
         assert (i < free_space_bucket_count);
-        
+
         seg_free_space* bucket_free_space = free_space_buckets[chosen_power2].free_space;
         ptrdiff_t free_space_count = free_space_buckets[chosen_power2].count_fit;
         size_t new_free_space_size = 0;
@@ -9451,14 +9448,14 @@ retry:
                     pinned_len (m) = new_free_space_size;
 #ifdef SIMPLE_DPRINTF
                     dprintf (SEG_REUSE_LOG_0, ("[%d]FP: 0x%Ix->0x%Ix(%Ix)(%Ix), [0x%Ix (2^%d) -> [0x%Ix (2^%d)",
-                                heap_num, 
+                                heap_num,
                                 old_loc,
-                                new_address, 
+                                new_address,
                                 (plug_size - pad),
                                 pad,
-                                pinned_plug (m), 
+                                pinned_plug (m),
                                 index_of_highest_set_bit (free_space_size),
-                                (pinned_plug (m) - pinned_len (m)), 
+                                (pinned_plug (m) - pinned_len (m)),
                                 index_of_highest_set_bit (new_free_space_size)));
 #endif //SIMPLE_DPRINTF
 
@@ -9491,12 +9488,12 @@ retry:
                     heap_segment_plan_allocated (seg) = new_address + plug_size;
 #ifdef SIMPLE_DPRINTF
                     dprintf (SEG_REUSE_LOG_0, ("[%d]FS: 0x%Ix-> 0x%Ix(%Ix) (2^%d) -> 0x%Ix (2^%d)",
-                                heap_num, 
+                                heap_num,
                                 old_loc,
-                                new_address, 
+                                new_address,
                                 (plug_size - pad),
                                 index_of_highest_set_bit (free_space_size),
-                                heap_segment_plan_allocated (seg), 
+                                heap_segment_plan_allocated (seg),
                                 index_of_highest_set_bit (new_free_space_size)));
 #endif //SIMPLE_DPRINTF
 
@@ -9617,8 +9614,8 @@ void gc_heap::clear_batch_mark_array_bits (uint8_t* start, uint8_t* end)
         size_t startwrd = mark_bit_word (start_mark_bit);
         size_t endwrd = mark_bit_word (end_mark_bit);
 
-        dprintf (3, ("Clearing all mark array bits between [%Ix:%Ix-[%Ix:%Ix", 
-            (size_t)start, (size_t)start_mark_bit, 
+        dprintf (3, ("Clearing all mark array bits between [%Ix:%Ix-[%Ix:%Ix",
+            (size_t)start, (size_t)start_mark_bit,
             (size_t)end, (size_t)end_mark_bit));
 
         unsigned int firstwrd = lowbits (~0, startbit);
@@ -9665,7 +9662,7 @@ void gc_heap::bgc_clear_batch_mark_array_bits (uint8_t* start, uint8_t* end)
 
 void gc_heap::clear_mark_array_by_objects (uint8_t* from, uint8_t* end, BOOL loh_p)
 {
-    dprintf (3, ("clearing mark array bits by objects for addr [%Ix,[%Ix", 
+    dprintf (3, ("clearing mark array bits by objects for addr [%Ix,[%Ix",
                   from, end));
     int align_const = get_alignment_constant (!loh_p);
 
@@ -9692,7 +9689,7 @@ BOOL gc_heap::is_mark_set (uint8_t* o)
 }
 
 #if defined (_MSC_VER) && defined (_TARGET_X86_)
-#pragma optimize("y", on)        // Small critical routines, don't put in EBP frame 
+#pragma optimize("y", on)        // Small critical routines, don't put in EBP frame
 #endif //_MSC_VER && _TARGET_X86_
 
 // return the generation number of an object.
@@ -9811,12 +9808,12 @@ void gc_heap::delete_heap_segment (heap_segment* seg, BOOL consider_hoarding)
 
     if (seg != 0)
     {
-        dprintf (2, ("h%d: del seg: [%Ix, %Ix[", 
+        dprintf (2, ("h%d: del seg: [%Ix, %Ix[",
                      heap_number, (size_t)seg,
                      (size_t)(heap_segment_reserved (seg))));
 
 #ifdef BACKGROUND_GC
-        ::record_changed_seg ((uint8_t*)seg, heap_segment_reserved (seg), 
+        ::record_changed_seg ((uint8_t*)seg, heap_segment_reserved (seg),
                             settings.gc_index, current_bgc_state,
                             seg_deleted);
         decommit_mark_array_by_seg (seg);
@@ -9961,7 +9958,7 @@ void gc_heap::rearrange_heap_segments(BOOL compacting)
         else
         {
             uint8_t* end_segment = (compacting ?
-                                 heap_segment_plan_allocated (seg) : 
+                                 heap_segment_plan_allocated (seg) :
                                  heap_segment_allocated (seg));
             // check if the segment was reached by allocation
             if ((end_segment == heap_segment_mem (seg))&&
@@ -10049,7 +10046,7 @@ inline void gc_heap::verify_card_bundles()
                 if (*card_word != 0)
                 {
                     dprintf  (3, ("gc: %d, Card word %Ix for address %Ix set, card_bundle %Ix clear",
-                            dd_collection_count (dynamic_data_of (0)), 
+                            dd_collection_count (dynamic_data_of (0)),
                             (size_t)(card_word-&card_table[0]),
                             (size_t)(card_address ((size_t)(card_word-&card_table[0]) * card_word_width)), cardb));
                 }
@@ -10064,7 +10061,7 @@ inline void gc_heap::verify_card_bundles()
 #endif
 }
 
-// If card bundles are enabled, use write watch to find pages in the card table that have 
+// If card bundles are enabled, use write watch to find pages in the card table that have
 // been dirtied, and set the corresponding card bundle bits.
 void gc_heap::update_card_table_bundle()
 {
@@ -10075,7 +10072,7 @@ void gc_heap::update_card_table_bundle()
 
         // The address of the card word containing the card representing the highest heap address
         uint8_t* high_address = (uint8_t*)(&card_table[card_word (card_of (highest_address))]);
-        
+
         uint8_t* saved_base_address = base_address;
         uintptr_t bcount = array_size;
         size_t saved_region_size = align_on_page (high_address) - saved_base_address;
@@ -10117,7 +10114,7 @@ void gc_heap::update_card_table_bundle()
 
         } while ((bcount >= array_size) && (base_address < high_address));
 
-        // Now that we've updated the card bundle bits, reset the write-tracking state. 
+        // Now that we've updated the card bundle bits, reset the write-tracking state.
         GCToOSInterface::ResetWriteWatch (saved_base_address, saved_region_size);
     }
 }
@@ -10177,7 +10174,7 @@ void gc_heap::reset_ww_by_chunk (uint8_t* start_address, size_t total_reset_size
     assert (reset_size == total_reset_size);
 }
 
-// This does a Sleep(1) for every reset ww_reset_quantum bytes of reset 
+// This does a Sleep(1) for every reset ww_reset_quantum bytes of reset
 // we do concurrently.
 void gc_heap::switch_on_reset (BOOL concurrent_p, size_t* current_total_reset_size, size_t last_reset_size)
 {
@@ -10220,7 +10217,7 @@ void gc_heap::reset_write_watch (BOOL concurrent_p)
         uint8_t* high_address = 0;
         high_address = ((seg == ephemeral_heap_segment) ? alloc_allocated : heap_segment_allocated (seg));
         high_address = min (high_address, background_saved_highest_address);
-        
+
         if (base_address < high_address)
         {
             region_size = high_address - base_address;
@@ -10264,7 +10261,7 @@ void gc_heap::reset_write_watch (BOOL concurrent_p)
         if (base_address < high_address)
         {
             region_size = high_address - base_address;
-            
+
 #ifdef TIME_WRITE_WATCH
             unsigned int time_start = GetCycleCount32();
 #endif //TIME_WRITE_WATCH
@@ -10278,7 +10275,7 @@ void gc_heap::reset_write_watch (BOOL concurrent_p)
             printf ("ResetWriteWatch Duration: %d, total: %d\n",
                     time_stop - time_start, tot_cycles);
 #endif //TIME_WRITE_WATCH
-    
+
             switch_on_reset (concurrent_p, &reset_size, region_size);
         }
 
@@ -10343,11 +10340,11 @@ void gc_heap::make_generation (generation& gen, heap_segment* seg, uint8_t* star
     gen.allocation_segment = seg;
     gen.plan_allocation_start = 0;
     gen.free_list_space = 0;
-    gen.pinned_allocated = 0; 
-    gen.free_list_allocated = 0; 
+    gen.pinned_allocated = 0;
+    gen.free_list_allocated = 0;
     gen.end_seg_allocated = 0;
-    gen.condemned_allocated = 0; 
-    gen.sweep_allocated = 0; 
+    gen.condemned_allocated = 0;
+    gen.sweep_allocated = 0;
     gen.free_obj_space = 0;
     gen.allocation_size = 0;
     gen.pinned_allocation_sweep_size = 0;
@@ -10421,10 +10418,10 @@ size_t gc_heap::get_segment_size_hard_limit (uint32_t* num_heaps, bool should_ad
         aligned_seg_size = max (aligned_seg_size, aligned_seg_size_config);
     }
 
-    //printf ("limit: %Idmb, aligned: %Idmb, %d heaps, seg size from config: %Idmb, seg size %Idmb", 
+    //printf ("limit: %Idmb, aligned: %Idmb, %d heaps, seg size from config: %Idmb, seg size %Idmb",
     //    (heap_hard_limit / 1024 / 1024),
     //    (aligned_hard_limit / 1024 / 1024),
-    //    *num_heaps, 
+    //    *num_heaps,
     //    (seg_size_from_config / 1024 / 1024),
     //    (aligned_seg_size / 1024 / 1024));
     return aligned_seg_size;
@@ -10485,7 +10482,7 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
 
         compact_ratio = static_cast<int>(GCConfig::GetCompactRatio());
 
-        //         h#  | GC  | gen | C   | EX   | NF  | BF  | ML  | DM  || PreS | PostS | Merge | Conv | Pre | Post | PrPo | PreP | PostP | 
+        //         h#  | GC  | gen | C   | EX   | NF  | BF  | ML  | DM  || PreS | PostS | Merge | Conv | Pre | Post | PrPo | PreP | PostP |
         cprintf (("%2s | %6s | %1s | %1s | %2s | %2s | %2s | %2s | %2s || %5s | %5s | %5s | %5s | %5s | %5s | %5s | %5s | %5s |",
                 "h#", // heap index
                 "GC", // GC index
@@ -10543,7 +10540,7 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
 
 #ifdef BACKGROUND_GC
     // leave the first page to contain only segment info
-    // because otherwise we could need to revisit the first page frequently in 
+    // because otherwise we could need to revisit the first page frequently in
     // background GC.
     segment_info_size = OS_PAGE_SIZE;
 #else
@@ -10610,7 +10607,7 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
     if (!g_heaps)
         return E_OUTOFMEMORY;
 
-#ifdef _PREFAST_ 
+#ifdef _PREFAST_
 #pragma warning(push)
 #pragma warning(disable:22011) // Suppress PREFast warning about integer underflow/overflow
 #endif // _PREFAST_
@@ -10619,7 +10616,7 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
 #ifdef MH_SC_MARK
     g_mark_stack_busy = new (nothrow) int[(number_of_heaps+2)*HS_CACHE_LINE_SIZE/sizeof(int)];
 #endif //MH_SC_MARK
-#ifdef _PREFAST_ 
+#ifdef _PREFAST_
 #pragma warning(pop)
 #endif // _PREFAST_
     if (!g_promoted || !g_bpromoted)
@@ -10673,7 +10670,7 @@ gc_heap::init_semi_shared()
 
     // This is used for heap expansion - it's to fix exactly the start for gen 0
     // through (max_generation-1). When we expand the heap we allocate all these
-    // gen starts at the beginning of the new ephemeral seg. 
+    // gen starts at the beginning of the new ephemeral seg.
     eph_gen_starts_size = (Align (min_obj_size)) * max_generation;
 
 #ifdef MARK_LIST
@@ -10829,7 +10826,7 @@ gc_heap::init_semi_shared()
     bgc_alloc_spin_count = static_cast<uint32_t>(GCConfig::GetBGCSpinCount());
     bgc_alloc_spin = static_cast<uint32_t>(GCConfig::GetBGCSpin());
 
-    {   
+    {
         int number_bgc_threads = 1;
 #ifdef MULTIPLE_HEAPS
         number_bgc_threads = n_heaps;
@@ -10894,12 +10891,12 @@ gc_heap* gc_heap::make_gc_heap (
     if (!res->mark_list_piece_start)
         return 0;
 
-#ifdef _PREFAST_ 
+#ifdef _PREFAST_
 #pragma warning(push)
 #pragma warning(disable:22011) // Suppress PREFast warning about integer underflow/overflow
 #endif // _PREFAST_
     res->mark_list_piece_end = new (nothrow) uint8_t**[n_heaps + 32]; // +32 is padding to reduce false sharing
-#ifdef _PREFAST_ 
+#ifdef _PREFAST_
 #pragma warning(pop)
 #endif // _PREFAST_
 
@@ -10938,7 +10935,7 @@ gc_heap::wait_for_gc_done(int32_t timeOut)
 
     gc_heap* wait_heap = NULL;
     while (gc_heap::gc_started)
-    {       
+    {
 #ifdef MULTIPLE_HEAPS
         wait_heap = GCHeap::GetHeap(heap_select::select_heap(NULL))->pGenGCHeap;
         dprintf(2, ("waiting for the gc_done_event on heap %d", wait_heap->heap_number));
@@ -10948,14 +10945,14 @@ gc_heap::wait_for_gc_done(int32_t timeOut)
         PREFIX_ASSUME(wait_heap != NULL);
 #endif // _PREFAST_
 
-        dwWaitResult = wait_heap->gc_done_event.Wait(timeOut, FALSE); 
+        dwWaitResult = wait_heap->gc_done_event.Wait(timeOut, FALSE);
     }
     disable_preemptive (cooperative_mode);
 
     return dwWaitResult;
 }
 
-void 
+void
 gc_heap::set_gc_done()
 {
     enter_gc_done_event_lock();
@@ -10968,7 +10965,7 @@ gc_heap::set_gc_done()
     exit_gc_done_event_lock();
 }
 
-void 
+void
 gc_heap::reset_gc_done()
 {
     enter_gc_done_event_lock();
@@ -10981,7 +10978,7 @@ gc_heap::reset_gc_done()
     exit_gc_done_event_lock();
 }
 
-void 
+void
 gc_heap::enter_gc_done_event_lock()
 {
     uint32_t dwSwitchCount = 0;
@@ -11010,7 +11007,7 @@ retry:
     }
 }
 
-void 
+void
 gc_heap::exit_gc_done_event_lock()
 {
     gc_done_event_lock = -1;
@@ -11030,8 +11027,8 @@ GCEvent gc_heap::gc_done_event;
 VOLATILE(bool) gc_heap::internal_gc_done;
 
 void gc_heap::add_saved_spinlock_info (
-            bool loh_p, 
-            msl_enter_state enter_state, 
+            bool loh_p,
+            msl_enter_state enter_state,
             msl_take_state take_state)
 
 {
@@ -11042,8 +11039,8 @@ void gc_heap::add_saved_spinlock_info (
     current->take_state = take_state;
     current->thread_id.SetToCurrentThread();
     current->loh_p = loh_p;
-    dprintf (SPINLOCK_LOG, ("[%d]%s %s %s", 
-        heap_number, 
+    dprintf (SPINLOCK_LOG, ("[%d]%s %s %s",
+        heap_number,
         (loh_p ? "loh" : "soh"),
         ((enter_state == me_acquire) ? "E" : "L"),
         msl_take_state_str[take_state]));
@@ -11175,7 +11172,7 @@ gc_heap::init_gc_heap (int  h_number)
     FIRE_EVENT(GCCreateSegment_V1, heap_segment_mem(seg),
                               (size_t)(heap_segment_reserved (seg) - heap_segment_mem(seg)),
                               gc_etw_segment_small_object_heap);
-    
+
 #ifdef SEG_MAPPING_TABLE
     seg_mapping_table_add_segment (seg, __this);
 #else //SEG_MAPPING_TABLE
@@ -11248,7 +11245,7 @@ gc_heap::init_gc_heap (int  h_number)
 #endif //SEG_MAPPING_TABLE
 
     generation_table [max_generation].free_list_allocator = allocator(NUM_GEN2_ALIST, BASE_GEN2_ALIST, gen2_alloc_list);
-    //assign the alloc_list for the large generation 
+    //assign the alloc_list for the large generation
     generation_table [max_generation+1].free_list_allocator = allocator(NUM_LOH_ALIST, BASE_LOH_ALIST, loh_alloc_list);
     generation_table [max_generation+1].gen_num = max_generation+1;
     make_generation (generation_table [max_generation+1],lseg, heap_segment_mem (lseg), 0);
@@ -11570,7 +11567,7 @@ BOOL gc_heap::size_fit_p (size_t size REQD_ALIGN_AND_OFFSET_DCL, uint8_t* alloc_
 #endif // FEATURE_STRUCTALIGN
 
     // in allocate_in_condemned_generation we can have this when we
-    // set the alloc_limit to plan_allocated which could be less than 
+    // set the alloc_limit to plan_allocated which could be less than
     // alloc_ptr
     if (alloc_limit < alloc_pointer)
     {
@@ -11579,7 +11576,7 @@ BOOL gc_heap::size_fit_p (size_t size REQD_ALIGN_AND_OFFSET_DCL, uint8_t* alloc_
 
     if (old_loc != 0)
     {
-        return (((size_t)(alloc_limit - alloc_pointer) >= (size + ((use_padding & USE_PADDING_TAIL)? Align(min_obj_size) : 0))) 
+        return (((size_t)(alloc_limit - alloc_pointer) >= (size + ((use_padding & USE_PADDING_TAIL)? Align(min_obj_size) : 0)))
 #ifdef SHORT_PLUGS
                 ||((!(use_padding & USE_PADDING_FRONT)) && ((alloc_pointer + size) == alloc_limit))
 #else //SHORT_PLUGS
@@ -11598,7 +11595,7 @@ inline
 BOOL gc_heap::a_size_fit_p (size_t size, uint8_t* alloc_pointer, uint8_t* alloc_limit,
                             int align_const)
 {
-    // We could have run into cases where this is true when alloc_allocated is the 
+    // We could have run into cases where this is true when alloc_allocated is the
     // the same as the seg committed.
     if (alloc_limit < alloc_pointer)
     {
@@ -11710,7 +11707,7 @@ void gc_heap::adjust_limit (uint8_t* start, size_t limit_size, generation* gen,
                             generation_free_obj_space (gen) += Align (min_obj_size);
                             make_unused_array (hole + Align (min_obj_size), size - Align (min_obj_size));
                             generation_free_list_space (gen) += size - Align (min_obj_size);
-                            generation_allocator(gen)->thread_item_front (hole + Align (min_obj_size), 
+                            generation_allocator(gen)->thread_item_front (hole + Align (min_obj_size),
                                                                           size - Align (min_obj_size));
                             add_gen_free (gen->gen_num, (size - Align (min_obj_size)));
                         }
@@ -11721,7 +11718,7 @@ void gc_heap::adjust_limit (uint8_t* start, size_t limit_size, generation* gen,
                             generation_free_obj_space (gen) += size;
                         }
                     }
-                    else 
+                    else
                     {
                         dprintf (3, ("threading hole in front of free list"));
                         make_unused_array (hole, size);
@@ -11770,8 +11767,8 @@ void gc_heap::set_batch_mark_array_bits (uint8_t* start, uint8_t* end)
     size_t startwrd = mark_bit_word (start_mark_bit);
     size_t endwrd = mark_bit_word (end_mark_bit);
 
-    dprintf (3, ("Setting all mark array bits between [%Ix:%Ix-[%Ix:%Ix", 
-        (size_t)start, (size_t)start_mark_bit, 
+    dprintf (3, ("Setting all mark array bits between [%Ix:%Ix-[%Ix:%Ix",
+        (size_t)start, (size_t)start_mark_bit,
         (size_t)end, (size_t)end_mark_bit));
 
     unsigned int firstwrd = ~(lowbits (~0, startbit));
@@ -11813,8 +11810,8 @@ void gc_heap::check_batch_mark_array_bits (uint8_t* start, uint8_t* end)
     size_t startwrd = mark_bit_word (start_mark_bit);
     size_t endwrd = mark_bit_word (end_mark_bit);
 
-    //dprintf (3, ("Setting all mark array bits between [%Ix:%Ix-[%Ix:%Ix", 
-    //    (size_t)start, (size_t)start_mark_bit, 
+    //dprintf (3, ("Setting all mark array bits between [%Ix:%Ix-[%Ix:%Ix",
+    //    (size_t)start, (size_t)start_mark_bit,
     //    (size_t)end, (size_t)end_mark_bit));
 
     unsigned int firstwrd = ~(lowbits (~0, startbit));
@@ -11825,8 +11822,8 @@ void gc_heap::check_batch_mark_array_bits (uint8_t* start, uint8_t* end)
         unsigned int wrd = firstwrd & lastwrd;
         if (mark_array[startwrd] & wrd)
         {
-            dprintf  (3, ("The %Ix portion of mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared", 
-                            wrd, startwrd, 
+            dprintf  (3, ("The %Ix portion of mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared",
+                            wrd, startwrd,
                             mark_array [startwrd], mark_word_address (startwrd)));
             FATAL_GC_ERROR();
         }
@@ -11838,8 +11835,8 @@ void gc_heap::check_batch_mark_array_bits (uint8_t* start, uint8_t* end)
     {
         if (mark_array[startwrd] & firstwrd)
         {
-            dprintf  (3, ("The %Ix portion of mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared", 
-                            firstwrd, startwrd, 
+            dprintf  (3, ("The %Ix portion of mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared",
+                            firstwrd, startwrd,
                             mark_array [startwrd], mark_word_address (startwrd)));
             FATAL_GC_ERROR();
         }
@@ -11851,8 +11848,8 @@ void gc_heap::check_batch_mark_array_bits (uint8_t* start, uint8_t* end)
     {
         if (mark_array[wrdtmp])
         {
-            dprintf  (3, ("The mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared", 
-                            wrdtmp, 
+            dprintf  (3, ("The mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared",
+                            wrdtmp,
                             mark_array [wrdtmp], mark_word_address (wrdtmp)));
             FATAL_GC_ERROR();
         }
@@ -11863,8 +11860,8 @@ void gc_heap::check_batch_mark_array_bits (uint8_t* start, uint8_t* end)
     {
         if (mark_array[endwrd] & lastwrd)
         {
-            dprintf  (3, ("The %Ix portion of mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared", 
-                            lastwrd, lastwrd, 
+            dprintf  (3, ("The %Ix portion of mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared",
+                            lastwrd, lastwrd,
                             mark_array [lastwrd], mark_word_address (lastwrd)));
             FATAL_GC_ERROR();
         }
@@ -11961,7 +11958,7 @@ void allocator::thread_free_item (uint8_t* item, uint8_t*& head, uint8_t*& tail)
 void allocator::thread_item (uint8_t* item, size_t size)
 {
     size_t sz = frst_bucket_size;
-    unsigned int a_l_number = 0; 
+    unsigned int a_l_number = 0;
 
     for (; a_l_number < (num_buckets-1); a_l_number++)
     {
@@ -11972,7 +11969,7 @@ void allocator::thread_item (uint8_t* item, size_t size)
         sz = sz * 2;
     }
     alloc_list* al = &alloc_list_of (a_l_number);
-    thread_free_item (item, 
+    thread_free_item (item,
                       al->alloc_list_head(),
                       al->alloc_list_tail());
 }
@@ -11981,7 +11978,7 @@ void allocator::thread_item_front (uint8_t* item, size_t size)
 {
     //find right free list
     size_t sz = frst_bucket_size;
-    unsigned int a_l_number = 0; 
+    unsigned int a_l_number = 0;
     for (; a_l_number < (num_buckets-1); a_l_number++)
     {
         if (size < sz)
@@ -12036,8 +12033,8 @@ void allocator::copy_from_alloc_list (alloc_list* fromalist)
         if (repair_list)
         {
             //repair the the list
-            //new items may have been added during the plan phase 
-            //items may have been unlinked. 
+            //new items may have been added during the plan phase
+            //items may have been unlinked.
             uint8_t* free_item = alloc_list_head_of (i);
             while (free_item && count)
             {
@@ -12078,7 +12075,7 @@ void allocator::commit_alloc_list_changes()
     {
         for (unsigned int i = 0; i < num_buckets; i++)
         {
-            //remove the undo info from list. 
+            //remove the undo info from list.
             uint8_t* free_item = alloc_list_head_of (i);
             size_t count = alloc_list_damage_count_of (i);
             while (free_item && count)
@@ -12094,13 +12091,13 @@ void allocator::commit_alloc_list_changes()
                 free_item = free_list_slot (free_item);
             }
 
-            alloc_list_damage_count_of (i) = 0; 
+            alloc_list_damage_count_of (i) = 0;
         }
     }
 }
 
 void gc_heap::adjust_limit_clr (uint8_t* start, size_t limit_size, size_t size,
-                                alloc_context* acontext, uint32_t flags, 
+                                alloc_context* acontext, uint32_t flags,
                                 heap_segment* seg, int align_const, int gen_number)
 {
     bool loh_p = (gen_number > 0);
@@ -12150,7 +12147,7 @@ void gc_heap::adjust_limit_clr (uint8_t* start, size_t limit_size, size_t size,
         if (gen_number == 0)
         {
             size_t pad_size = Align (min_obj_size, align_const);
-            dprintf (3, ("contigous ac: making min obj gap %Ix->%Ix(%Id)", 
+            dprintf (3, ("contigous ac: making min obj gap %Ix->%Ix(%Id)",
                 acontext->alloc_ptr, (acontext->alloc_ptr + pad_size), pad_size));
             make_unused_array (acontext->alloc_ptr, pad_size);
             acontext->alloc_ptr += pad_size;
@@ -12194,9 +12191,9 @@ void gc_heap::adjust_limit_clr (uint8_t* start, size_t limit_size, size_t size,
     }
 #endif //BACKGROUND_GC
 
-    // we are going to clear a right-edge exclusive span [clear_start, clear_limit)  
+    // we are going to clear a right-edge exclusive span [clear_start, clear_limit)
     // but will adjust for cases when object is ok to stay dirty or the space has not seen any use yet
-    // NB: the size and limit_size include syncblock, which is to the -1 of the object start 
+    // NB: the size and limit_size include syncblock, which is to the -1 of the object start
     //     that effectively shifts the allocation by `plug_skew`
     uint8_t* clear_start = start - plug_skew;
     uint8_t* clear_limit = start + limit_size - plug_skew;
@@ -12305,7 +12302,7 @@ size_t gc_heap::limit_from_size (size_t size, uint32_t flags, size_t physical_li
     // as size.
     assert ((gen_number != 0) || (physical_limit >= padded_size));
 
-    // For SOH if the size asked for is very small, we want to allocate more than just what's asked for if possible. 
+    // For SOH if the size asked for is very small, we want to allocate more than just what's asked for if possible.
     // Unless we were told not to clean, then we will not force it.
     size_t min_size_to_allocate = ((gen_number == 0 && !(flags & GC_ALLOC_ZEROING_OPTIONAL)) ? allocation_quantum : 0);
 
@@ -12331,7 +12328,7 @@ void gc_heap::add_to_oom_history_per_heap()
     }
 }
 
-void gc_heap::handle_oom (int heap_num, oom_reason reason, size_t alloc_size, 
+void gc_heap::handle_oom (int heap_num, oom_reason reason, size_t alloc_size,
                           uint8_t* allocated, uint8_t* reserved)
 {
     UNREFERENCED_PARAMETER(heap_num);
@@ -12345,7 +12342,7 @@ void gc_heap::handle_oom (int heap_num, oom_reason reason, size_t alloc_size,
     {
         // This means during the last GC we needed to reserve and/or commit more memory
         // but we couldn't. We proceeded with the GC and ended up not having enough
-        // memory at the end. This is a legitimate OOM situtation. Otherwise we 
+        // memory at the end. This is a legitimate OOM situtation. Otherwise we
         // probably made a mistake and didn't expand the heap when we should have.
         reason = oom_low_mem;
     }
@@ -12383,7 +12380,7 @@ void gc_heap::check_for_full_gc (int gen_num, size_t size)
     BOOL should_notify = FALSE;
     // if we detect full gc because of the allocation budget specified this is TRUE;
     // it's FALSE if it's due to other factors.
-    BOOL alloc_factor = TRUE; 
+    BOOL alloc_factor = TRUE;
     int i = 0;
     int n = 0;
     int n_initial = gen_num;
@@ -12395,7 +12392,7 @@ void gc_heap::check_for_full_gc (int gen_num, size_t size)
     {
         return;
     }
-    
+
     if (gen_num != (max_generation + 1))
     {
         gen_num = max_generation;
@@ -12407,7 +12404,7 @@ void gc_heap::check_for_full_gc (int gen_num, size_t size)
 
     for (int gen_index = 0; gen_index <= (max_generation + 1); gen_index++)
     {
-        dprintf (2, ("FGN: h#%d: gen%d: %Id(%Id)", 
+        dprintf (2, ("FGN: h#%d: gen%d: %Id(%Id)",
                      heap_number, gen_index,
                      dd_new_allocation (dynamic_data_of (gen_index)),
                      dd_desired_allocation (dynamic_data_of (gen_index))));
@@ -12459,14 +12456,14 @@ void gc_heap::check_for_full_gc (int gen_num, size_t size)
 
     new_alloc_remain_percent = (int)(((float)(new_alloc_remain) / (float)dd_desired_allocation (dd_full)) * 100);
 
-    dprintf (2, ("FGN: alloc threshold for gen%d is %d%%, current threshold is %d%%", 
+    dprintf (2, ("FGN: alloc threshold for gen%d is %d%%, current threshold is %d%%",
                  gen_num, pct, new_alloc_remain_percent));
 
     if (new_alloc_remain_percent <= (int)pct)
     {
 #ifdef BACKGROUND_GC
         // If background GC is enabled, we still want to check whether this will
-        // be a blocking GC or not because we only want to notify when it's a 
+        // be a blocking GC or not because we only want to notify when it's a
         // blocking full GC.
         if (background_allowed_p())
         {
@@ -12481,9 +12478,9 @@ void gc_heap::check_for_full_gc (int gen_num, size_t size)
 check_other_factors:
 
     dprintf (2, ("FGC: checking other factors"));
-    n = generation_to_condemn (n, 
-                               &local_blocking_collection, 
-                               &local_elevation_requested, 
+    n = generation_to_condemn (n,
+                               &local_blocking_collection,
+                               &local_elevation_requested,
                                TRUE);
 
     if (local_elevation_requested && (n == max_generation))
@@ -12493,7 +12490,7 @@ check_other_factors:
             int local_elevation_locked_count = settings.elevation_locked_count + 1;
             if (local_elevation_locked_count != 6)
             {
-                dprintf (2, ("FGN: lock count is %d - Condemning max_generation-1", 
+                dprintf (2, ("FGN: lock count is %d - Condemning max_generation-1",
                     local_elevation_locked_count));
                 n = max_generation - 1;
             }
@@ -12504,7 +12501,7 @@ check_other_factors:
 
 #ifdef BACKGROUND_GC
     // When background GC is enabled it decreases the accuracy of our predictability -
-    // by the time the GC happens, we may not be under BGC anymore. If we try to 
+    // by the time the GC happens, we may not be under BGC anymore. If we try to
     // predict often enough it should be ok.
     if ((n == max_generation) &&
         (recursive_gc_sync::background_running_p()))
@@ -12522,8 +12519,8 @@ check_other_factors:
     }
 #endif //BACKGROUND_GC
 
-    dprintf (2, ("FGN: we estimate gen%d will be collected: %s", 
-                       n, 
+    dprintf (2, ("FGN: we estimate gen%d will be collected: %s",
+                       n,
                        (local_blocking_collection ? "blocking" : "background")));
 
     if ((n == max_generation) && local_blocking_collection)
@@ -12537,11 +12534,11 @@ done:
 
     if (should_notify)
     {
-        dprintf (2, ("FGN: gen%d detecting full GC approaching(%s) (GC#%d) (%Id%% left in gen%d)", 
+        dprintf (2, ("FGN: gen%d detecting full GC approaching(%s) (GC#%d) (%Id%% left in gen%d)",
                      n_initial,
                      (alloc_factor ? "alloc" : "other"),
                      dd_collection_count (dynamic_data_of (0)),
-                     new_alloc_remain_percent, 
+                     new_alloc_remain_percent,
                      gen_num));
 
         send_full_gc_notification (n_initial, alloc_factor);
@@ -12582,7 +12579,7 @@ wait_full_gc_status gc_heap::full_gc_wait (GCEvent *event, int time_out_ms)
         {
             return wait_full_gc_cancelled;
         }
-        
+
         if (wait_result == WAIT_OBJECT_0)
         {
 #ifdef BACKGROUND_GC
@@ -12623,8 +12620,8 @@ BOOL gc_heap::short_on_end_of_seg (int gen_number,
     UNREFERENCED_PARAMETER(gen_number);
     uint8_t* allocated = heap_segment_allocated(seg);
 
-    BOOL sufficient_p = sufficient_space_end_seg (allocated, 
-                                                  heap_segment_reserved (seg), 
+    BOOL sufficient_p = sufficient_space_end_seg (allocated,
+                                                  heap_segment_reserved (seg),
                                                   end_space_after_gc(),
                                                   tuning_deciding_short_on_seg);
     if (!sufficient_p)
@@ -12645,8 +12642,8 @@ BOOL gc_heap::short_on_end_of_seg (int gen_number,
 #endif // _MSC_VER
 
 inline
-BOOL gc_heap::a_fit_free_list_p (int gen_number, 
-                                 size_t size, 
+BOOL gc_heap::a_fit_free_list_p (int gen_number,
+                                 size_t size,
                                  alloc_context* acontext,
                                  uint32_t flags,
                                  int align_const)
@@ -12710,7 +12707,7 @@ BOOL gc_heap::a_fit_free_list_p (int gen_number,
                 {
                     prev_free_item = free_list;
                 }
-                free_list = free_list_slot (free_list); 
+                free_list = free_list_slot (free_list);
             }
         }
         sz_list = sz_list * 2;
@@ -12722,10 +12719,10 @@ end:
 
 #ifdef BACKGROUND_GC
 void gc_heap::bgc_loh_alloc_clr (uint8_t* alloc_start,
-                                 size_t size, 
+                                 size_t size,
                                  alloc_context* acontext,
-                                 uint32_t flags,  
-                                 int align_const, 
+                                 uint32_t flags,
+                                 int align_const,
                                  int lock_index,
                                  BOOL check_used_p,
                                  heap_segment* seg)
@@ -12736,7 +12733,7 @@ void gc_heap::bgc_loh_alloc_clr (uint8_t* alloc_start,
 
     bgc_alloc_lock->loh_alloc_done_with_index (lock_index);
 
-    // clear memory while not holding the lock. 
+    // clear memory while not holding the lock.
     size_t size_to_skip = size_of_array_base;
     size_t size_to_clear = size - size_to_skip - plug_skew;
     size_t saved_size_to_clear = size_to_clear;
@@ -12800,15 +12797,15 @@ void gc_heap::bgc_loh_alloc_clr (uint8_t* alloc_start,
 }
 #endif //BACKGROUND_GC
 
-BOOL gc_heap::a_fit_free_list_large_p (size_t size, 
+BOOL gc_heap::a_fit_free_list_large_p (size_t size,
                                        alloc_context* acontext,
-                                       uint32_t flags, 
+                                       uint32_t flags,
                                        int align_const)
 {
     BOOL can_fit = FALSE;
     int gen_number = max_generation + 1;
     generation* gen = generation_of (gen_number);
-    allocator* loh_allocator = generation_allocator (gen); 
+    allocator* loh_allocator = generation_allocator (gen);
 
 #ifdef FEATURE_LOH_COMPACTION
     size_t loh_pad = Align (loh_padding_obj_size, align_const);
@@ -12846,7 +12843,7 @@ BOOL gc_heap::a_fit_free_list_large_p (size_t size,
                     loh_allocator->unlink_item (a_l_idx, free_list, prev_free_item, FALSE);
 
                     // Substract min obj size because limit_from_size adds it. Not needed for LOH
-                    size_t limit = limit_from_size (size - Align(min_obj_size, align_const), flags, free_list_size, 
+                    size_t limit = limit_from_size (size - Align(min_obj_size, align_const), flags, free_list_size,
                                                     gen_number, align_const);
 
 #ifdef FEATURE_LOH_COMPACTION
@@ -12885,13 +12882,13 @@ BOOL gc_heap::a_fit_free_list_large_p (size_t size,
                         adjust_limit_clr (free_list, limit, size, acontext, flags, 0, align_const, gen_number);
                     }
 
-                    //fix the limit to compensate for adjust_limit_clr making it too short 
+                    //fix the limit to compensate for adjust_limit_clr making it too short
                     acontext->alloc_limit += Align (min_obj_size, align_const);
                     can_fit = TRUE;
                     goto exit;
                 }
                 prev_free_item = free_list;
-                free_list = free_list_slot (free_list); 
+                free_list = free_list_slot (free_list);
             }
         }
         sz_list = sz_list * 2;
@@ -12906,9 +12903,9 @@ exit:
 
 BOOL gc_heap::a_fit_segment_end_p (int gen_number,
                                    heap_segment* seg,
-                                   size_t size, 
+                                   size_t size,
                                    alloc_context* acontext,
-                                   uint32_t flags, 
+                                   uint32_t flags,
                                    int align_const,
                                    BOOL* commit_failed_p)
 {
@@ -12920,7 +12917,7 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
 #endif //BACKGROUND_GC
 
     uint8_t*& allocated = ((gen_number == 0) ?
-                                    alloc_allocated : 
+                                    alloc_allocated :
                                     heap_segment_allocated(seg));
 
     size_t pad = Align (min_obj_size, align_const);
@@ -12937,9 +12934,9 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
 
     if (a_size_fit_p (size, allocated, end, align_const))
     {
-        limit = limit_from_size (size, 
+        limit = limit_from_size (size,
                                  flags,
-                                 (end - allocated), 
+                                 (end - allocated),
                                  gen_number, align_const);
         goto found_fit;
     }
@@ -12948,9 +12945,9 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
 
     if (a_size_fit_p (size, allocated, end, align_const))
     {
-        limit = limit_from_size (size, 
+        limit = limit_from_size (size,
                                  flags,
-                                 (end - allocated), 
+                                 (end - allocated),
                                  gen_number, align_const);
 
         if (grow_heap_segment (seg, (allocated + limit), &hard_limit_short_seg_end_p))
@@ -12993,14 +12990,14 @@ found_fit:
 #endif //FEATURE_LOH_COMPACTION
 
 #if defined (VERIFY_HEAP) && defined (_DEBUG)
-    // we are responsible for cleaning the syncblock and we will do it later 
+    // we are responsible for cleaning the syncblock and we will do it later
     // as a part of cleanup routine and when not holding the heap lock.
-    // However, once we move "allocated" forward and if another thread initiate verification of 
+    // However, once we move "allocated" forward and if another thread initiate verification of
     // the previous object, it may consider the syncblock in the "next" eligible for validation.
     // (see also: object.cpp/Object::ValidateInner)
     // Make sure it will see cleaned up state to prevent triggering occasional verification failures.
     // And make sure the write happens before updating "allocated"
-    VolatileStore(((void**)allocated - 1), (void*)0);     //clear the sync block	
+    VolatileStore(((void**)allocated - 1), (void*)0);     //clear the sync block
 #endif //VERIFY_HEAP && _DEBUG
 
     uint8_t* old_alloc;
@@ -13015,7 +13012,7 @@ found_fit:
     }
     else
 #endif //BACKGROUND_GC
-    {      
+    {
         // In a contiguous AC case with GC_ALLOC_ZEROING_OPTIONAL, deduct unspent space from the limit to clear only what is necessary.
         if ((flags & GC_ALLOC_ZEROING_OPTIONAL) &&
             ((allocated == acontext->alloc_limit) || (allocated == (acontext->alloc_limit + Align (min_obj_size, align_const)))))
@@ -13040,7 +13037,7 @@ found_no_fit:
 }
 
 BOOL gc_heap::loh_a_fit_segment_end_p (int gen_number,
-                                       size_t size, 
+                                       size_t size,
                                        alloc_context* acontext,
                                        uint32_t flags,
                                        int align_const,
@@ -13061,7 +13058,7 @@ BOOL gc_heap::loh_a_fit_segment_end_p (int gen_number,
         else
 #endif //BACKGROUND_GC
         {
-            if (a_fit_segment_end_p (gen_number, seg, (size - Align (min_obj_size, align_const)), 
+            if (a_fit_segment_end_p (gen_number, seg, (size - Align (min_obj_size, align_const)),
                                         acontext, flags, align_const, commit_failed_p))
             {
                 acontext->alloc_limit += Align (min_obj_size, align_const);
@@ -13143,7 +13140,7 @@ BOOL gc_heap::trigger_ephemeral_gc (gc_reason gr)
 }
 
 BOOL gc_heap::soh_try_fit (int gen_number,
-                           size_t size, 
+                           size_t size,
                            alloc_context* acontext,
                            uint32_t flags,
                            int align_const,
@@ -13167,7 +13164,7 @@ BOOL gc_heap::soh_try_fit (int gen_number,
         // otherwise we would only try if we are actually not short at end of seg.
         if (!short_seg_end_p || !(*short_seg_end_p))
         {
-            can_allocate = a_fit_segment_end_p (gen_number, ephemeral_heap_segment, size, 
+            can_allocate = a_fit_segment_end_p (gen_number, ephemeral_heap_segment, size,
                                                 acontext, flags, align_const, commit_failed_p);
         }
     }
@@ -13176,7 +13173,7 @@ BOOL gc_heap::soh_try_fit (int gen_number,
 }
 
 allocation_state gc_heap::allocate_small (int gen_number,
-                                          size_t size, 
+                                          size_t size,
                                           alloc_context* acontext,
                                           uint32_t flags,
                                           int align_const)
@@ -13205,7 +13202,7 @@ allocation_state gc_heap::allocate_small (int gen_number,
     gc_reason gr = reason_oos_soh;
     oom_reason oom_r = oom_no_failure;
 
-    // No variable values should be "carried over" from one state to the other. 
+    // No variable values should be "carried over" from one state to the other.
     // That's why there are local variable for each state
 
     allocation_state soh_alloc_state = a_state_start;
@@ -13236,8 +13233,8 @@ allocation_state gc_heap::allocate_small (int gen_number,
                                                   align_const, &commit_failed_p,
                                                   NULL);
                 soh_alloc_state = (can_use_existing_p ?
-                                        a_state_can_allocate : 
-                                        (commit_failed_p ? 
+                                        a_state_can_allocate :
+                                        (commit_failed_p ?
                                             a_state_trigger_full_compact_gc :
                                             a_state_trigger_ephemeral_gc));
                 break;
@@ -13251,10 +13248,10 @@ allocation_state gc_heap::allocate_small (int gen_number,
                 can_use_existing_p = soh_try_fit (gen_number, size, acontext, flags,
                                                   align_const, &commit_failed_p,
                                                   &short_seg_end_p);
-                soh_alloc_state = (can_use_existing_p ? 
-                                        a_state_can_allocate : 
-                                        (short_seg_end_p ? 
-                                            a_state_trigger_2nd_ephemeral_gc : 
+                soh_alloc_state = (can_use_existing_p ?
+                                        a_state_can_allocate :
+                                        (short_seg_end_p ?
+                                            a_state_trigger_2nd_ephemeral_gc :
                                             a_state_trigger_full_compact_gc));
                 break;
             }
@@ -13277,7 +13274,7 @@ allocation_state gc_heap::allocate_small (int gen_number,
                 {
                     // some other threads already grabbed the more space lock and allocated
                     // so we should attempt an ephemeral GC again.
-                    soh_alloc_state = a_state_trigger_ephemeral_gc; 
+                    soh_alloc_state = a_state_trigger_ephemeral_gc;
                 }
 #endif //MULTIPLE_HEAPS
                 else if (short_seg_end_p)
@@ -13285,7 +13282,7 @@ allocation_state gc_heap::allocate_small (int gen_number,
                     soh_alloc_state = a_state_cant_allocate;
                     oom_r = oom_budget;
                 }
-                else 
+                else
                 {
                     assert (commit_failed_p);
                     soh_alloc_state = a_state_cant_allocate;
@@ -13299,8 +13296,8 @@ allocation_state gc_heap::allocate_small (int gen_number,
                 BOOL did_full_compacting_gc = FALSE;
 
                 bgc_in_progress_p = check_and_wait_for_bgc (awr_gen0_oos_bgc, &did_full_compacting_gc, false);
-                soh_alloc_state = (did_full_compacting_gc ? 
-                                        a_state_try_fit_after_cg : 
+                soh_alloc_state = (did_full_compacting_gc ?
+                                        a_state_try_fit_after_cg :
                                         a_state_try_fit_after_bgc);
                 break;
             }
@@ -13319,7 +13316,7 @@ allocation_state gc_heap::allocate_small (int gen_number,
                 }
                 else
                 {
-                    can_use_existing_p = soh_try_fit (gen_number, size, acontext, flags, 
+                    can_use_existing_p = soh_try_fit (gen_number, size, acontext, flags,
                                                       align_const, &commit_failed_p,
                                                       &short_seg_end_p);
 #ifdef BACKGROUND_GC
@@ -13341,8 +13338,8 @@ allocation_state gc_heap::allocate_small (int gen_number,
                             }
                             else
                             {
-                                soh_alloc_state = (bgc_in_progress_p ? 
-                                                        a_state_check_and_wait_for_bgc : 
+                                soh_alloc_state = (bgc_in_progress_p ?
+                                                        a_state_check_and_wait_for_bgc :
                                                         a_state_trigger_full_compact_gc);
                             }
                         }
@@ -13356,7 +13353,7 @@ allocation_state gc_heap::allocate_small (int gen_number,
                             // some other threads already grabbed the more space lock and allocated
                             // so we should attempt an ephemeral GC again.
                             assert (gen0_allocated_after_gc_p);
-                            soh_alloc_state = a_state_trigger_ephemeral_gc; 
+                            soh_alloc_state = a_state_trigger_ephemeral_gc;
 #else //MULTIPLE_HEAPS
                             assert (!"shouldn't get here");
 #endif //MULTIPLE_HEAPS
@@ -13374,7 +13371,7 @@ allocation_state gc_heap::allocate_small (int gen_number,
 
 
                 did_full_compacting_gc = trigger_ephemeral_gc (gr);
-                
+
                 if (did_full_compacting_gc)
                 {
                     soh_alloc_state = a_state_try_fit_after_cg;
@@ -13422,8 +13419,8 @@ exit:
     if (soh_alloc_state == a_state_cant_allocate)
     {
         assert (oom_r != oom_no_failure);
-        handle_oom (heap_number, 
-                    oom_r, 
+        handle_oom (heap_number,
+                    oom_r,
                     size,
                     heap_segment_allocated (ephemeral_heap_segment),
                     heap_segment_reserved (ephemeral_heap_segment));
@@ -13584,9 +13581,9 @@ BOOL gc_heap::check_and_wait_for_bgc (alloc_wait_reason awr,
 }
 
 BOOL gc_heap::loh_try_fit (int gen_number,
-                           size_t size, 
+                           size_t size,
                            alloc_context* acontext,
-                           uint32_t flags, 
+                           uint32_t flags,
                            int align_const,
                            BOOL* commit_failed_p,
                            oom_reason* oom_r)
@@ -13595,8 +13592,8 @@ BOOL gc_heap::loh_try_fit (int gen_number,
 
     if (!a_fit_free_list_large_p (size, acontext, flags, align_const))
     {
-        can_allocate = loh_a_fit_segment_end_p (gen_number, size, 
-                                                acontext, flags, align_const, 
+        can_allocate = loh_a_fit_segment_end_p (gen_number, size,
+                                                acontext, flags, align_const,
                                                 commit_failed_p, oom_r);
 
 #ifdef BACKGROUND_GC
@@ -13619,7 +13616,7 @@ BOOL gc_heap::loh_try_fit (int gen_number,
     return can_allocate;
 }
 
-BOOL gc_heap::trigger_full_compact_gc (gc_reason gr, 
+BOOL gc_heap::trigger_full_compact_gc (gc_reason gr,
                                        oom_reason* oom_r,
                                        bool loh_p)
 {
@@ -13666,9 +13663,9 @@ BOOL gc_heap::trigger_full_compact_gc (gc_reason gr,
     }
     else
     {
-        dprintf (3, ("h%d: T full compacting GC (%d->%d)", 
-            heap_number, 
-            last_full_compact_gc_count, 
+        dprintf (3, ("h%d: T full compacting GC (%d->%d)",
+            heap_number,
+            last_full_compact_gc_count,
             current_full_compact_gc_count));
 
         assert (current_full_compact_gc_count > last_full_compact_gc_count);
@@ -13706,7 +13703,7 @@ bool gc_heap::should_retry_other_heap (size_t size)
 #ifdef MULTIPLE_HEAPS
     if (heap_hard_limit)
     {
-        size_t total_heap_committed_recorded = 
+        size_t total_heap_committed_recorded =
             current_total_committed - current_total_committed_bookkeeping;
         size_t min_size = dd_min_size (g_heaps[0]->dynamic_data_of (max_generation + 1));
         size_t slack_space = max (commit_min_th, min_size);
@@ -13725,9 +13722,9 @@ bool gc_heap::should_retry_other_heap (size_t size)
 }
 
 allocation_state gc_heap::allocate_large (int gen_number,
-                                          size_t size, 
+                                          size_t size,
                                           alloc_context* acontext,
-                                          uint32_t flags,  
+                                          uint32_t flags,
                                           int align_const)
 {
 #ifdef BACKGROUND_GC
@@ -13784,7 +13781,7 @@ allocation_state gc_heap::allocate_large (int gen_number,
     oom_reason oom_r = oom_no_failure;
     size_t current_full_compact_gc_count = 0;
 
-    // No variable values should be "carried over" from one state to the other. 
+    // No variable values should be "carried over" from one state to the other.
     // That's why there are local variable for each state
     allocation_state loh_alloc_state = a_state_start;
 #ifdef RECORD_LOH_STATE
@@ -13817,11 +13814,11 @@ allocation_state gc_heap::allocate_large (int gen_number,
                 BOOL commit_failed_p = FALSE;
                 BOOL can_use_existing_p = FALSE;
 
-                can_use_existing_p = loh_try_fit (gen_number, size, acontext, flags, 
+                can_use_existing_p = loh_try_fit (gen_number, size, acontext, flags,
                                                   align_const, &commit_failed_p, &oom_r);
                 loh_alloc_state = (can_use_existing_p ?
-                                        a_state_can_allocate : 
-                                        (commit_failed_p ? 
+                                        a_state_can_allocate :
+                                        (commit_failed_p ?
                                             a_state_trigger_full_compact_gc :
                                             a_state_acquire_seg));
                 assert ((loh_alloc_state == a_state_can_allocate) == (acontext->alloc_ptr != 0));
@@ -13832,10 +13829,10 @@ allocation_state gc_heap::allocate_large (int gen_number,
                 BOOL commit_failed_p = FALSE;
                 BOOL can_use_existing_p = FALSE;
 
-                can_use_existing_p = loh_try_fit (gen_number, size, acontext, flags, 
+                can_use_existing_p = loh_try_fit (gen_number, size, acontext, flags,
                                                   align_const, &commit_failed_p, &oom_r);
                 // Even after we got a new seg it doesn't necessarily mean we can allocate,
-                // another LOH allocating thread could have beat us to acquire the msl so 
+                // another LOH allocating thread could have beat us to acquire the msl so
                 // we need to try again.
                 loh_alloc_state = (can_use_existing_p ? a_state_can_allocate : a_state_try_fit);
                 assert ((loh_alloc_state == a_state_can_allocate) == (acontext->alloc_ptr != 0));
@@ -13848,11 +13845,11 @@ allocation_state gc_heap::allocate_large (int gen_number,
 
                 can_use_existing_p = loh_try_fit (gen_number, size, acontext, flags,
                                                   align_const, &commit_failed_p, &oom_r);
-                // If we failed to commit, we bail right away 'cause we already did a 
+                // If we failed to commit, we bail right away 'cause we already did a
                 // full compacting GC.
                 loh_alloc_state = (can_use_existing_p ?
-                                        a_state_can_allocate : 
-                                        (commit_failed_p ? 
+                                        a_state_can_allocate :
+                                        (commit_failed_p ?
                                             a_state_cant_allocate :
                                             a_state_acquire_seg_after_cg));
                 assert ((loh_alloc_state == a_state_can_allocate) == (acontext->alloc_ptr != 0));
@@ -13866,8 +13863,8 @@ allocation_state gc_heap::allocate_large (int gen_number,
                 can_use_existing_p = loh_try_fit (gen_number, size, acontext, flags,
                                                   align_const, &commit_failed_p, &oom_r);
                 loh_alloc_state = (can_use_existing_p ?
-                                        a_state_can_allocate : 
-                                        (commit_failed_p ? 
+                                        a_state_can_allocate :
+                                        (commit_failed_p ?
                                             a_state_trigger_full_compact_gc :
                                             a_state_acquire_seg_after_bgc));
                 assert ((loh_alloc_state == a_state_can_allocate) == (acontext->alloc_ptr != 0));
@@ -13881,9 +13878,9 @@ allocation_state gc_heap::allocate_large (int gen_number,
                 current_full_compact_gc_count = get_full_compact_gc_count();
 
                 can_get_new_seg_p = loh_get_new_seg (gen, size, align_const, &did_full_compacting_gc, &oom_r);
-                loh_alloc_state = (can_get_new_seg_p ? 
-                                        a_state_try_fit_new_seg : 
-                                        (did_full_compacting_gc ? 
+                loh_alloc_state = (can_get_new_seg_p ?
+                                        a_state_try_fit_new_seg :
+                                        (did_full_compacting_gc ?
                                             a_state_check_retry_seg :
                                             a_state_check_and_wait_for_bgc));
                 break;
@@ -13899,8 +13896,8 @@ allocation_state gc_heap::allocate_large (int gen_number,
                 // Since we release the msl before we try to allocate a seg, other
                 // threads could have allocated a bunch of segments before us so
                 // we might need to retry.
-                loh_alloc_state = (can_get_new_seg_p ? 
-                                        a_state_try_fit_after_cg : 
+                loh_alloc_state = (can_get_new_seg_p ?
+                                        a_state_try_fit_after_cg :
                                         a_state_check_retry_seg);
                 break;
             }
@@ -13908,13 +13905,13 @@ allocation_state gc_heap::allocate_large (int gen_number,
             {
                 BOOL can_get_new_seg_p = FALSE;
                 BOOL did_full_compacting_gc = FALSE;
-             
+
                 current_full_compact_gc_count = get_full_compact_gc_count();
 
-                can_get_new_seg_p = loh_get_new_seg (gen, size, align_const, &did_full_compacting_gc, &oom_r); 
-                loh_alloc_state = (can_get_new_seg_p ? 
-                                        a_state_try_fit_new_seg : 
-                                        (did_full_compacting_gc ? 
+                can_get_new_seg_p = loh_get_new_seg (gen, size, align_const, &did_full_compacting_gc, &oom_r);
+                loh_alloc_state = (can_get_new_seg_p ?
+                                        a_state_try_fit_new_seg :
+                                        (did_full_compacting_gc ?
                                             a_state_check_retry_seg :
                                             a_state_trigger_full_compact_gc));
                 assert ((loh_alloc_state != a_state_cant_allocate) || (oom_r != oom_no_failure));
@@ -13927,8 +13924,8 @@ allocation_state gc_heap::allocate_large (int gen_number,
 
                 bgc_in_progress_p = check_and_wait_for_bgc (awr_loh_oos_bgc, &did_full_compacting_gc, true);
                 loh_alloc_state = (!bgc_in_progress_p ?
-                                        a_state_trigger_full_compact_gc : 
-                                        (did_full_compacting_gc ? 
+                                        a_state_trigger_full_compact_gc :
+                                        (did_full_compacting_gc ?
                                             a_state_try_fit_after_cg :
                                             a_state_try_fit_after_bgc));
                 break;
@@ -13961,9 +13958,9 @@ allocation_state gc_heap::allocate_large (int gen_number,
                         should_retry_get_seg = TRUE;
                     }
                 }
-    
-                loh_alloc_state = (should_retry_gc ? 
-                                        a_state_trigger_full_compact_gc : 
+
+                loh_alloc_state = (should_retry_gc ?
+                                        a_state_trigger_full_compact_gc :
                                         (should_retry_get_seg ?
                                             a_state_try_fit_after_cg :
                                             a_state_cant_allocate));
@@ -13989,8 +13986,8 @@ exit:
         }
         else
         {
-            handle_oom (heap_number, 
-                        oom_r, 
+            handle_oom (heap_number,
+                        oom_r,
                         size,
                         0,
                         0);
@@ -14006,8 +14003,8 @@ exit:
 }
 
 // BGC's final mark phase will acquire the msl, so release it here and re-acquire.
-void gc_heap::trigger_gc_for_alloc (int gen_number, gc_reason gr, 
-                                    GCSpinLock* msl, bool loh_p, 
+void gc_heap::trigger_gc_for_alloc (int gen_number, gc_reason gr,
+                                    GCSpinLock* msl, bool loh_p,
                                     msl_take_state take_state)
 {
 #ifdef BACKGROUND_GC
@@ -14037,7 +14034,7 @@ void gc_heap::trigger_gc_for_alloc (int gen_number, gc_reason gr,
 #endif //BACKGROUND_GC
 }
 
-allocation_state gc_heap::try_allocate_more_space (alloc_context* acontext, size_t size, 
+allocation_state gc_heap::try_allocate_more_space (alloc_context* acontext, size_t size,
                                     uint32_t flags, int gen_number)
 {
     if (gc_heap::gc_started)
@@ -14109,7 +14106,7 @@ allocation_state gc_heap::try_allocate_more_space (alloc_context* acontext, size
     else
 #endif //BGC_SERVO_TUNING
     {
-        bool trigger_on_budget_loh_p = 
+        bool trigger_on_budget_loh_p =
 #ifdef BGC_SERVO_TUNING
             !bgc_tuning::enable_fl_tuning;
 #else
@@ -14150,7 +14147,7 @@ allocation_state gc_heap::try_allocate_more_space (alloc_context* acontext, size
     allocation_state can_allocate = ((gen_number == 0) ?
         allocate_small (gen_number, size, acontext, flags, align_const) :
         allocate_large (gen_number, size, acontext, flags, align_const));
-   
+
     if (can_allocate == a_state_can_allocate)
     {
         size_t alloc_context_bytes = acontext->alloc_limit + Align (min_obj_size, align_const) - acontext->alloc_ptr;
@@ -14364,7 +14361,7 @@ try_again:
                             max_alloc_context_count = hp_alloc_context_count;
                         }
                     }
-                } 
+                }
                 while (org_alloc_context_count != org_hp->alloc_context_count ||
                     max_alloc_context_count != max_hp->alloc_context_count);
 
@@ -14463,7 +14460,7 @@ gc_heap* gc_heap::balance_heaps_loh (alloc_context* acontext, size_t alloc_size)
 try_again:
     gc_heap* max_hp = home_hp;
     ptrdiff_t max_size = home_hp_size + delta;
-    
+
     dprintf (3, ("home hp: %d, max size: %d",
         home_hp_num,
         max_size));
@@ -14493,7 +14490,7 @@ try_again:
 
     if (max_hp != home_hp)
     {
-        dprintf (3, ("loh: %d(%Id)->%d(%Id)", 
+        dprintf (3, ("loh: %d(%Id)->%d(%Id)",
             home_hp->heap_number, dd_new_allocation (home_hp->dynamic_data_of (max_generation + 1)),
             max_hp->heap_number, dd_new_allocation (max_hp->dynamic_data_of (max_generation + 1))));
     }
@@ -14547,7 +14544,7 @@ BOOL gc_heap::allocate_more_space(alloc_context* acontext, size_t size,
 {
     allocation_state status = a_state_start;
     do
-    { 
+    {
 #ifdef MULTIPLE_HEAPS
         if (alloc_generation_number == 0)
         {
@@ -14581,7 +14578,7 @@ BOOL gc_heap::allocate_more_space(alloc_context* acontext, size_t size,
 #endif //MULTIPLE_HEAPS
     }
     while (status == a_state_retry_allocate);
-    
+
     return (status == a_state_can_allocate);
 }
 
@@ -14658,9 +14655,9 @@ void gc_heap::print_free_and_plug (const char* msg)
         {
             if ((gen->gen_free_spaces[j] != 0) || (gen->gen_plugs[j] != 0))
             {
-                dprintf (2, ("[%s][h%d][%s#%d]gen%d: 2^%d: F: %Id, P: %Id", 
-                    msg, 
-                    heap_number, 
+                dprintf (2, ("[%s][h%d][%s#%d]gen%d: 2^%d: F: %Id, P: %Id",
+                    msg,
+                    heap_number,
                     (settings.concurrent ? "BGC" : "GC"),
                     settings.gc_index,
                     i,
@@ -14689,7 +14686,7 @@ void gc_heap::add_gen_plug (int gen_number, size_t plug_size)
         }
         sz = sz * 2;
     }
-    
+
     (gen->gen_plugs[i])++;
 #else
     UNREFERENCED_PARAMETER(gen_number);
@@ -14712,11 +14709,11 @@ void gc_heap::add_item_to_current_pinned_free (int gen_number, size_t free_size)
         }
         sz = sz * 2;
     }
-    
+
     (gen->gen_current_pinned_free_spaces[i])++;
     generation_pinned_free_obj_space (gen) += free_size;
-    dprintf (3, ("left pin free %Id(2^%d) to gen%d, total %Id bytes (%Id)", 
-        free_size, (i + 10), gen_number, 
+    dprintf (3, ("left pin free %Id(2^%d) to gen%d, total %Id bytes (%Id)",
+        free_size, (i + 10), gen_number,
         generation_pinned_free_obj_space (gen),
         gen->gen_current_pinned_free_spaces[i]));
 #else
@@ -14741,7 +14738,7 @@ void gc_heap::add_gen_free (int gen_number, size_t free_size)
         }
         sz = sz * 2;
     }
-    
+
     (gen->gen_free_spaces[i])++;
 #else
     UNREFERENCED_PARAMETER(gen_number);
@@ -14765,7 +14762,7 @@ void gc_heap::remove_gen_free (int gen_number, size_t free_size)
         }
         sz = sz * 2;
     }
-    
+
     (gen->gen_free_spaces[i])--;
 #else
     UNREFERENCED_PARAMETER(gen_number);
@@ -14835,12 +14832,12 @@ uint8_t* gc_heap::allocate_in_older_generation (generation* gen, size_t size,
                     {
                         prev_free_item = free_list;
                     }
-                    free_list = free_list_slot (free_list); 
+                    free_list = free_list_slot (free_list);
                 }
             }
             sz_list = sz_list * 2;
         }
-        //go back to the beginning of the segment list 
+        //go back to the beginning of the segment list
         heap_segment* seg = heap_segment_rw (generation_start_segment (gen));
         if (seg != generation_allocation_segment (gen))
         {
@@ -14963,7 +14960,7 @@ uint8_t* gc_heap::allocate_in_older_generation (generation* gen, size_t size,
         }
         generation_allocation_size (gen) += size;
 
-        dprintf (3, ("aio: ptr: %Ix, limit: %Ix, sr: %Ix", 
+        dprintf (3, ("aio: ptr: %Ix, limit: %Ix, sr: %Ix",
             generation_allocation_pointer (gen), generation_allocation_limit (gen),
             generation_allocation_context_start_region (gen)));
 
@@ -15041,9 +15038,9 @@ uint8_t* gc_heap::allocate_in_expanded_heap (generation* gen,
     if (consider_bestfit && use_bestfit)
     {
         assert (bestfit_seg);
-        dprintf (SEG_REUSE_LOG_1, ("reallocating 0x%Ix in expanded heap, size: %Id", 
+        dprintf (SEG_REUSE_LOG_1, ("reallocating 0x%Ix in expanded heap, size: %Id",
                     old_loc, size));
-        return bestfit_seg->fit (old_loc, 
+        return bestfit_seg->fit (old_loc,
                                  size REQD_ALIGN_AND_OFFSET_ARG);
     }
 
@@ -15104,8 +15101,8 @@ uint8_t* gc_heap::allocate_in_expanded_heap (generation* gen,
                     {
                         size_t saved_pinned_len = pinned_len (pinned_plug_of(mi1));
                         pinned_len (pinned_plug_of(mi1)) = hsize;
-                        dprintf (3, ("changing %Ix len %Ix->%Ix", 
-                            pinned_plug (pinned_plug_of(mi1)), 
+                        dprintf (3, ("changing %Ix len %Ix->%Ix",
+                            pinned_plug (pinned_plug_of(mi1)),
                             saved_pinned_len, pinned_len (pinned_plug_of(mi1))));
                     }
                 }
@@ -15122,7 +15119,7 @@ uint8_t* gc_heap::allocate_in_expanded_heap (generation* gen,
         {
             size_t len = pinned_len (m);
             uint8_t*  free_list = (pinned_plug (m) - len);
-            dprintf (3, ("aie: testing free item: %Ix->%Ix(%Ix)", 
+            dprintf (3, ("aie: testing free item: %Ix->%Ix(%Ix)",
                 free_list, (free_list + len), len));
             if (size_fit_p (size REQD_ALIGN_AND_OFFSET_ARG, free_list, (free_list + len), old_loc, USE_PADDING_TAIL | pad_in_front))
             {
@@ -15144,7 +15141,7 @@ uint8_t* gc_heap::allocate_in_expanded_heap (generation* gen,
         generation_allocation_context_start_region (gen) = generation_allocation_pointer (gen);
         heap_segment_plan_allocated (seg) = heap_segment_committed (seg);
         generation_allocation_limit (gen) = heap_segment_plan_allocated (seg);
-        dprintf (3, ("aie: switching to end of seg: %Ix->%Ix(%Ix)", 
+        dprintf (3, ("aie: switching to end of seg: %Ix->%Ix(%Ix)",
             generation_allocation_pointer (gen), generation_allocation_limit (gen),
             (generation_allocation_limit (gen) - generation_allocation_pointer (gen))));
 
@@ -15210,7 +15207,7 @@ allocate_in_free:
         assert (generation_allocation_pointer (gen) <= generation_allocation_limit (gen));
         dprintf (3, ("Allocated in expanded heap %Ix:%Id", (size_t)(result+pad), size));
 
-        dprintf (3, ("aie: ptr: %Ix, limit: %Ix, sr: %Ix", 
+        dprintf (3, ("aie: ptr: %Ix, limit: %Ix, sr: %Ix",
             generation_allocation_pointer (gen), generation_allocation_limit (gen),
             generation_allocation_context_start_region (gen)));
 
@@ -15234,7 +15231,7 @@ generation*  gc_heap::ensure_ephemeral_heap_segment (generation* consing_gen)
                 heap_segment_mem (ephemeral_heap_segment);
         generation_allocation_limit (new_consing_gen) =
             generation_allocation_pointer (new_consing_gen);
-        generation_allocation_context_start_region (new_consing_gen) = 
+        generation_allocation_context_start_region (new_consing_gen) =
             generation_allocation_pointer (new_consing_gen);
         generation_allocation_segment (new_consing_gen) = ephemeral_heap_segment;
 
@@ -15272,7 +15269,7 @@ uint8_t* gc_heap::allocate_in_condemned_generations (generation* gen,
     dprintf (3, ("aic gen%d: s: %Id", gen->gen_num, size));
 
     int pad_in_front = ((old_loc != 0) && (to_gen_number != max_generation)) ? USE_PADDING_FRONT : 0;
-    
+
     if ((from_gen_number != -1) && (from_gen_number != (int)max_generation) && settings.promotion)
     {
         generation_condemned_allocated (generation_of (from_gen_number + (settings.promotion ? 1 : 0))) += size;
@@ -15297,8 +15294,8 @@ retry:
 
 #ifdef FREE_USAGE_STATS
                 generation_allocated_in_pinned_free (gen) += generation_allocated_since_last_pin (gen);
-                dprintf (3, ("allocated %Id so far within pin %Ix, total->%Id", 
-                    generation_allocated_since_last_pin (gen), 
+                dprintf (3, ("allocated %Id so far within pin %Ix, total->%Id",
+                    generation_allocated_since_last_pin (gen),
                     plug,
                     generation_allocated_in_pinned_free (gen)));
                 generation_allocated_since_last_pin (gen) = 0;
@@ -15306,7 +15303,7 @@ retry:
                 add_item_to_current_pinned_free (gen->gen_num, pinned_len (pinned_plug_of (entry)));
 #endif //FREE_USAGE_STATS
 
-                dprintf (3, ("mark stack bos: %Id, tos: %Id, aic: p %Ix len: %Ix->%Ix", 
+                dprintf (3, ("mark stack bos: %Id, tos: %Id, aic: p %Ix len: %Ix->%Ix",
                     mark_stack_bos, mark_stack_tos, plug, len, pinned_len (pinned_plug_of (entry))));
 
                 assert(mark_stack_array[entry].len == 0 ||
@@ -15317,7 +15314,7 @@ retry:
                 set_allocator_next_pin (gen);
 
                 //Add the size of the pinned plug to the right pinned allocations
-                //find out which gen this pinned plug came from 
+                //find out which gen this pinned plug came from
                 int frgn = object_gennum (plug);
                 if ((frgn != (int)max_generation) && settings.promotion)
                 {
@@ -15330,7 +15327,7 @@ retry:
                 }
                 goto retry;
             }
-            
+
             if (generation_allocation_limit (gen) != heap_segment_plan_allocated (seg))
             {
                 generation_allocation_limit (gen) = heap_segment_plan_allocated (seg);
@@ -15460,12 +15457,12 @@ retry:
 
             if ((dist_to_next_pin >= 0) && (dist_to_next_pin < (ptrdiff_t)Align (min_obj_size)))
             {
-                dprintf (3, ("%Ix->(%Ix,%Ix),%Ix(%Ix)(%Ix),NP->PP", 
-                    old_loc, 
+                dprintf (3, ("%Ix->(%Ix,%Ix),%Ix(%Ix)(%Ix),NP->PP",
+                    old_loc,
                     generation_allocation_pointer (gen),
                     generation_allocation_limit (gen),
                     next_pinned_plug,
-                    size, 
+                    size,
                     dist_to_next_pin));
                 clear_plug_padded (old_loc);
                 pad = 0;
@@ -15490,7 +15487,7 @@ retry:
         generation_allocated_since_last_pin (gen) += size;
 #endif //FREE_USAGE_STATS
 
-        dprintf (3, ("aic: ptr: %Ix, limit: %Ix, sr: %Ix", 
+        dprintf (3, ("aic: ptr: %Ix, limit: %Ix, sr: %Ix",
             generation_allocation_pointer (gen), generation_allocation_limit (gen),
             generation_allocation_context_start_region (gen)));
 
@@ -15509,7 +15506,7 @@ inline int power (int x, int y)
     return z;
 }
 
-int gc_heap::joined_generation_to_condemn (BOOL should_evaluate_elevation, 
+int gc_heap::joined_generation_to_condemn (BOOL should_evaluate_elevation,
                                            int initial_gen,
                                            int current_gen,
                                            BOOL* blocking_collection_p
@@ -15550,8 +15547,8 @@ int gc_heap::joined_generation_to_condemn (BOOL should_evaluate_elevation,
 
     if (should_evaluate_elevation && (n == max_generation))
     {
-        dprintf (GTC_LOG, ("lock: %d(%d)", 
-            (settings.should_lock_elevation ? 1 : 0), 
+        dprintf (GTC_LOG, ("lock: %d(%d)",
+            (settings.should_lock_elevation ? 1 : 0),
             settings.elevation_locked_count));
 
         if (settings.should_lock_elevation)
@@ -15611,7 +15608,7 @@ int gc_heap::joined_generation_to_condemn (BOOL should_evaluate_elevation,
     {
         // If we have already consumed 90% of the limit, we should check to see if we should compact LOH.
         // TODO: should unify this with gen2.
-        dprintf (GTC_LOG, ("committed %Id is %d%% of limit %Id", 
+        dprintf (GTC_LOG, ("committed %Id is %d%% of limit %Id",
             current_total_committed, (int)((float)current_total_committed * 100.0 / (float)heap_hard_limit),
             heap_hard_limit));
 
@@ -15624,7 +15621,7 @@ int gc_heap::joined_generation_to_condemn (BOOL should_evaluate_elevation,
         else if ((current_total_committed * 10) >= (heap_hard_limit * 9))
         {
             size_t loh_frag = get_total_gen_fragmentation (max_generation + 1);
-            
+
             // If the LOH frag is >= 1/8 it's worth compacting it
             if ((loh_frag * 8) >= heap_hard_limit)
             {
@@ -15657,7 +15654,7 @@ int gc_heap::joined_generation_to_condemn (BOOL should_evaluate_elevation,
         *blocking_collection_p = TRUE;
     }
 
-    if ((n < max_generation) && !recursive_gc_sync::background_running_p() && 
+    if ((n < max_generation) && !recursive_gc_sync::background_running_p() &&
         bgc_tuning::stepping_trigger (settings.entry_memory_load, get_current_gc_index (max_generation)))
     {
         n = max_generation;
@@ -15743,9 +15740,9 @@ size_t get_survived_size (gc_history_per_heap* hist)
 
     for (int gen_number = 0; gen_number <= (max_generation + 1); gen_number++)
     {
-        gen_data = &(hist->gen_data[gen_number]); 
-        surv_size += (gen_data->size_after - 
-                      gen_data->free_list_space_after - 
+        gen_data = &(hist->gen_data[gen_number]);
+        surv_size += (gen_data->size_after -
+                      gen_data->free_list_space_after -
                       gen_data->free_obj_space_after);
     }
 
@@ -15830,11 +15827,11 @@ size_t gc_heap::get_total_generation_size (int gen_number)
     return total_generation_size;
 }
 
-// gets all that's allocated into the gen. This is only used for gen2/3 
+// gets all that's allocated into the gen. This is only used for gen2/3
 // for servo tuning.
 size_t gc_heap::get_total_servo_alloc (int gen_number)
 {
-    size_t total_alloc = 0; 
+    size_t total_alloc = 0;
     bool loh_p = (gen_number == (max_generation + 1));
 
 #ifdef MULTIPLE_HEAPS
@@ -15852,7 +15849,7 @@ size_t gc_heap::get_total_servo_alloc (int gen_number)
         total_alloc += generation_sweep_allocated (gen);
     }
 
-    return total_alloc;    
+    return total_alloc;
 }
 
 size_t gc_heap::get_total_bgc_promoted()
@@ -15952,13 +15949,13 @@ size_t gc_heap::current_generation_size (int gen_number)
     we would do a full blocking GC, in which case check_only_p is TRUE.
 
     The difference between calling this with check_only_p TRUE and FALSE is that when it's
-    TRUE: 
+    TRUE:
             settings.reason is ignored
             budgets are not checked (since they are checked before this is called)
             it doesn't change anything non local like generation_skip_ratio
 */
-int gc_heap::generation_to_condemn (int n_initial, 
-                                    BOOL* blocking_collection_p, 
+int gc_heap::generation_to_condemn (int n_initial,
+                                    BOOL* blocking_collection_p,
                                     BOOL* elevation_requested_p,
                                     BOOL check_only_p)
 {
@@ -16007,12 +16004,12 @@ int gc_heap::generation_to_condemn (int n_initial,
 
     if (!check_only_p)
     {
-        dd_fragmentation (dynamic_data_of (0)) = 
-            generation_free_list_space (youngest_generation) + 
+        dd_fragmentation (dynamic_data_of (0)) =
+            generation_free_list_space (youngest_generation) +
             generation_free_obj_space (youngest_generation);
 
-        dd_fragmentation (dynamic_data_of (max_generation + 1)) = 
-            generation_free_list_space (large_object_generation) + 
+        dd_fragmentation (dynamic_data_of (max_generation + 1)) =
+            generation_free_list_space (large_object_generation) +
             generation_free_obj_space (large_object_generation);
 
         //save new_allocation
@@ -16049,7 +16046,7 @@ int gc_heap::generation_to_condemn (int n_initial,
                 n = max_generation;
                 local_condemn_reasons->set_gen (gen_alloc_budget, n);
                 dprintf (BGC_TUNING_LOG, ("BTL[GTC]: trigger based on gen%d b: %Id",
-                         (max_generation + 1), 
+                         (max_generation + 1),
                          get_new_allocation (max_generation+1)));
             }
         }
@@ -16145,8 +16142,8 @@ int gc_heap::generation_to_condemn (int n_initial,
         generation_skip_ratio = 100;
     }
 
-    if (dt_low_ephemeral_space_p (check_only_p ? 
-                                  tuning_deciding_full_gc : 
+    if (dt_low_ephemeral_space_p (check_only_p ?
+                                  tuning_deciding_full_gc :
                                   tuning_deciding_condemned_gen))
     {
         low_ephemeral_space = TRUE;
@@ -16163,10 +16160,10 @@ int gc_heap::generation_to_condemn (int n_initial,
             {
                 //It is better to defragment first if we are running out of space for
                 //the ephemeral generation but we have enough fragmentation to make up for it
-                //in the non ephemeral generation. Essentially we are trading a gen2 for 
+                //in the non ephemeral generation. Essentially we are trading a gen2 for
                 // having to expand heap in ephemeral collections.
-                if (dt_high_frag_p (tuning_deciding_condemned_gen, 
-                                    max_generation - 1, 
+                if (dt_high_frag_p (tuning_deciding_condemned_gen,
+                                    max_generation - 1,
                                     TRUE))
                 {
                     high_fragmentation = TRUE;
@@ -16218,8 +16215,8 @@ int gc_heap::generation_to_condemn (int n_initial,
     // It's hard to catch when we get to the point that the memory load is so high
     // we get an induced GC from the finalizer thread so we are checking the memory load
     // for every gen0 GC.
-    check_memory = (check_only_p ? 
-                    (n >= 0) : 
+    check_memory = (check_only_p ?
+                    (n >= 0) :
                     ((n >= 1) || low_memory_detected));
 
     if (check_memory)
@@ -16230,7 +16227,7 @@ int gc_heap::generation_to_condemn (int n_initial,
         {
             dprintf (GTC_LOG, ("ml: %d", memory_load));
         }
-        
+
         // Need to get it early enough for all heaps to use.
         local_settings->entry_available_physical_mem = available_physical;
         local_settings->entry_memory_load = memory_load;
@@ -16310,7 +16307,7 @@ int gc_heap::generation_to_condemn (int n_initial,
 
     if (!check_only_p)
     {
-        if (is_induced_blocking (settings.reason) && 
+        if (is_induced_blocking (settings.reason) &&
             n_initial == max_generation
             IN_STRESS_HEAP( && !settings.stress_induced ))
         {
@@ -16341,7 +16338,7 @@ int gc_heap::generation_to_condemn (int n_initial,
             dynamic_data* dd_max = dynamic_data_of (max_generation);
             if (((float)dd_new_allocation (dd_max) / (float)dd_desired_allocation (dd_max)) < 0.9)
             {
-                dprintf (GTC_LOG, ("%Id left in gen2 alloc (%Id)", 
+                dprintf (GTC_LOG, ("%Id left in gen2 alloc (%Id)",
                     dd_new_allocation (dd_max), dd_desired_allocation (dd_max)));
                 n = max_generation;
                 local_condemn_reasons->set_condition (gen_almost_max_alloc);
@@ -16363,7 +16360,7 @@ int gc_heap::generation_to_condemn (int n_initial,
                     // For background GC we want to do blocking collections more eagerly because we don't
                     // want to get into the situation where the memory load becomes high while we are in
                     // a background GC and we'd have to wait for the background GC to finish to start
-                    // a blocking collection (right now the implemenation doesn't handle converting 
+                    // a blocking collection (right now the implemenation doesn't handle converting
                     // a background GC to a blocking collection midway.
                     dprintf (GTC_LOG, ("h%d: bgc - BLOCK", heap_number));
                     *blocking_collection_p = TRUE;
@@ -16404,7 +16401,7 @@ int gc_heap::generation_to_condemn (int n_initial,
     }
 
     //figure out if max_generation is too fragmented -> blocking collection
-    if (!provisional_mode_triggered 
+    if (!provisional_mode_triggered
 #ifdef BGC_SERVO_TUNING
         && !bgc_tuning::enable_fl_tuning
 #endif //BGC_SERVO_TUNING
@@ -16432,7 +16429,7 @@ int gc_heap::generation_to_condemn (int n_initial,
 #ifdef MULTIPLE_HEAPS
             for (int i = 0; i < n_heaps; i++)
             {
-                if (((g_heaps[i]->current_generation_size (max_generation)) > bgc_min_per_heap) || 
+                if (((g_heaps[i]->current_generation_size (max_generation)) > bgc_min_per_heap) ||
                     ((g_heaps[i]->current_generation_size (max_generation + 1)) > bgc_min_per_heap))
                 {
                     bgc_heap_too_small = FALSE;
@@ -16440,11 +16437,11 @@ int gc_heap::generation_to_condemn (int n_initial,
                 }
             }
 #else //MULTIPLE_HEAPS
-            if ((current_generation_size (max_generation) > bgc_min_per_heap) || 
+            if ((current_generation_size (max_generation) > bgc_min_per_heap) ||
                 (current_generation_size (max_generation + 1) > bgc_min_per_heap))
             {
                 bgc_heap_too_small = FALSE;
-            }            
+            }
 #endif //MULTIPLE_HEAPS
 
             if (bgc_heap_too_small)
@@ -16493,7 +16490,7 @@ exit:
         local_condemn_reasons->print (heap_number);
 #endif //DT_LOG
 
-        if ((local_settings->reason == reason_oos_soh) || 
+        if ((local_settings->reason == reason_oos_soh) ||
             (local_settings->reason == reason_oos_loh))
         {
             assert (n >= 1);
@@ -16511,14 +16508,14 @@ inline
 size_t gc_heap::min_reclaim_fragmentation_threshold (uint32_t num_heaps)
 {
     // if the memory load is higher, the threshold we'd want to collect gets lower.
-    size_t min_mem_based_on_available = 
+    size_t min_mem_based_on_available =
         (500 - (settings.entry_memory_load - high_memory_load_th) * 40) * 1024 * 1024 / num_heaps;
 
     size_t ten_percent_size = (size_t)((float)generation_size (max_generation) * 0.10);
     uint64_t three_percent_mem = mem_one_percent * 3 / num_heaps;
 
 #ifdef SIMPLE_DPRINTF
-    dprintf (GTC_LOG, ("min av: %Id, 10%% gen2: %Id, 3%% mem: %I64d", 
+    dprintf (GTC_LOG, ("min av: %Id, 10%% gen2: %Id, 3%% mem: %I64d",
         min_mem_based_on_available, ten_percent_size, three_percent_mem));
 #endif //SIMPLE_DPRINTF
     return (size_t)(min (min_mem_based_on_available, min (ten_percent_size, three_percent_mem)));
@@ -16555,9 +16552,9 @@ void gc_heap::init_background_gc ()
 
     if (heap_number == 0)
     {
-        dprintf (2, ("heap%d: bgc lowest: %Ix, highest: %Ix", 
+        dprintf (2, ("heap%d: bgc lowest: %Ix, highest: %Ix",
             heap_number,
-            background_saved_lowest_address, 
+            background_saved_lowest_address,
             background_saved_highest_address));
     }
 
@@ -16573,7 +16570,7 @@ void fire_drain_mark_list_event (size_t mark_list_objects)
 }
 
 inline
-void fire_revisit_event (size_t dirtied_pages, 
+void fire_revisit_event (size_t dirtied_pages,
                          size_t marked_objects,
                          BOOL large_objects_p)
 {
@@ -16583,7 +16580,7 @@ void fire_revisit_event (size_t dirtied_pages,
 inline
 void fire_overflow_event (uint8_t* overflow_min,
                           uint8_t* overflow_max,
-                          size_t marked_objects, 
+                          size_t marked_objects,
                           int large_objects_p)
 {
     FIRE_EVENT(BGCOverflow, (uint64_t)overflow_min, (uint64_t)overflow_max, marked_objects, large_objects_p);
@@ -16610,8 +16607,8 @@ void gc_heap::free_list_info (int gen_num, const char* msg)
     for (int i = 0; i <= (max_generation + 1); i++)
     {
         generation* gen = generation_of (i);
-        if ((generation_allocation_size (gen) == 0) && 
-            (generation_free_list_space (gen) == 0) && 
+        if ((generation_allocation_size (gen) == 0) &&
+            (generation_free_list_space (gen) == 0) &&
             (generation_free_obj_space (gen) == 0))
         {
             // don't print if everything is 0.
@@ -16619,9 +16616,9 @@ void gc_heap::free_list_info (int gen_num, const char* msg)
         else
         {
             dprintf (3, ("h%d: g%d: a-%Id, fl-%Id, fo-%Id",
-                heap_number, i, 
-                generation_allocation_size (gen), 
-                generation_free_list_space (gen), 
+                heap_number, i,
+                generation_allocation_size (gen),
+                generation_free_list_space (gen),
                 generation_free_obj_space (gen)));
         }
     }
@@ -16700,7 +16697,7 @@ void gc_heap::gc1()
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
     assert (g_gc_card_bundle_table == card_bundle_table);
-#endif    
+#endif
 
     {
         if (n == max_generation)
@@ -16712,7 +16709,7 @@ void gc_heap::gc1()
         {
             gc_low = generation_allocation_start (generation_of (n));
             gc_high = heap_segment_reserved (ephemeral_heap_segment);
-        }   
+        }
 #ifdef BACKGROUND_GC
         if (settings.concurrent)
         {
@@ -16731,7 +16728,7 @@ void gc_heap::gc1()
             concurrent_print_time_delta ("RW");
             background_mark_phase();
             free_list_info (max_generation, "after mark phase");
-            
+
             background_sweep();
             free_list_info (max_generation, "after sweep phase");
         }
@@ -16749,7 +16746,7 @@ void gc_heap::gc1()
     size_t end_gc_time = GetHighPrecisionTimeStamp();
 //    printf ("generation: %d, elapsed time: %Id\n", n,  end_gc_time - dd_time_clock (dynamic_data_of (0)));
 
-    //adjust the allocation size from the pinned quantities. 
+    //adjust the allocation size from the pinned quantities.
     for (int gen_number = 0; gen_number <= min (max_generation,n+1); gen_number++)
     {
         generation* gn = generation_of (gen_number);
@@ -16787,7 +16784,7 @@ void gc_heap::gc1()
 
         for (int gen_number = 0; gen_number < max_generation; gen_number++)
         {
-            dprintf (2, ("end of BGC: gen%d new_alloc: %Id", 
+            dprintf (2, ("end of BGC: gen%d new_alloc: %Id",
                          gen_number, dd_desired_allocation (dynamic_data_of (gen_number))));
             current_gc_data_per_heap->gen_data[gen_number].size_after = generation_size (gen_number);
             current_gc_data_per_heap->gen_data[gen_number].free_list_space_after = generation_free_list_space (generation_of (gen_number));
@@ -16819,7 +16816,7 @@ void gc_heap::gc1()
         get_gc_data_per_heap()->maxgen_size_info.running_free_list_efficiency = (uint32_t)(generation_allocator_efficiency (generation_of (max_generation)) * 100);
 
         free_list_info (max_generation, "after computing new dynamic data");
-        
+
         if (heap_number == 0)
         {
             size_t gc_elapsed_time = dd_gc_elapsed_time (dynamic_data_of (0));
@@ -16829,14 +16826,14 @@ void gc_heap::gc1()
 #endif //HEAP_BALANCE_INSTRUMENTATION
 
             dprintf (GTC_LOG, ("GC#%d(gen%d) took %Idms",
-                dd_collection_count (dynamic_data_of (0)), 
+                dd_collection_count (dynamic_data_of (0)),
                 settings.condemned_generation,
                 gc_elapsed_time));
         }
 
         for (int gen_number = 0; gen_number <= (max_generation + 1); gen_number++)
         {
-            dprintf (2, ("end of FGC/NGC: gen%d new_alloc: %Id", 
+            dprintf (2, ("end of FGC/NGC: gen%d new_alloc: %Id",
                          gen_number, dd_desired_allocation (dynamic_data_of (gen_number))));
         }
     }
@@ -16846,7 +16843,7 @@ void gc_heap::gc1()
         compute_promoted_allocation (1 + n);
 
         dynamic_data* dd = dynamic_data_of (1 + n);
-        size_t new_fragmentation = generation_free_list_space (generation_of (1 + n)) + 
+        size_t new_fragmentation = generation_free_list_space (generation_of (1 + n)) +
                                    generation_free_obj_space (generation_of (1 + n));
 
 #ifdef BACKGROUND_GC
@@ -16888,7 +16885,7 @@ void gc_heap::gc1()
         }
         else if (settings.condemned_generation == max_generation)
         {
-            if (full_gc_approach_event_set 
+            if (full_gc_approach_event_set
 #ifdef MULTIPLE_HEAPS
                 && (heap_number == 0)
 #endif //MULTIPLE_HEAPS
@@ -16902,7 +16899,7 @@ void gc_heap::gc1()
                 fgn_last_gc_was_concurrent = settings.concurrent ? TRUE : FALSE;
 #endif //BACKGROUND_GC
                 full_gc_end_event.Set();
-                full_gc_approach_event_set = false;            
+                full_gc_approach_event_set = false;
             }
         }
     }
@@ -16935,7 +16932,7 @@ void gc_heap::gc1()
 
 #ifdef GC_STATS
     if (GCStatistics::Enabled() && heap_number == 0)
-        g_GCStatistics.AddGCStats(settings, 
+        g_GCStatistics.AddGCStats(settings,
             dd_gc_elapsed_time(dynamic_data_of(settings.condemned_generation)));
 #endif // GC_STATS
 
@@ -16949,7 +16946,7 @@ void gc_heap::gc1()
 #endif //BACKGROUND_GC
 
 #if defined(VERIFY_HEAP) || (defined (FEATURE_EVENT_TRACE) && defined(BACKGROUND_GC))
-    if (FALSE 
+    if (FALSE
 #ifdef VERIFY_HEAP
         // Note that right now g_pConfig->GetHeapVerifyLevel always returns the same
         // value. If we ever allow randomly adjusting this as the process runs,
@@ -17091,7 +17088,7 @@ void gc_heap::gc1()
 
                 if (gen == 0)
                 {
-#if 1 //subsumed by the linear allocation model 
+#if 1 //subsumed by the linear allocation model
                     // to avoid spikes in mem usage due to short terms fluctuations in survivorship,
                     // apply some smoothing.
                     size_t smoothing = 3; // exponential smoothing factor
@@ -17121,7 +17118,7 @@ void gc_heap::gc1()
 #endif // BIT64
                     gc_data_global.final_youngest_desired = desired_per_heap;
                 }
-#if 1 //subsumed by the linear allocation model 
+#if 1 //subsumed by the linear allocation model
                 if (gen == (max_generation + 1))
                 {
                     // to avoid spikes in mem usage due to short terms fluctuations in survivorship,
@@ -17193,7 +17190,7 @@ void gc_heap::gc1()
     }
 
 #else
-    gc_data_global.final_youngest_desired = 
+    gc_data_global.final_youngest_desired =
         dd_desired_allocation (dynamic_data_of (0));
 
     check_loh_compact_mode (loh_compacted_p);
@@ -17219,7 +17216,7 @@ void gc_heap::save_data_for_no_gc()
 {
     current_no_gc_region_info.saved_pause_mode = settings.pause_mode;
 #ifdef MULTIPLE_HEAPS
-    // This is to affect heap balancing. 
+    // This is to affect heap balancing.
     for (int i = 0; i < n_heaps; i++)
     {
         current_no_gc_region_info.saved_gen0_min_size = dd_min_size (g_heaps[i]->dynamic_data_of (0));
@@ -17243,7 +17240,7 @@ void gc_heap::restore_data_for_no_gc()
 }
 
 start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size,
-                                                             BOOL loh_size_known, 
+                                                             BOOL loh_size_known,
                                                              uint64_t loh_size,
                                                              BOOL disallow_full_blocking)
 {
@@ -17396,7 +17393,7 @@ BOOL gc_heap::find_loh_free_for_no_gc()
                     return TRUE;
                 }
 
-                free_list = free_list_slot (free_list); 
+                free_list = free_list_slot (free_list);
             }
         }
         sz_list = sz_list * 2;
@@ -17444,7 +17441,7 @@ BOOL gc_heap::loh_allocated_for_no_gc()
         return FALSE;
 
     heap_segment* seg = generation_allocation_segment (generation_of (max_generation + 1));
-    do 
+    do
     {
         if (seg == saved_loh_segment_no_gc)
         {
@@ -17481,7 +17478,7 @@ void gc_heap::thread_no_gc_loh_segments()
         thread_loh_segment (saved_loh_segment_no_gc);
         saved_loh_segment_no_gc = 0;
     }
-#endif //MULTIPLE_HEAPS    
+#endif //MULTIPLE_HEAPS
 }
 
 void gc_heap::set_loh_allocations_for_no_gc()
@@ -17581,7 +17578,7 @@ BOOL gc_heap::should_proceed_for_no_gc()
 
     if (!soh_full_gc_requested && current_no_gc_region_info.loh_allocation_size)
     {
-        // Check to see if we have enough reserved space. 
+        // Check to see if we have enough reserved space.
 #ifdef MULTIPLE_HEAPS
         for (int i = 0; i < n_heaps; i++)
         {
@@ -17712,8 +17709,8 @@ BOOL gc_heap::expand_soh_with_minimal_gc()
         }
 
         // We do need to clear the bricks here as we are converting a bunch of ephemeral objects to gen2
-        // and need to make sure that there are no left over bricks from the previous GCs for the space 
-        // we just used for gen0 allocation. We will need to go through the bricks for these objects for 
+        // and need to make sure that there are no left over bricks from the previous GCs for the space
+        // we just used for gen0 allocation. We will need to go through the bricks for these objects for
         // ephemeral GCs later.
         for (size_t b = brick_of (generation_allocation_start (generation_of (0)));
              b < brick_of (align_on_brick (heap_segment_allocated (ephemeral_heap_segment)));
@@ -17722,7 +17719,7 @@ BOOL gc_heap::expand_soh_with_minimal_gc()
             set_brick (b, -1);
         }
 
-        size_t ephemeral_size = (heap_segment_allocated (ephemeral_heap_segment) - 
+        size_t ephemeral_size = (heap_segment_allocated (ephemeral_heap_segment) -
                                 generation_allocation_start (generation_of (max_generation - 1)));
         heap_segment_next (ephemeral_heap_segment) = new_seg;
         ephemeral_heap_segment = new_seg;
@@ -17807,7 +17804,7 @@ void gc_heap::allocate_for_no_gc_after_gc()
         }
 
         if ((current_no_gc_region_info.start_status == start_no_gc_success) &&
-            !(current_no_gc_region_info.minimal_gc_p) && 
+            !(current_no_gc_region_info.minimal_gc_p) &&
             (current_no_gc_region_info.loh_allocation_size != 0))
         {
             gc_policy = policy_compact;
@@ -17903,9 +17900,9 @@ void gc_heap::allocate_for_no_gc_after_gc()
 
 void gc_heap::init_records()
 {
-    // An option is to move this to be after we figure out which gen to condemn so we don't 
-    // need to clear some generations' data 'cause we know they don't change, but that also means 
-    // we can't simply call memset here. 
+    // An option is to move this to be after we figure out which gen to condemn so we don't
+    // need to clear some generations' data 'cause we know they don't change, but that also means
+    // we can't simply call memset here.
     memset (&gc_data_per_heap, 0, sizeof (gc_data_per_heap));
     gc_data_per_heap.heap_index = heap_number;
     if (heap_number == 0)
@@ -17952,7 +17949,7 @@ void gc_heap::pm_full_gc_init_or_clear()
             settings.condemned_generation = max_generation;
             settings.entry_memory_load = saved_entry_memory_load;
             // Can't assert this since we only check at the end of gen2 GCs,
-            // during gen1 the memory load could have already dropped. 
+            // during gen1 the memory load could have already dropped.
             // Although arguably we should just turn off PM then...
             //assert (settings.entry_memory_load >= high_memory_load_th);
             assert (settings.entry_memory_load > 0);
@@ -18041,9 +18038,9 @@ void gc_heap::garbage_collect (int n)
 #ifdef MULTIPLE_HEAPS
     //align all heaps on the max generation to condemn
     dprintf (3, ("Joining for max generation to condemn"));
-    condemned_generation_num = generation_to_condemn (n, 
-                                                    &blocking_collection, 
-                                                    &elevation_requested, 
+    condemned_generation_num = generation_to_condemn (n,
+                                                    &blocking_collection,
+                                                    &elevation_requested,
                                                     FALSE);
     gc_t_join.join(this, gc_join_generation_determined);
     if (gc_t_join.joined())
@@ -18098,9 +18095,9 @@ void gc_heap::garbage_collect (int n)
 
     settings.condemned_generation = gen_max;
 #else //MULTIPLE_HEAPS
-    settings.condemned_generation = generation_to_condemn (n, 
-                                                        &blocking_collection, 
-                                                        &elevation_requested, 
+    settings.condemned_generation = generation_to_condemn (n,
+                                                        &blocking_collection,
+                                                        &elevation_requested,
                                                         FALSE);
     should_evaluate_elevation = elevation_requested;
     should_do_blocking_collection = blocking_collection;
@@ -18114,7 +18111,7 @@ void gc_heap::garbage_collect (int n)
                                         STRESS_HEAP_ARG(n)
                                         );
 
-    STRESS_LOG1(LF_GCROOTS|LF_GC|LF_GCALLOC, LL_INFO10, 
+    STRESS_LOG1(LF_GCROOTS|LF_GC|LF_GCALLOC, LL_INFO10,
             "condemned generation num: %d\n", settings.condemned_generation);
 
     record_gcs_during_no_gc();
@@ -18148,7 +18145,7 @@ void gc_heap::garbage_collect (int n)
         if ((settings.condemned_generation == max_generation) &&
             (should_do_blocking_collection == FALSE) &&
             gc_can_use_concurrent &&
-            !temp_disable_concurrent_p &&                 
+            !temp_disable_concurrent_p &&
             ((settings.pause_mode == pause_interactive) || (settings.pause_mode == pause_sustained_low_latency)))
         {
             keep_bgc_threads_p = TRUE;
@@ -18166,7 +18163,7 @@ void gc_heap::garbage_collect (int n)
         // Call the EE for start of GC work
         // just one thread for MP GC
         GCToEEInterface::GcStartWork (settings.condemned_generation,
-                                max_generation);            
+                                max_generation);
 
         // TODO: we could fire an ETW event to say this GC as a concurrent GC but later on due to not being able to
         // create threads or whatever, this could be a non concurrent GC. Maybe for concurrent GC we should fire
@@ -18269,13 +18266,13 @@ void gc_heap::garbage_collect (int n)
 #endif //MULTIPLE_HEAPS
 
                 int gen = check_for_ephemeral_alloc();
-                // always do a gen1 GC before we start BGC. 
+                // always do a gen1 GC before we start BGC.
                 // This is temporary for testing purpose.
                 //int gen = max_generation - 1;
                 dont_restart_ee_p = TRUE;
                 if (gen == -1)
                 {
-                    // If we decide to not do a GC before the BGC we need to 
+                    // If we decide to not do a GC before the BGC we need to
                     // restore the gen0 alloc context.
 #ifdef MULTIPLE_HEAPS
                     for (int i = 0; i < n_heaps; i++)
@@ -18414,7 +18411,7 @@ heap_segment* gc_heap::find_segment (uint8_t* interior, BOOL small_segment_only_
         if (hs)
         {
             break;
-        }        
+        }
     }
 #else
     {
@@ -18781,7 +18778,7 @@ BOOL gc_heap::background_mark1 (uint8_t* o)
         return FALSE;
 }
 
-// TODO: we could consider filtering out NULL's here instead of going to 
+// TODO: we could consider filtering out NULL's here instead of going to
 // look for it on other heaps
 inline
 BOOL gc_heap::background_mark (uint8_t* o, uint8_t* low, uint8_t* high)
@@ -18880,7 +18877,7 @@ uint8_t* gc_heap::next_end (heap_segment* seg, uint8_t* f)
 #define go_through_object_nostart(mt,o,size,parm,exp) {go_through_object(mt,o,size,parm,o,ignore_start,(o + size),exp); }
 
 // 1 thing to note about this macro:
-// 1) you can use *parm safely but in general you don't want to use parm 
+// 1) you can use *parm safely but in general you don't want to use parm
 // because for the collectible types it's not an address on the managed heap.
 #ifndef COLLECTIBLE_CLASS
 #define go_through_object_cl(mt,o,size,parm,exp)                            \
@@ -18908,7 +18905,7 @@ uint8_t* gc_heap::next_end (heap_segment* seg, uint8_t* f)
 
 // This starts a plug. But mark_stack_tos isn't increased until set_pinned_info is called.
 void gc_heap::enque_pinned_plug (uint8_t* plug,
-                                 BOOL save_pre_plug_info_p, 
+                                 BOOL save_pre_plug_info_p,
                                  uint8_t* last_object_in_last_plug)
 {
     if (mark_stack_array_length <= mark_stack_tos)
@@ -18923,7 +18920,7 @@ void gc_heap::enque_pinned_plug (uint8_t* plug,
         }
     }
 
-    dprintf (3, ("enqueuing P #%Id(%Ix): %Ix. oldest: %Id, LO: %Ix, pre: %d", 
+    dprintf (3, ("enqueuing P #%Id(%Ix): %Ix. oldest: %Id, LO: %Ix, pre: %d",
         mark_stack_tos, &mark_stack_array[mark_stack_tos], plug, mark_stack_bos, last_object_in_last_plug, (save_pre_plug_info_p ? 1 : 0)));
     mark& m = mark_stack_array[mark_stack_tos];
     m.first = plug;
@@ -18954,9 +18951,9 @@ void gc_heap::enque_pinned_plug (uint8_t* plug,
             if (is_padded)
                 record_interesting_data_point (idp_pre_short_padded);
 #endif //SHORT_PLUGS
-            dprintf (3, ("encountered a short object %Ix right before pinned plug %Ix!", 
+            dprintf (3, ("encountered a short object %Ix right before pinned plug %Ix!",
                          last_object_in_last_plug, plug));
-            // Need to set the short bit regardless of having refs or not because we need to 
+            // Need to set the short bit regardless of having refs or not because we need to
             // indicate that this object is not walkable.
             m.set_pre_short();
 
@@ -19080,7 +19077,7 @@ VOLATILE(uint8_t*)& gc_heap::ref_mark_stack (gc_heap* hp, int index)
 #define stolen 2
 #define partial 1
 #define partial_object 3
-inline 
+inline
 uint8_t* ref_from_slot (uint8_t* r)
 {
     return (uint8_t*)((size_t)r & ~(stolen | partial));
@@ -19090,7 +19087,7 @@ BOOL stolen_p (uint8_t* r)
 {
     return (((size_t)r&2) && !((size_t)r&1));
 }
-inline 
+inline
 BOOL ready_p (uint8_t* r)
 {
     return ((size_t)r != 1);
@@ -19100,12 +19097,12 @@ BOOL partial_p (uint8_t* r)
 {
     return (((size_t)r&1) && !((size_t)r&2));
 }
-inline 
+inline
 BOOL straight_ref_p (uint8_t* r)
 {
     return (!stolen_p (r) && !partial_p (r));
 }
-inline 
+inline
 BOOL partial_object_p (uint8_t* r)
 {
     return (((size_t)r & partial_object) == partial_object);
@@ -19125,7 +19122,7 @@ void gc_heap::mark_object_simple1 (uint8_t* oo, uint8_t* start THREAD_NUMBER_DCL
     SERVER_SC_MARK_VOLATILE(uint8_t*)* sorted_tos = mark_stack_base;
 #endif //SORT_MARK_STACK
 
-    // If we are doing a full GC we don't use mark list anyway so use m_boundary_fullgc that doesn't 
+    // If we are doing a full GC we don't use mark list anyway so use m_boundary_fullgc that doesn't
     // update mark list.
     BOOL  full_p = (settings.condemned_generation == max_generation);
 
@@ -19144,7 +19141,7 @@ void gc_heap::mark_object_simple1 (uint8_t* oo, uint8_t* start THREAD_NUMBER_DCL
 
         if (oo && ((size_t)oo != 4))
         {
-            size_t s = 0; 
+            size_t s = 0;
             if (stolen_p (oo))
             {
                 --mark_stack_tos;
@@ -19162,7 +19159,7 @@ void gc_heap::mark_object_simple1 (uint8_t* oo, uint8_t* start THREAD_NUMBER_DCL
                         overflow_p = TRUE;
                     }
                 }
-                
+
                 if (overflow_p == FALSE)
                 {
                     dprintf(3,("pushing mark for %Ix ", (size_t)oo));
@@ -19230,7 +19227,7 @@ void gc_heap::mark_object_simple1 (uint8_t* oo, uint8_t* start THREAD_NUMBER_DCL
                             promoted_bytes (thread) += obj_size;
                             *(mark_stack_tos++) = class_obj;
                             // The code below expects that the oo is still stored in the stack slot that was
-                            // just popped and it "pushes" it back just by incrementing the mark_stack_tos. 
+                            // just popped and it "pushes" it back just by incrementing the mark_stack_tos.
                             // But the class_obj has just overwritten that stack slot and so the oo needs to
                             // be stored to the new slot that's pointed to by the mark_stack_tos.
                             *mark_stack_tos = oo;
@@ -19245,9 +19242,9 @@ void gc_heap::mark_object_simple1 (uint8_t* oo, uint8_t* start THREAD_NUMBER_DCL
 #endif //COLLECTIBLE_CLASS
 
                 s = size (oo);
-                
+
                 BOOL overflow_p = FALSE;
-            
+
                 if (mark_stack_tos + (num_partial_refs + 2)  >= mark_stack_limit)
                 {
                     overflow_p = TRUE;
@@ -19256,14 +19253,14 @@ void gc_heap::mark_object_simple1 (uint8_t* oo, uint8_t* start THREAD_NUMBER_DCL
                 {
                     dprintf(3,("pushing mark for %Ix ", (size_t)oo));
 
-                    //push the object and its current 
+                    //push the object and its current
                     SERVER_SC_MARK_VOLATILE(uint8_t*)* place = ++mark_stack_tos;
                     mark_stack_tos++;
 #ifdef MH_SC_MARK
                     *(place-1) = 0;
                     *(place) = (uint8_t*)partial;
 #endif //MH_SC_MARK
-                    int i = num_partial_refs; 
+                    int i = num_partial_refs;
                     uint8_t* ref_to_continue = 0;
 
                     go_through_object (method_table(oo), oo, s, ppslot,
@@ -19304,7 +19301,7 @@ void gc_heap::mark_object_simple1 (uint8_t* oo, uint8_t* start THREAD_NUMBER_DCL
 #else //MH_SC_MARK
                     *(place-1) = 0;
 #endif //MH_SC_MARK
-                    *place = 0; 
+                    *place = 0;
                     // shouldn't we decrease tos by 2 here??
 
 more_to_do:
@@ -19367,7 +19364,7 @@ int find_next_buddy_heap (int this_heap_number, int current_buddy, int n_heaps)
     return current_buddy;
 }
 
-void 
+void
 gc_heap::mark_steal()
 {
     mark_stack_busy() = 0;
@@ -19385,21 +19382,21 @@ gc_heap::mark_steal()
         uint32_t begin_tick = GCToOSInterface::GetLowPrecisionTimeStamp();
 #endif //SNOOP_STATS
 
-    int idle_loop_count = 0; 
+    int idle_loop_count = 0;
     int first_not_ready_level = 0;
 
     while (1)
     {
         gc_heap* hp = g_heaps [thpn];
         int level = first_not_ready_level;
-        first_not_ready_level = 0; 
+        first_not_ready_level = 0;
 
         while (check_next_mark_stack (hp) && (level < (max_snoop_level-1)))
         {
-            idle_loop_count = 0; 
+            idle_loop_count = 0;
 #ifdef SNOOP_STATS
             snoop_stat.busy_count++;
-            dprintf (SNOOP_LOG, ("heap%d: looking at next heap level %d stack contents: %Ix", 
+            dprintf (SNOOP_LOG, ("heap%d: looking at next heap level %d stack contents: %Ix",
                                  heap_number, level, (int)((uint8_t**)(hp->mark_stack_array))[level]));
 #endif //SNOOP_STATS
 
@@ -19458,7 +19455,7 @@ gc_heap::mark_steal()
                         snoop_stat.interlocked_count++;
                         if (success)
                         {
-                            snoop_stat.partial_mark_parent_count++;                    
+                            snoop_stat.partial_mark_parent_count++;
                         }
 #endif //SNOOP_STATS
                     }
@@ -19474,7 +19471,7 @@ gc_heap::mark_steal()
                         level+=2;
 #ifdef SNOOP_STATS
                         snoop_stat.pm_not_ready_count++;
-#endif //SNOOP_STATS                        
+#endif //SNOOP_STATS
                     }
                 }
                 if (success)
@@ -19509,7 +19506,7 @@ gc_heap::mark_steal()
                         }
                     }
 
-                    level = 0; 
+                    level = 0;
                 }
                 mark_stack_busy() = 0;
             }
@@ -19522,10 +19519,10 @@ gc_heap::mark_steal()
         if ((first_not_ready_level != 0) && hp->mark_stack_busy())
         {
             continue;
-        } 
+        }
         if (!hp->mark_stack_busy())
         {
-            first_not_ready_level = 0; 
+            first_not_ready_level = 0;
             idle_loop_count++;
 
             if ((idle_loop_count % (6) )==1)
@@ -19578,7 +19575,7 @@ BOOL gc_heap::check_next_mark_stack (gc_heap* next_heap)
 #ifdef SNOOP_STATS
 void gc_heap::print_snoop_stat()
 {
-    dprintf (1234, ("%4s | %8s | %8s | %8s | %8s | %8s | %8s | %8s", 
+    dprintf (1234, ("%4s | %8s | %8s | %8s | %8s | %8s | %8s | %8s",
         "heap", "check", "zero", "mark", "stole", "pstack", "nstack", "nonsk"));
     dprintf (1234, ("%4d | %8d | %8d | %8d | %8d | %8d | %8d | %8d",
         snoop_stat.heap_index,
@@ -19589,7 +19586,7 @@ void gc_heap::print_snoop_stat()
         snoop_stat.partial_stack_count,
         snoop_stat.normal_stack_count,
         snoop_stat.non_stack_count));
-    dprintf (1234, ("%4s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s", 
+    dprintf (1234, ("%4s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s",
         "heap", "level", "busy", "xchg", "pmparent", "s_pm", "stolen", "nready", "clear"));
     dprintf (1234, ("%4d | %8d | %8d | %8d | %8d | %8d | %8d | %8d | %8d | %8d\n",
         snoop_stat.heap_index,
@@ -19603,7 +19600,7 @@ void gc_heap::print_snoop_stat()
         snoop_stat.normal_count,
         snoop_stat.stack_bottom_clear_count));
 
-    printf ("\n%4s | %8s | %8s | %8s | %8s | %8s\n", 
+    printf ("\n%4s | %8s | %8s | %8s | %8s | %8s\n",
         "heap", "check", "zero", "mark", "idle", "switch");
     printf ("%4d | %8d | %8d | %8d | %8d | %8d\n",
         snoop_stat.heap_index,
@@ -19612,7 +19609,7 @@ void gc_heap::print_snoop_stat()
         snoop_stat.objects_marked_count,
         snoop_stat.stack_idle_count,
         snoop_stat.switch_to_thread_count);
-    printf ("%4s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s\n", 
+    printf ("%4s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s\n",
         "heap", "level", "busy", "xchg", "pmparent", "s_pm", "stolen", "nready", "normal", "clear");
     printf ("%4d | %8d | %8d | %8d | %8d | %8d | %8d | %8d | %8d | %8d\n",
         snoop_stat.heap_index,
@@ -19674,7 +19671,7 @@ gc_heap::ha_mark_object_simple (uint8_t** po THREAD_NUMBER_DCL)
         PREFIX_ASSUME(internal_root_array_index < internal_root_array_length);
 
         uint8_t* ref = (uint8_t*)po;
-        if (!current_obj || 
+        if (!current_obj ||
             !((ref >= current_obj) && (ref < (current_obj + current_obj_size))))
         {
             gc_heap* hp = gc_heap::heap_of (ref);
@@ -19768,28 +19765,28 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
 #endif //MULTIPLE_HEAPS
         if (oo)
         {
-            size_t s = 0; 
+            size_t s = 0;
             if ((((size_t)oo & 1) == 0) && ((s = size (oo)) < (partial_size_th*sizeof (uint8_t*))))
             {
                 BOOL overflow_p = FALSE;
-            
+
                 if (background_mark_stack_tos + (s) /sizeof (uint8_t*) >= (mark_stack_limit - 1))
                 {
                     size_t num_components = ((method_table(oo))->HasComponentSize() ? ((CObjectHeader*)oo)->GetNumComponents() : 0);
                     size_t num_pointers = CGCDesc::GetNumPointers(method_table(oo), s, num_components);
                     if (background_mark_stack_tos + num_pointers >= (mark_stack_limit - 1))
                     {
-                        dprintf (2, ("h%d: %Id left, obj (mt: %Ix) %Id ptrs", 
+                        dprintf (2, ("h%d: %Id left, obj (mt: %Ix) %Id ptrs",
                             heap_number,
                             (size_t)(mark_stack_limit - 1 - background_mark_stack_tos),
-                            method_table(oo), 
+                            method_table(oo),
                             num_pointers));
 
                         bgc_overflow_count++;
                         overflow_p = TRUE;
                     }
                 }
-            
+
                 if (overflow_p == FALSE)
                 {
                     dprintf(3,("pushing mark for %Ix ", (size_t)oo));
@@ -19798,8 +19795,8 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
                     {
                         uint8_t* o = *ppslot;
                         Prefetch(o);
-                        if (background_mark (o, 
-                                             background_saved_lowest_address, 
+                        if (background_mark (o,
+                                             background_saved_lowest_address,
                                              background_saved_highest_address))
                         {
                             //m_boundary (o);
@@ -19821,7 +19818,7 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
                     background_max_overflow_address = max (background_max_overflow_address, oo);
                 }
             }
-            else 
+            else
             {
                 uint8_t* start = oo;
                 if ((size_t)oo & 1)
@@ -19838,8 +19835,8 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
                     if (is_collectible (oo))
                     {
                         uint8_t* class_obj = get_class_object (oo);
-                        if (background_mark (class_obj, 
-                                            background_saved_lowest_address, 
+                        if (background_mark (class_obj,
+                                            background_saved_lowest_address,
                                             background_saved_highest_address))
                         {
                             size_t obj_size = size (class_obj);
@@ -19852,24 +19849,24 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
                     if (!contain_pointers (oo))
                     {
                         goto next_level;
-                    }                    
+                    }
                 }
 #endif //COLLECTIBLE_CLASS
 
                 s = size (oo);
-                
+
                 BOOL overflow_p = FALSE;
-            
+
                 if (background_mark_stack_tos + (num_partial_refs + 2)  >= mark_stack_limit)
                 {
                     size_t num_components = ((method_table(oo))->HasComponentSize() ? ((CObjectHeader*)oo)->GetNumComponents() : 0);
                     size_t num_pointers = CGCDesc::GetNumPointers(method_table(oo), s, num_components);
 
-                    dprintf (2, ("h%d: PM: %Id left, obj %Ix (mt: %Ix) start: %Ix, total: %Id", 
+                    dprintf (2, ("h%d: PM: %Id left, obj %Ix (mt: %Ix) start: %Ix, total: %Id",
                         heap_number,
                         (size_t)(mark_stack_limit - background_mark_stack_tos),
                         oo,
-                        method_table(oo), 
+                        method_table(oo),
                         start,
                         num_pointers));
 
@@ -19880,12 +19877,12 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
                 {
                     dprintf(3,("pushing mark for %Ix ", (size_t)oo));
 
-                    //push the object and its current 
+                    //push the object and its current
                     uint8_t** place = background_mark_stack_tos++;
                     *(place) = start;
                     *(background_mark_stack_tos++) = (uint8_t*)((size_t)oo | 1);
 
-                    int i = num_partial_refs; 
+                    int i = num_partial_refs;
 
                     go_through_object (method_table(oo), oo, s, ppslot,
                                        start, use_start, (oo + s),
@@ -19893,8 +19890,8 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
                         uint8_t* o = *ppslot;
                         Prefetch(o);
 
-                        if (background_mark (o, 
-                                            background_saved_lowest_address, 
+                        if (background_mark (o,
+                                            background_saved_lowest_address,
                                             background_saved_highest_address))
                         {
                             //m_boundary (o);
@@ -19916,7 +19913,7 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
                     }
                         );
                     //we are finished with this object
-                    *place = 0; 
+                    *place = 0;
                     *(place+1) = 0;
 
                 more_to_do:;
@@ -19973,7 +19970,7 @@ gc_heap::background_mark_simple (uint8_t* o THREAD_NUMBER_DCL)
 #endif //MULTIPLE_HEAPS
     {
         dprintf (3, ("bmarking %Ix", o));
-        
+
         if (background_mark1 (o))
         {
             //m_boundary (o);
@@ -20178,7 +20175,7 @@ void gc_heap::background_mark_through_object (uint8_t* oo THREAD_NUMBER_DCL)
                           }
             );
 
-        dprintf (3,("Background marking through %Ix went through %Id refs", 
+        dprintf (3,("Background marking through %Ix went through %Id refs",
                           (size_t)oo,
                            total_refs));
     }
@@ -20188,7 +20185,7 @@ uint8_t* gc_heap::background_seg_end (heap_segment* seg, BOOL concurrent_p)
 {
     if (concurrent_p && (seg == saved_overflow_ephemeral_seg))
     {
-        // for now we stop at where gen1 started when we started processing 
+        // for now we stop at where gen1 started when we started processing
         return background_min_soh_overflow_address;
     }
     else
@@ -20199,7 +20196,7 @@ uint8_t* gc_heap::background_seg_end (heap_segment* seg, BOOL concurrent_p)
 
 uint8_t* gc_heap::background_first_overflow (uint8_t* min_add,
                                           heap_segment* seg,
-                                          BOOL concurrent_p, 
+                                          BOOL concurrent_p,
                                           BOOL small_object_p)
 {
     uint8_t* o = 0;
@@ -20211,7 +20208,7 @@ uint8_t* gc_heap::background_first_overflow (uint8_t* min_add,
             // min_add was the beginning of gen1 when we did the concurrent
             // overflow. Now we could be in a situation where min_add is
             // actually the same as allocated for that segment (because
-            // we expanded heap), in which case we can not call 
+            // we expanded heap), in which case we can not call
             // find first on this address or we will AV.
             if (min_add >= heap_segment_allocated (seg))
             {
@@ -20219,7 +20216,7 @@ uint8_t* gc_heap::background_first_overflow (uint8_t* min_add,
             }
             else
             {
-                if (concurrent_p && 
+                if (concurrent_p &&
                     ((seg == saved_overflow_ephemeral_seg) && (min_add >= background_min_soh_overflow_address)))
                 {
                     return background_min_soh_overflow_address;
@@ -20277,8 +20274,8 @@ void gc_heap::background_process_mark_overflow_internal (int condemned_gen_numbe
         loh_alloc_lock = hp->bgc_alloc_lock;
 
         uint8_t* o = hp->background_first_overflow (min_add,
-                                                    seg, 
-                                                    concurrent_p, 
+                                                    seg,
+                                                    concurrent_p,
                                                     small_object_segments);
 
         while (1)
@@ -20329,7 +20326,7 @@ void gc_heap::background_process_mark_overflow_internal (int condemned_gen_numbe
                 }
             }
 
-            dprintf (2, ("went through overflow objects in segment %Ix (%d) (so far %Id marked)", 
+            dprintf (2, ("went through overflow objects in segment %Ix (%d) (so far %Id marked)",
                 heap_segment_mem (seg), (small_object_segments ? 0 : 1), total_marked_objects));
 
             if ((concurrent_p && (seg == hp->saved_overflow_ephemeral_seg)) ||
@@ -20361,12 +20358,12 @@ void gc_heap::background_process_mark_overflow_internal (int condemned_gen_numbe
                     fire_overflow_event (min_add, max_add, total_marked_objects, !small_object_segments);
                     break;
                 }
-            } 
+            }
             else
             {
-                o = hp->background_first_overflow (min_add, 
-                                                   seg, 
-                                                   concurrent_p, 
+                o = hp->background_first_overflow (min_add,
+                                                   seg,
+                                                   concurrent_p,
                                                    small_object_segments);
                 continue;
             }
@@ -20386,7 +20383,7 @@ BOOL gc_heap::background_process_mark_overflow (BOOL concurrent_p)
             (background_min_overflow_address != MAX_PTR))
         {
             // We have overflow to process but we know we can't process the ephemeral generations
-            // now (we actually could process till the current gen1 start but since we are going to 
+            // now (we actually could process till the current gen1 start but since we are going to
             // make overflow per segment, for now I'll just stop at the saved gen1 start.
             saved_overflow_ephemeral_seg = ephemeral_heap_segment;
             background_max_soh_overflow_address = heap_segment_reserved (saved_overflow_ephemeral_seg);
@@ -20395,13 +20392,13 @@ BOOL gc_heap::background_process_mark_overflow (BOOL concurrent_p)
     }
     else
     {
-        assert ((saved_overflow_ephemeral_seg == 0) || 
+        assert ((saved_overflow_ephemeral_seg == 0) ||
                 ((background_max_soh_overflow_address != 0) &&
                  (background_min_soh_overflow_address != MAX_PTR)));
-        
+
         if (!processed_soh_overflow_p)
         {
-            // if there was no more overflow we just need to process what we didn't process 
+            // if there was no more overflow we just need to process what we didn't process
             // on the saved ephemeral segment.
             if ((background_max_overflow_address == 0) && (background_min_overflow_address == MAX_PTR))
             {
@@ -20409,7 +20406,7 @@ BOOL gc_heap::background_process_mark_overflow (BOOL concurrent_p)
                 grow_mark_array_p = FALSE;
             }
 
-            background_min_overflow_address = min (background_min_overflow_address, 
+            background_min_overflow_address = min (background_min_overflow_address,
                                                 background_min_soh_overflow_address);
             background_max_overflow_address = max (background_max_overflow_address,
                                                 background_max_soh_overflow_address);
@@ -20436,7 +20433,7 @@ recheck:
                 new_size = min(new_max_size, new_size);
             }
 
-            if ((background_mark_stack_array_length < new_size) && 
+            if ((background_mark_stack_array_length < new_size) &&
                 ((new_size - background_mark_stack_array_length) > (background_mark_stack_array_length / 2)))
             {
                 dprintf (2, ("h%d: ov grow to %Id", heap_number, new_size));
@@ -20464,7 +20461,7 @@ recheck:
 
         background_process_mark_overflow_internal (max_generation, min_add, max_add, concurrent_p);
         if (!concurrent_p)
-        {        
+        {
             goto recheck;
         }
     }
@@ -20648,7 +20645,7 @@ size_t gc_heap::committed_size (bool loh_p, size_t* allocated)
     return total_committed;
 }
 
-void gc_heap::get_memory_info (uint32_t* memory_load, 
+void gc_heap::get_memory_info (uint32_t* memory_load,
                                uint64_t* available_physical,
                                uint64_t* available_page_file)
 {
@@ -20682,7 +20679,7 @@ recheck:
             new_size = min(new_max_size, new_size);
         }
 
-        if ((mark_stack_array_length < new_size) && 
+        if ((mark_stack_array_length < new_size) &&
             ((new_size - mark_stack_array_length) > (mark_stack_array_length / 2)))
         {
             mark* tmp = new (nothrow) mark [new_size];
@@ -20732,7 +20729,7 @@ void gc_heap::process_mark_overflow_internal (int condemned_gen_number,
         int align_const = get_alignment_constant (small_object_segments);
         generation* gen = hp->generation_of (condemned_gen_number);
         heap_segment* seg = heap_segment_in_range (generation_start_segment (gen));
-        
+
         PREFIX_ASSUME(seg != NULL);
         uint8_t*  o = max (heap_segment_mem (seg), min_add);
         while (1)
@@ -20767,8 +20764,8 @@ void gc_heap::process_mark_overflow_internal (int condemned_gen_number,
                 else
                 {
                     break;
-                } 
-            } 
+                }
+            }
             else
             {
                 o = max (heap_segment_mem (seg), min_add);
@@ -20980,7 +20977,7 @@ void gc_heap::mark_phase (int condemned_gen_number, BOOL mark_only_p)
     for (int gen_idx = 0; gen_idx <= gen_to_init; gen_idx++)
     {
         dynamic_data* dd = dynamic_data_of (gen_idx);
-        dd_begin_data_size (dd) = generation_size (gen_idx) - 
+        dd_begin_data_size (dd) = generation_size (gen_idx) -
                                    dd_fragmentation (dd) -
                                    Align (size (generation_allocation_start (generation_of (gen_idx))));
         dprintf (2, ("begin data size for gen%d is %Id", gen_idx, dd_begin_data_size (dd)));
@@ -21027,7 +21024,7 @@ void gc_heap::mark_phase (int condemned_gen_number, BOOL mark_only_p)
 #ifdef MH_SC_MARK
     static BOOL do_mark_steal_p = FALSE;
 #endif //MH_SC_MARK
-    
+
 #ifdef FEATURE_CARD_MARKING_STEALING
     reset_card_marking_enumerators();
 #endif // FEATURE_CARD_MARKING_STEALING
@@ -21110,7 +21107,7 @@ void gc_heap::mark_phase (int condemned_gen_number, BOOL mark_only_p)
             }
 #endif //MULTIPLE_HEAPS
         }
-    
+
         dprintf(3,("Marking Roots"));
 
         GCScan::GcScanRoots(GCHeap::Promote,
@@ -21231,7 +21228,7 @@ void gc_heap::mark_phase (int condemned_gen_number, BOOL mark_only_p)
             }
 #endif // MULTIPLE_HEAPS && FEATURE_CARD_MARKING_STEALING
 
-            dprintf (3, ("marked by cards: %Id", 
+            dprintf (3, ("marked by cards: %Id",
                 (promoted_bytes (heap_number) - promoted_before_cards)));
             fire_mark_event (heap_number, ETW::GC_ROOT_OLDER, (promoted_bytes (heap_number) - last_promoted_bytes));
             last_promoted_bytes = promoted_bytes (heap_number);
@@ -21393,9 +21390,9 @@ void gc_heap::mark_phase (int condemned_gen_number, BOOL mark_only_p)
             size_t busy_count = 0;
             size_t interlocked_count = 0;
             size_t partial_mark_parent_count = 0;
-            size_t stolen_or_pm_count = 0; 
-            size_t stolen_entry_count = 0; 
-            size_t pm_not_ready_count = 0; 
+            size_t stolen_or_pm_count = 0;
+            size_t stolen_entry_count = 0;
+            size_t pm_not_ready_count = 0;
             size_t normal_count = 0;
             size_t stack_bottom_clear_count = 0;
 
@@ -21420,7 +21417,7 @@ void gc_heap::mark_phase (int condemned_gen_number, BOOL mark_only_p)
             fflush (stdout);
 
             printf ("-------total stats-------\n");
-            printf ("%8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s\n", 
+            printf ("%8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s | %8s\n",
                 "checked", "zero", "marked", "level", "busy", "xchg", "pmparent", "s_pm", "stolen", "nready", "normal", "clear");
             printf ("%8d | %8d | %8d | %8d | %8d | %8d | %8d | %8d | %8d | %8d | %8d | %8d\n",
                 objects_checked_count,
@@ -21503,7 +21500,7 @@ void gc_heap::pin_object (uint8_t* o, uint8_t** ppObject, uint8_t* low, uint8_t*
         dprintf(3,("^%Ix^", (size_t)o));
         set_pinned (o);
 
-#ifdef FEATURE_EVENT_TRACE        
+#ifdef FEATURE_EVENT_TRACE
         if(EVENT_ENABLED(PinObjectAtGCTime))
         {
             fire_etw_pin_object_event(o, ppObject);
@@ -21760,8 +21757,8 @@ uint8_t* gc_heap::insert_node (uint8_t* new_node, size_t sequence_number,
                    uint8_t* tree, uint8_t* last_node)
 {
     dprintf (3, ("IN: %Ix(%Ix), T: %Ix(%Ix), L: %Ix(%Ix) [%Ix]",
-                 (size_t)new_node, brick_of(new_node), 
-                 (size_t)tree, brick_of(tree), 
+                 (size_t)new_node, brick_of(new_node),
+                 (size_t)tree, brick_of(tree),
                  (size_t)last_node, brick_of(last_node),
                  sequence_number));
     if (power_of_two_p (sequence_number))
@@ -21790,7 +21787,7 @@ uint8_t* gc_heap::insert_node (uint8_t* new_node, size_t sequence_number,
             set_node_left_child (new_node, ((earlier_node + tmp_offset ) - new_node));
             set_node_right_child (earlier_node, (new_node - earlier_node));
 
-            dprintf (3, ("%Ix LC->%Ix, %Ix RC->%Ix", 
+            dprintf (3, ("%Ix LC->%Ix, %Ix RC->%Ix",
                 new_node, ((earlier_node + tmp_offset ) - new_node),
                 earlier_node, (new_node - earlier_node)));
         }
@@ -21806,7 +21803,7 @@ size_t gc_heap::update_brick_table (uint8_t* tree, size_t current_brick,
 
     if (tree != NULL)
     {
-        dprintf (3, ("b- %Ix->%Ix pointing to tree %Ix", 
+        dprintf (3, ("b- %Ix->%Ix pointing to tree %Ix",
             current_brick, (size_t)(tree - brick_address (current_brick)), tree));
         set_brick (current_brick, (tree - brick_address (current_brick)));
     }
@@ -21889,7 +21886,7 @@ void gc_heap::plan_generation_start (generation* gen, generation* consing_gen, u
         generation_allocation_pointer (consing_gen) += allocation_left;
     }
 
-    dprintf (2, ("plan alloc gen%d(%Ix) start at %Ix (ptr: %Ix, limit: %Ix, next: %Ix)", gen->gen_num, 
+    dprintf (2, ("plan alloc gen%d(%Ix) start at %Ix (ptr: %Ix, limit: %Ix, next: %Ix)", gen->gen_num,
         generation_plan_allocation_start (gen),
         generation_plan_allocation_start_size (gen),
         generation_allocation_pointer (consing_gen), generation_allocation_limit (consing_gen),
@@ -21900,26 +21897,26 @@ void gc_heap::realloc_plan_generation_start (generation* gen, generation* consin
 {
     BOOL adjacentp = FALSE;
 
-    generation_plan_allocation_start (gen) =  
-        allocate_in_expanded_heap (consing_gen, Align(min_obj_size), adjacentp, 0, 
+    generation_plan_allocation_start (gen) =
+        allocate_in_expanded_heap (consing_gen, Align(min_obj_size), adjacentp, 0,
 #ifdef SHORT_PLUGS
-                                   FALSE, NULL, 
+                                   FALSE, NULL,
 #endif //SHORT_PLUGS
                                    FALSE, -1 REQD_ALIGN_AND_OFFSET_ARG);
 
     generation_plan_allocation_start_size (gen) = Align (min_obj_size);
     size_t allocation_left = (size_t)(generation_allocation_limit (consing_gen) - generation_allocation_pointer (consing_gen));
-    if ((allocation_left < Align (min_obj_size)) && 
+    if ((allocation_left < Align (min_obj_size)) &&
          (generation_allocation_limit (consing_gen)!=heap_segment_plan_allocated (generation_allocation_segment (consing_gen))))
     {
         generation_plan_allocation_start_size (gen) += allocation_left;
         generation_allocation_pointer (consing_gen) += allocation_left;
     }
 
-    dprintf (1, ("plan re-alloc gen%d start at %Ix (ptr: %Ix, limit: %Ix)", gen->gen_num, 
+    dprintf (1, ("plan re-alloc gen%d start at %Ix (ptr: %Ix, limit: %Ix)", gen->gen_num,
         generation_plan_allocation_start (consing_gen),
-        generation_allocation_pointer (consing_gen), 
-        generation_allocation_limit (consing_gen))); 
+        generation_allocation_pointer (consing_gen),
+        generation_allocation_limit (consing_gen)));
 }
 
 void gc_heap::plan_generation_starts (generation*& consing_gen)
@@ -21973,7 +21970,7 @@ void gc_heap::advance_pins_for_demotion (generation* gen)
                 set_allocator_next_pin (gen);
 
                 //Add the size of the pinned plug to the right pinned allocations
-                //find out which gen this pinned plug came from 
+                //find out which gen this pinned plug came from
                 int frgn = object_gennum (plug);
                 if ((frgn != (int)max_generation) && settings.promotion)
                 {
@@ -21985,11 +21982,11 @@ void gc_heap::advance_pins_for_demotion (generation* gen)
                     }
                 }
 
-                dprintf (2, ("skipping gap %d, pin %Ix (%Id)", 
+                dprintf (2, ("skipping gap %d, pin %Ix (%Id)",
                     pinned_len (pinned_plug_of (entry)), plug, len));
             }
         }
-        dprintf (2, ("ad_p_d: PL: %Id, SL: %Id, pfr: %d, psr: %d", 
+        dprintf (2, ("ad_p_d: PL: %Id, SL: %Id, pfr: %d, psr: %d",
             gen1_pins_left, total_space_to_skip, (int)(pin_frag_ratio*100), (int)(pin_surv_ratio*100)));
     }
 }
@@ -22009,7 +22006,7 @@ retry:
         if (!pinned_plug_que_empty_p())
         {
             dprintf (2, ("oldest pin: %Ix(%Id)",
-                pinned_plug (oldest_pin()), 
+                pinned_plug (oldest_pin()),
                 (x - pinned_plug (oldest_pin()))));
         }
 
@@ -22035,10 +22032,10 @@ retry:
                 // We are about to allocate gen1, check to see how efficient fitting in gen2 pinned free spaces is.
                 for (int j = 0; j < NUM_GEN_POWER2; j++)
                 {
-                    dprintf (1, ("[h%d][#%Id]2^%d: current: %Id, S: 2: %Id, 1: %Id(%Id)", 
-                        heap_number, 
+                    dprintf (1, ("[h%d][#%Id]2^%d: current: %Id, S: 2: %Id, 1: %Id(%Id)",
+                        heap_number,
                         settings.gc_index,
-                        (j + 10), 
+                        (j + 10),
                         gen_2->gen_current_pinned_free_spaces[j],
                         gen_2->gen_plugs[j], gen_1->gen_plugs[j],
                         (gen_2->gen_plugs[j] + gen_1->gen_plugs[j])));
@@ -22056,7 +22053,7 @@ retry:
                 dprintf (1, ("[h%d] gen2 allocated %Id bytes with %Id bytes pinned free spaces (effi: %d%%), %Id (%Id) left",
                             heap_number,
                             generation_allocated_in_pinned_free (gen_2),
-                            total_pinned_free_space, 
+                            total_pinned_free_space,
                             (int)(pinned_free_list_efficiency * 100),
                             generation_pinned_free_obj_space (gen_2),
                             total_num_pinned_free_spaces_left));
@@ -22117,8 +22114,8 @@ retry:
             }
 
             plan_generation_start (generation_of (active_new_gen_number), consing_gen, x);
-                
-            dprintf (2, ("process eph: allocated gen%d start at %Ix", 
+
+            dprintf (2, ("process eph: allocated gen%d start at %Ix",
                 active_new_gen_number,
                 generation_plan_allocation_start (generation_of (active_new_gen_number))));
 
@@ -22263,8 +22260,8 @@ BOOL gc_heap::loh_enque_pinned_plug (uint8_t* plug, size_t len)
 inline
 BOOL gc_heap::loh_size_fit_p (size_t size, uint8_t* alloc_pointer, uint8_t* alloc_limit)
 {
-    dprintf (1235, ("trying to fit %Id(%Id) between %Ix and %Ix (%Id)", 
-        size, 
+    dprintf (1235, ("trying to fit %Id(%Id) between %Ix and %Ix (%Id)",
+        size,
         (2* AlignQword (loh_padding_obj_size) +  size),
         alloc_pointer,
         alloc_limit,
@@ -22278,7 +22275,7 @@ uint8_t* gc_heap::loh_allocate_in_condemned (uint8_t* old_loc, size_t size)
     UNREFERENCED_PARAMETER(old_loc);
 
     generation* gen = large_object_generation;
-    dprintf (1235, ("E: p:%Ix, l:%Ix, s: %Id", 
+    dprintf (1235, ("E: p:%Ix, l:%Ix, s: %Id",
         generation_allocation_pointer (gen),
         generation_allocation_limit (gen),
         size));
@@ -22298,11 +22295,11 @@ retry:
                 dprintf (1235, ("AIC: %Ix->%Ix(%Id)", generation_allocation_pointer (gen), plug, plug - generation_allocation_pointer (gen)));
                 pinned_len (m) = plug - generation_allocation_pointer (gen);
                 generation_allocation_pointer (gen) = plug + len;
-                
+
                 generation_allocation_limit (gen) = heap_segment_plan_allocated (seg);
                 loh_set_allocator_next_pin();
-                dprintf (1235, ("s: p: %Ix, l: %Ix (%Id)", 
-                    generation_allocation_pointer (gen), 
+                dprintf (1235, ("s: p: %Ix, l: %Ix (%Id)",
+                    generation_allocation_pointer (gen),
                     generation_allocation_limit (gen),
                     (generation_allocation_limit (gen) - generation_allocation_pointer (gen))));
 
@@ -22333,8 +22330,8 @@ retry:
                         heap_segment_plan_allocated (seg) = heap_segment_committed (seg);
                         generation_allocation_limit (gen) = heap_segment_plan_allocated (seg);
 
-                        dprintf (1235, ("g: p: %Ix, l: %Ix (%Id)", 
-                            generation_allocation_pointer (gen), 
+                        dprintf (1235, ("g: p: %Ix, l: %Ix (%Id)",
+                            generation_allocation_pointer (gen),
                             generation_allocation_limit (gen),
                             (generation_allocation_limit (gen) - generation_allocation_pointer (gen))));
                     }
@@ -22368,8 +22365,8 @@ retry:
                             generation_allocation_pointer (gen) = heap_segment_mem (next_seg);
                             generation_allocation_limit (gen) = generation_allocation_pointer (gen);
 
-                            dprintf (1235, ("n: p: %Ix, l: %Ix (%Id)", 
-                                generation_allocation_pointer (gen), 
+                            dprintf (1235, ("n: p: %Ix, l: %Ix (%Id)",
+                                generation_allocation_pointer (gen),
                                 generation_allocation_limit (gen),
                                 (generation_allocation_limit (gen) - generation_allocation_pointer (gen))));
                         }
@@ -22383,8 +22380,8 @@ retry:
             }
             loh_set_allocator_next_pin();
 
-            dprintf (1235, ("r: p: %Ix, l: %Ix (%Id)", 
-                generation_allocation_pointer (gen), 
+            dprintf (1235, ("r: p: %Ix, l: %Ix (%Id)",
+                generation_allocation_pointer (gen),
                 generation_allocation_limit (gen),
                 (generation_allocation_limit (gen) - generation_allocation_pointer (gen))));
 
@@ -22401,8 +22398,8 @@ retry:
         generation_allocation_pointer (gen) += size + loh_pad;
         assert (generation_allocation_pointer (gen) <= generation_allocation_limit (gen));
 
-        dprintf (1235, ("p: %Ix, l: %Ix (%Id)", 
-            generation_allocation_pointer (gen), 
+        dprintf (1235, ("p: %Ix, l: %Ix (%Id)",
+            generation_allocation_pointer (gen),
             generation_allocation_limit (gen),
             (generation_allocation_limit (gen) - generation_allocation_pointer (gen))));
 
@@ -22424,7 +22421,7 @@ void gc_heap::check_loh_compact_mode (BOOL all_heaps_compacted_p)
     {
         if (all_heaps_compacted_p)
         {
-            // If the compaction mode says to compact once and we are going to compact LOH, 
+            // If the compaction mode says to compact once and we are going to compact LOH,
             // we need to revert it back to no compaction.
             loh_compaction_mode = loh_compaction_default;
         }
@@ -22438,7 +22435,7 @@ BOOL gc_heap::plan_loh()
         loh_pinned_queue = new (nothrow) (mark [LOH_PIN_QUEUE_LENGTH]);
         if (!loh_pinned_queue)
         {
-            dprintf (1, ("Cannot allocate the LOH pinned queue (%Id bytes), no compaction", 
+            dprintf (1, ("Cannot allocate the LOH pinned queue (%Id bytes), no compaction",
                          LOH_PIN_QUEUE_LENGTH * sizeof (mark)));
             return FALSE;
         }
@@ -22451,15 +22448,15 @@ BOOL gc_heap::plan_loh()
 
     loh_pinned_queue_tos = 0;
     loh_pinned_queue_bos = 0;
-    
+
     generation* gen        = large_object_generation;
     heap_segment* start_seg = heap_segment_rw (generation_start_segment (gen));
     PREFIX_ASSUME(start_seg != NULL);
     heap_segment* seg      = start_seg;
     uint8_t* o             = generation_allocation_start (gen);
 
-    dprintf (1235, ("before GC LOH size: %Id, free list: %Id, free obj: %Id\n", 
-        generation_size (max_generation + 1), 
+    dprintf (1235, ("before GC LOH size: %Id, free list: %Id, free obj: %Id\n",
+        generation_size (max_generation + 1),
         generation_free_list_space (gen),
         generation_free_obj_space (gen)));
 
@@ -22504,7 +22501,7 @@ BOOL gc_heap::plan_loh()
 
             if (pinned (o))
             {
-                // We don't clear the pinned bit yet so we can check in 
+                // We don't clear the pinned bit yet so we can check in
                 // compact phase how big a free object we should allocate
                 // in front of the pinned object. We use the reloc address
                 // field to store this.
@@ -22636,7 +22633,7 @@ void gc_heap::compact_loh()
                     dprintf (3, ("Trimming seg to %Ix[", heap_segment_allocated (seg)));
                     decommit_heap_segment_pages (seg, 0);
                     dprintf (1236, ("CLOH: seg: %Ix, alloc: %Ix, used: %Ix, committed: %Ix",
-                        seg, 
+                        seg,
                         heap_segment_allocated (seg),
                         heap_segment_used (seg),
                         heap_segment_committed (seg)));
@@ -22666,7 +22663,7 @@ void gc_heap::compact_loh()
 
             if (pinned (o))
             {
-                // We are relying on the fact the pinned objects are always looked at in the same order 
+                // We are relying on the fact the pinned objects are always looked at in the same order
                 // in plan phase and in compact phase.
                 mark* m = loh_pinned_plug_of (loh_deque_pinned_plug());
                 uint8_t* plug = pinned_plug (m);
@@ -22703,8 +22700,8 @@ void gc_heap::compact_loh()
 
     assert (loh_pinned_plug_que_empty_p());
 
-    dprintf (1235, ("after GC LOH size: %Id, free list: %Id, free obj: %Id\n\n", 
-        generation_size (max_generation + 1), 
+    dprintf (1235, ("after GC LOH size: %Id, free list: %Id, free obj: %Id\n\n",
+        generation_size (max_generation + 1),
         generation_free_list_space (gen),
         generation_free_obj_space (gen)));
 }
@@ -22764,8 +22761,8 @@ void gc_heap::relocate_in_loh_compact()
         }
     }
 
-    dprintf (1235, ("after GC LOH size: %Id, free list: %Id, free obj: %Id\n\n", 
-        generation_size (max_generation + 1), 
+    dprintf (1235, ("after GC LOH size: %Id, free list: %Id, free obj: %Id\n\n",
+        generation_size (max_generation + 1),
         generation_free_list_space (gen),
         generation_free_obj_space (gen)));
 }
@@ -22831,8 +22828,8 @@ BOOL gc_heap::loh_object_p (uint8_t* o)
 }
 #endif //FEATURE_LOH_COMPACTION
 
-void gc_heap::convert_to_pinned_plug (BOOL& last_npinned_plug_p, 
-                                      BOOL& last_pinned_plug_p, 
+void gc_heap::convert_to_pinned_plug (BOOL& last_npinned_plug_p,
+                                      BOOL& last_pinned_plug_p,
                                       BOOL& pinned_plug_p,
                                       size_t ps,
                                       size_t& artificial_pinned_size)
@@ -22847,8 +22844,8 @@ void gc_heap::convert_to_pinned_plug (BOOL& last_npinned_plug_p,
 // plugs are always interleaved.
 void gc_heap::store_plug_gap_info (uint8_t* plug_start,
                                    uint8_t* plug_end,
-                                   BOOL& last_npinned_plug_p, 
-                                   BOOL& last_pinned_plug_p, 
+                                   BOOL& last_npinned_plug_p,
+                                   BOOL& last_pinned_plug_p,
                                    uint8_t*& last_pinned_plug,
                                    BOOL& pinned_plug_p,
                                    uint8_t* last_object_in_last_plug,
@@ -22892,7 +22889,7 @@ void gc_heap::store_plug_gap_info (uint8_t* plug_start,
         {
             last_pinned_plug_p = TRUE;
             last_pinned_plug = plug_start;
-                
+
             enque_pinned_plug (last_pinned_plug, save_pre_plug_info_p, last_object_in_last_plug);
 
             if (save_pre_plug_info_p)
@@ -22965,7 +22962,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
 #ifdef GC_CONFIG_DRIVEN
     dprintf (3, ("total number of marked objects: %Id (%Id)",
                  (mark_list_index - &mark_list[0]), ((mark_list_end - &mark_list[0]))));
-    
+
     if (mark_list_index >= (mark_list_end + 1))
         mark_list_index = mark_list_end + 1;
 #else
@@ -22974,8 +22971,8 @@ void gc_heap::plan_phase (int condemned_gen_number)
 #endif //GC_CONFIG_DRIVEN
 
     if ((condemned_gen_number < max_generation) &&
-        (mark_list_index <= mark_list_end) 
-#ifdef BACKGROUND_GC        
+        (mark_list_index <= mark_list_end)
+#ifdef BACKGROUND_GC
         && (!recursive_gc_sync::background_running_p())
 #endif //BACKGROUND_GC
         )
@@ -23031,7 +23028,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
 #endif //BACKGROUND_GC
                         make_unused_array (o, slow - o);
                     }
-                } 
+                }
                 else
                 {
                     assert (condemned_gen_number == max_generation);
@@ -23198,11 +23195,11 @@ void gc_heap::plan_phase (int condemned_gen_number)
         generation_free_list_space (condemned_gen2) = 0;
         generation_free_obj_space (condemned_gen2) = 0;
         generation_allocation_size (condemned_gen2) = 0;
-        generation_condemned_allocated (condemned_gen2) = 0; 
+        generation_condemned_allocated (condemned_gen2) = 0;
         generation_sweep_allocated (condemned_gen2) = 0;
-        generation_pinned_allocated (condemned_gen2) = 0; 
-        generation_free_list_allocated(condemned_gen2) = 0; 
-        generation_end_seg_allocated (condemned_gen2) = 0; 
+        generation_pinned_allocated (condemned_gen2) = 0;
+        generation_free_list_allocated(condemned_gen2) = 0;
+        generation_end_seg_allocated (condemned_gen2) = 0;
         generation_pinned_allocation_sweep_size (condemned_gen2) = 0;
         generation_pinned_allocation_compact_size (condemned_gen2) = 0;
 #ifdef FREE_USAGE_STATS
@@ -23233,7 +23230,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
     }
 
     BOOL allocate_first_generation_start = FALSE;
-    
+
     if (allocate_in_condemned)
     {
         allocate_first_generation_start = TRUE;
@@ -23246,8 +23243,8 @@ void gc_heap::plan_phase (int condemned_gen_number)
 
     // If we are doing a gen1 only because of cards, it means we should not demote any pinned plugs
     // from gen1. They should get promoted to gen2.
-    demote_gen1_p = !(settings.promotion && 
-                      (settings.condemned_generation == (max_generation - 1)) && 
+    demote_gen1_p = !(settings.promotion &&
+                      (settings.condemned_generation == (max_generation - 1)) &&
                       gen_to_condemn_reasons.is_only_condition (gen_low_card_p));
 
     total_ephemeral_size = 0;
@@ -23259,7 +23256,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
         generation* temp_gen = generation_of (gen_idx);
 
         dprintf (2, ("gen%d start %Ix, plan start %Ix",
-            gen_idx, 
+            gen_idx,
             generation_allocation_start (temp_gen),
             generation_plan_allocation_start (temp_gen)));
     }
@@ -23319,8 +23316,8 @@ void gc_heap::plan_phase (int condemned_gen_number)
             size_t added_pinning_size = 0;
             size_t artificial_pinned_size = 0;
 
-            store_plug_gap_info (plug_start, plug_end, last_npinned_plug_p, last_pinned_plug_p, 
-                                 last_pinned_plug, pinned_plug_p, last_object_in_plug, 
+            store_plug_gap_info (plug_start, plug_end, last_npinned_plug_p, last_pinned_plug_p,
+                                 last_pinned_plug, pinned_plug_p, last_object_in_plug,
                                  merge_with_last_pin_p, last_plug_len);
 
 #ifdef FEATURE_STRUCTALIGN
@@ -23368,7 +23365,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
                     // If it is pinned we need to extend to the next marked object as we can't use part of
                     // a pinned object to make the artificial gap (unless the last 3 ptr sized words are all
                     // references but for now I am just using the next non pinned object for that).
-                    if (next_object_marked_p) 
+                    if (next_object_marked_p)
                     {
                         clear_marked (xl);
                         last_object_in_plug = xl;
@@ -23497,7 +23494,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
                             allocate_in_condemned = TRUE;
                         }
 
-                        new_address = allocate_in_condemned_generations (consing_gen, ps, active_old_gen_number, 
+                        new_address = allocate_in_condemned_generations (consing_gen, ps, active_old_gen_number,
 #ifdef SHORT_PLUGS
                                                                          &convert_to_pinned_p,
                                                                          (npin_before_pin_p ? plug_end : 0),
@@ -23533,9 +23530,9 @@ void gc_heap::plan_phase (int condemned_gen_number)
                     {
 #ifdef SIMPLE_DPRINTF
                         dprintf (3, ("(%Ix)[%Ix->%Ix, NA: [%Ix(%Id), %Ix[: %Ix(%d)",
-                            (size_t)(node_gap_size (plug_start)), 
+                            (size_t)(node_gap_size (plug_start)),
                             plug_start, plug_end, (size_t)new_address, (size_t)(plug_start - new_address),
-                                (size_t)new_address + ps, ps, 
+                                (size_t)new_address + ps, ps,
                                 (is_plug_padded (plug_start) ? 1 : 0)));
 #endif //SIMPLE_DPRINTF
 
@@ -23554,7 +23551,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
             {
                 if (fire_pinned_plug_events_p)
                 {
-                    FIRE_EVENT(PinPlugAtGCTime, plug_start, plug_end, 
+                    FIRE_EVENT(PinPlugAtGCTime, plug_start, plug_end,
                                (merge_with_last_pin_p ? 0 : (uint8_t*)node_gap_size (plug_start)));
                 }
 
@@ -23648,7 +23645,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
                 verify_pins_with_post_plug_info("after insert node");
             }
         }
-        
+
         if (num_pinned_plugs_in_plug > 1)
         {
             dprintf (3, ("more than %Id pinned plugs in this plug", num_pinned_plugs_in_plug));
@@ -23735,7 +23732,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
                         dprintf (3, ("end plan: dlow->%Ix", demotion_low));
                     }
 
-                    dprintf (2, ("(%d)gen%d plan start: %Ix", 
+                    dprintf (2, ("(%d)gen%d plan start: %Ix",
                                   heap_number, active_new_gen_number, (size_t)generation_plan_allocation_start (gen)));
                     assert (generation_plan_allocation_start (gen));
                 }
@@ -23783,7 +23780,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
         generation_allocation_limit (consing_gen) =
             generation_allocation_pointer (consing_gen);
         //Add the size of the pinned plug to the right pinned allocations
-        //find out which gen this pinned plug came from 
+        //find out which gen this pinned plug came from
         int frgn = object_gennum (plug);
         if ((frgn != (int)max_generation) && settings.promotion)
         {
@@ -23811,14 +23808,14 @@ void gc_heap::plan_phase (int condemned_gen_number)
                 artificial_pinned_ratio = (int)((float)dd_artificial_pinned_survived_size (temp_dd) * 100 / (float)dd_pinned_survived_size (temp_dd));
             }
 
-            size_t padding_size = 
+            size_t padding_size =
 #ifdef SHORT_PLUGS
                 dd_padding_size (temp_dd);
 #else
                 0;
 #endif //SHORT_PLUGS
             dprintf (1, ("gen%d: %Ix, %Ix(%Id), NON PIN alloc: %Id, pin com: %Id, sweep: %Id, surv: %Id, pinsurv: %Id(%d%% added, %d%% art), np surv: %Id, pad: %Id",
-                gen_idx, 
+                gen_idx,
                 generation_allocation_start (temp_gen),
                 generation_plan_allocation_start (temp_gen),
                 (size_t)(generation_plan_allocation_start (temp_gen) - generation_allocation_start (temp_gen)),
@@ -23847,21 +23844,21 @@ void gc_heap::plan_phase (int condemned_gen_number)
 
         if (growth > 0)
         {
-            dprintf (1, ("gen2 grew %Id (end seg alloc: %Id, condemned alloc: %Id", 
+            dprintf (1, ("gen2 grew %Id (end seg alloc: %Id, condemned alloc: %Id",
                          growth, end_seg_allocated, condemned_allocated));
 
             maxgen_size_inc_p = true;
         }
         else
         {
-            dprintf (2, ("gen2 didn't grow (end seg alloc: %Id, , condemned alloc: %Id, gen1 c alloc: %Id", 
+            dprintf (2, ("gen2 didn't grow (end seg alloc: %Id, , condemned alloc: %Id, gen1 c alloc: %Id",
                          end_seg_allocated, condemned_allocated,
                          generation_condemned_allocated (generation_of (max_generation - 1))));
         }
 
         dprintf (1, ("older gen's free alloc: %Id->%Id, seg alloc: %Id->%Id, condemned alloc: %Id->%Id",
                     r_older_gen_free_list_allocated, generation_free_list_allocated (older_gen),
-                    r_older_gen_end_seg_allocated, generation_end_seg_allocated (older_gen), 
+                    r_older_gen_end_seg_allocated, generation_end_seg_allocated (older_gen),
                     r_older_gen_condemned_allocated, generation_condemned_allocated (older_gen)));
 
         dprintf (1, ("this GC did %Id free list alloc(%Id bytes free space rejected)",
@@ -23889,10 +23886,10 @@ void gc_heap::plan_phase (int condemned_gen_number)
         dprintf (1, ("gen2 free list change"));
         for (int j = 0; j < NUM_GEN_POWER2; j++)
         {
-            dprintf (1, ("[h%d][#%Id]: 2^%d: F: %Id->%Id(%Id), P: %Id", 
-                heap_number, 
+            dprintf (1, ("[h%d][#%Id]: 2^%d: F: %Id->%Id(%Id), P: %Id",
+                heap_number,
                 settings.gc_index,
-                (j + 10), r_older_gen_free_space[j], older_gen->gen_free_spaces[j], 
+                (j + 10), r_older_gen_free_space[j], older_gen->gen_free_spaces[j],
                 (ptrdiff_t)(r_older_gen_free_space[j] - older_gen->gen_free_spaces[j]),
                 (generation_of(max_generation - 1))->gen_plugs[j]));
         }
@@ -23922,7 +23919,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
 #ifdef BIT64
     if ((!settings.concurrent) &&
         !provisional_mode_triggered &&
-        ((condemned_gen_number < max_generation) && 
+        ((condemned_gen_number < max_generation) &&
          ((settings.gen0_reduction_count > 0) || (settings.entry_memory_load >= 95))))
     {
         dprintf (GTC_LOG, ("gen0 reduction count is %d, condemning %d, mem load %d",
@@ -23931,10 +23928,10 @@ void gc_heap::plan_phase (int condemned_gen_number)
                      settings.entry_memory_load));
         should_compact = TRUE;
 
-        get_gc_data_per_heap()->set_mechanism (gc_heap_compact, 
+        get_gc_data_per_heap()->set_mechanism (gc_heap_compact,
             ((settings.gen0_reduction_count > 0) ? compact_fragmented_gen0 : compact_high_mem_load));
 
-        if ((condemned_gen_number >= (max_generation - 1)) && 
+        if ((condemned_gen_number >= (max_generation - 1)) &&
             dt_low_ephemeral_space_p (tuning_deciding_expansion))
         {
             dprintf (GTC_LOG, ("Not enough space for all ephemeral generations with compaction"));
@@ -24206,7 +24203,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
                                           new_heap_segment);
             }
 
-            // If we couldn't get a new segment, or we were able to 
+            // If we couldn't get a new segment, or we were able to
             // reserve one but no space to commit, we couldn't
             // expand heap.
             if (ephemeral_heap_segment != new_heap_segment)
@@ -24315,7 +24312,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
             generation*  gen = generation_of (gen_number);
             uint8_t*  low = generation_allocation_start (generation_of (gen_number-1));
             uint8_t*  high =  heap_segment_allocated (ephemeral_heap_segment);
-            
+
             while (!pinned_plug_que_empty_p())
             {
                 mark*  m = pinned_plug_of (deque_pinned_plug());
@@ -24519,7 +24516,7 @@ void gc_heap::fix_generation_bounds (int condemned_gen_number,
         dprintf(3,("Fixing generation pointers for %Ix", gen_number));
         if ((gen_number < max_generation) && ephemeral_promotion)
         {
-            make_unused_array (saved_ephemeral_plan_start[gen_number], 
+            make_unused_array (saved_ephemeral_plan_start[gen_number],
                                saved_ephemeral_plan_start_size[gen_number]);
         }
         reset_allocation_pointers (gen, generation_plan_allocation_start (gen));
@@ -24531,7 +24528,7 @@ void gc_heap::fix_generation_bounds (int condemned_gen_number,
     if (ephemeral_promotion)
     {
         //we are creating a generation fault. set the cards.
-        // and we are only doing this for multiple heaps because in the single heap scenario the 
+        // and we are only doing this for multiple heaps because in the single heap scenario the
         // new ephemeral generations will be empty and there'll be no need to set cards for the
         // old ephemeral generations that got promoted into max_generation.
         ptrdiff_t delta = 0;
@@ -24838,7 +24835,7 @@ void gc_heap::thread_gap (uint8_t* gap_start, size_t size, generation*  gen)
                 (gap_start > generation_allocation_start (gen)));
         // The beginning of a segment gap is not aligned
         assert (size >= Align (min_obj_size));
-        make_unused_array (gap_start, size, 
+        make_unused_array (gap_start, size,
                           (!settings.concurrent && (gen != youngest_generation)),
                           (gen->gen_num == max_generation));
         dprintf (3, ("fr: [%Ix, %Ix[", (size_t)gap_start, (size_t)gap_start+size));
@@ -24908,7 +24905,7 @@ void gc_heap::make_unused_array (uint8_t* x, size_t size, BOOL clearp, BOOL rese
         while (remaining_size > UINT32_MAX)
         {
             // Make sure that there will be at least Align(min_obj_size) left
-            size_t current_size = UINT32_MAX - get_alignment_constant (FALSE) 
+            size_t current_size = UINT32_MAX - get_alignment_constant (FALSE)
                 - Align (min_obj_size, get_alignment_constant (FALSE));
 
             ((CObjectHeader*)tmp)->SetFree(current_size);
@@ -24950,7 +24947,7 @@ void gc_heap::clear_unused_array (uint8_t* x, size_t size)
 
         while (remaining_size > UINT32_MAX)
         {
-            size_t current_size = UINT32_MAX - get_alignment_constant (FALSE) 
+            size_t current_size = UINT32_MAX - get_alignment_constant (FALSE)
                 - Align (min_obj_size, get_alignment_constant (FALSE));
 
             ((CObjectHeader*)tmp)->UnsetFree();
@@ -25105,7 +25102,7 @@ void gc_heap::relocate_address (uint8_t** pold_address THREAD_NUMBER_DCL)
     }
 }
 
-inline void 
+inline void
 gc_heap::check_class_object_demotion (uint8_t* obj)
 {
 #ifdef COLLECTIBLE_CLASS
@@ -25119,7 +25116,7 @@ gc_heap::check_class_object_demotion (uint8_t* obj)
 }
 
 #ifdef COLLECTIBLE_CLASS
-NOINLINE void 
+NOINLINE void
 gc_heap::check_class_object_demotion_internal (uint8_t* obj)
 {
     if (settings.demotion)
@@ -25127,7 +25124,7 @@ gc_heap::check_class_object_demotion_internal (uint8_t* obj)
 #ifdef MULTIPLE_HEAPS
         // We set the card without checking the demotion range 'cause at this point
         // the handle that points to the loader allocator object may or may not have
-        // been relocated by other GC threads. 
+        // been relocated by other GC threads.
         set_card (card_of (obj));
 #else
         THREAD_FROM_HEAP;
@@ -25206,7 +25203,7 @@ gc_heap::relocate_obj_helper (uint8_t* x, size_t s)
     check_class_object_demotion (x);
 }
 
-inline 
+inline
 void gc_heap::reloc_ref_in_shortened_obj (uint8_t** address_to_set_card, uint8_t** address_to_reloc)
 {
     THREAD_FROM_HEAP;
@@ -25250,12 +25247,12 @@ void gc_heap::relocate_pre_plug_info (mark* pinned_plug_entry)
     uint8_t* plug = pinned_plug (pinned_plug_entry);
     uint8_t* pre_plug_start = plug - sizeof (plug_and_gap);
     // Note that we need to add one ptr size here otherwise we may not be able to find the relocated
-    // address. Consider this scenario: 
+    // address. Consider this scenario:
     // gen1 start | 3-ptr sized NP | PP
     // 0          | 0x18           | 0x30
     // If we are asking for the reloc address of 0x10 we will AV in relocate_address because
     // the first plug we saw in the brick is 0x18 which means 0x10 will cause us to go back a brick
-    // which is 0, and then we'll AV in tree_search when we try to do node_right_child (tree). 
+    // which is 0, and then we'll AV in tree_search when we try to do node_right_child (tree).
     pre_plug_start += sizeof (uint8_t*);
     uint8_t** old_address = &pre_plug_start;
 
@@ -25263,7 +25260,7 @@ void gc_heap::relocate_pre_plug_info (mark* pinned_plug_entry)
     relocate_address (old_address THREAD_NUMBER_ARG);
     if (old_address)
     {
-        dprintf (3, ("PreR %Ix: %Ix->%Ix, set reloc: %Ix", 
+        dprintf (3, ("PreR %Ix: %Ix->%Ix, set reloc: %Ix",
             (uint8_t*)old_address, old_val, *old_address, (pre_plug_start - sizeof (uint8_t*))));
     }
 
@@ -25281,7 +25278,7 @@ void gc_heap::relocate_shortened_obj_helper (uint8_t* x, size_t s, uint8_t* end,
         //// Temporary - we just wanna make sure we are doing things right when padding is needed.
         //if ((x + s) < plug)
         //{
-        //    dprintf (3, ("obj %Ix needed padding: end %Ix is %d bytes from pinned obj %Ix", 
+        //    dprintf (3, ("obj %Ix needed padding: end %Ix is %d bytes from pinned obj %Ix",
         //        x, (x + s), (plug- (x + s)), plug));
         //    GCToOSInterface::DebugBreak();
         //}
@@ -25304,7 +25301,7 @@ void gc_heap::relocate_shortened_obj_helper (uint8_t* x, size_t s, uint8_t* end,
         saved_plug_info_start = (plug - sizeof (plug_and_gap));
         saved_info_to_relocate = (uint8_t**)(pinned_plug_entry->get_pre_plug_reloc_info());
     }
-    
+
     uint8_t** current_saved_info_to_relocate = 0;
     uint8_t* child = 0;
 
@@ -25369,13 +25366,13 @@ void gc_heap::verify_pins_with_post_plug_info (const char* msg)
 
             mark* pinned_plug_entry = pinned_plug_of(i);
 
-            if (pinned_plug_entry->has_post_plug_info() && 
-                pinned_plug_entry->post_short_p() && 
+            if (pinned_plug_entry->has_post_plug_info() &&
+                pinned_plug_entry->post_short_p() &&
                 (pinned_plug_entry->saved_post_plug_debug.gap != 1))
             {
                 uint8_t* next_obj = pinned_plug_entry->get_post_plug_info_start() + sizeof (plug_and_gap);
                 // object after pin
-                dprintf (3, ("OFP: %Ix, G: %Ix, R: %Ix, LC: %d, RC: %d", 
+                dprintf (3, ("OFP: %Ix, G: %Ix, R: %Ix, LC: %d, RC: %d",
                     next_obj, node_gap_size (next_obj), node_relocation_distance (next_obj),
                     (int)node_left_child (next_obj), (int)node_right_child (next_obj)));
 
@@ -25383,7 +25380,7 @@ void gc_heap::verify_pins_with_post_plug_info (const char* msg)
 
                 if (node_gap_size (next_obj) != *post_plug_debug)
                 {
-                    dprintf (3, ("obj: %Ix gap should be %Ix but it is %Ix", 
+                    dprintf (3, ("obj: %Ix gap should be %Ix but it is %Ix",
                         next_obj, *post_plug_debug, (size_t)(node_gap_size (next_obj))));
                     FATAL_GC_ERROR();
                 }
@@ -25392,7 +25389,7 @@ void gc_heap::verify_pins_with_post_plug_info (const char* msg)
                 //if (node_relocation_distance (next_obj) != *post_plug_debug)
                 if (*((size_t*)(next_obj - 3 * sizeof (size_t))) != *post_plug_debug)
                 {
-                    dprintf (3, ("obj: %Ix reloc should be %Ix but it is %Ix", 
+                    dprintf (3, ("obj: %Ix reloc should be %Ix but it is %Ix",
                         next_obj, *post_plug_debug, (size_t)(node_relocation_distance (next_obj))));
                     FATAL_GC_ERROR();
                 }
@@ -25410,7 +25407,7 @@ void gc_heap::verify_pins_with_post_plug_info (const char* msg)
 }
 
 #ifdef COLLECTIBLE_CLASS
-// We don't want to burn another ptr size space for pinned plugs to record this so just 
+// We don't want to burn another ptr size space for pinned plugs to record this so just
 // set the card unconditionally for collectible objects if we are demoting.
 inline void
 gc_heap::unconditional_set_card_collectible (uint8_t* obj)
@@ -25488,9 +25485,9 @@ void gc_heap::relocate_shortened_survivor_helper (uint8_t* plug, uint8_t* plug_e
         uint8_t* next_obj = x + Align (s);
         Prefetch (next_obj);
 
-        if (next_obj >= plug_end) 
+        if (next_obj >= plug_end)
         {
-            dprintf (3, ("object %Ix is at the end of the plug %Ix->%Ix", 
+            dprintf (3, ("object %Ix is at the end of the plug %Ix->%Ix",
                 next_obj, plug, plug_end));
 
             verify_pins_with_post_plug_info("before reloc short obj");
@@ -25510,7 +25507,7 @@ void gc_heap::relocate_shortened_survivor_helper (uint8_t* plug, uint8_t* plug_e
 }
 
 void gc_heap::relocate_survivors_in_plug (uint8_t* plug, uint8_t* plug_end,
-                                          BOOL check_last_object_p, 
+                                          BOOL check_last_object_p,
                                           mark* pinned_plug_entry)
 {
     //dprintf(3,("Relocating pointers in Plug [%Ix,%Ix[", (size_t)plug, (size_t)plug_end));
@@ -25531,7 +25528,7 @@ void gc_heap::relocate_survivors_in_brick (uint8_t* tree, relocate_args* args)
     assert ((tree != NULL));
 
     dprintf (3, ("tree: %Ix, args->last_plug: %Ix, left: %Ix, right: %Ix, gap(t): %Ix",
-        tree, args->last_plug, 
+        tree, args->last_plug,
         (tree + node_left_child (tree)),
         (tree + node_right_child (tree)),
         node_gap_size (tree)));
@@ -25606,7 +25603,7 @@ void gc_heap::relocate_survivors (int condemned_gen_number,
 
     reset_pinned_queue_bos();
     update_oldest_pinned_plug();
-    
+
     end_address = heap_segment_allocated (current_heap_segment);
 
     size_t  end_brick = brick_of (end_address - 1);
@@ -25626,7 +25623,7 @@ void gc_heap::relocate_survivors (int condemned_gen_number,
                     assert (!(args.is_shortened));
                     relocate_survivors_in_plug (args.last_plug,
                                                 heap_segment_allocated (current_heap_segment),
-                                                args.is_shortened, 
+                                                args.is_shortened,
                                                 args.pinned_plug_entry);
                 }
 
@@ -25724,9 +25721,9 @@ void gc_heap::walk_relocation_in_brick (uint8_t* tree, walk_relocate_args* args)
         uint8_t*  gap = (plug - gap_size);
         uint8_t*  last_plug_end = gap;
         size_t last_plug_size = (last_plug_end - args->last_plug);
-        dprintf (3, ("tree: %Ix, last_plug: %Ix, gap: %Ix(%Ix), last_plug_end: %Ix, size: %Ix", 
+        dprintf (3, ("tree: %Ix, last_plug: %Ix, gap: %Ix(%Ix), last_plug_end: %Ix, size: %Ix",
             tree, args->last_plug, gap, gap_size, last_plug_end, last_plug_size));
-        
+
         BOOL check_last_object_p = (args->is_shortened || has_pre_plug_info_p);
         if (!check_last_object_p)
         {
@@ -25775,8 +25772,8 @@ void gc_heap::walk_relocation (void* profiling_context, record_surv_fn fn)
         {
             if (args.last_plug)
             {
-                walk_plug (args.last_plug, 
-                           (heap_segment_allocated (current_heap_segment) - args.last_plug), 
+                walk_plug (args.last_plug,
+                           (heap_segment_allocated (current_heap_segment) - args.last_plug),
                            args.is_shortened,
                            &args);
                 args.last_plug = 0;
@@ -25847,7 +25844,7 @@ void gc_heap::walk_survivors_for_bgc (void* profiling_context, record_surv_fn fn
 
                 continue;
             }
-            else 
+            else
                 break;
         }
 
@@ -25875,10 +25872,10 @@ void gc_heap::walk_survivors_for_bgc (void* profiling_context, record_surv_fn fn
                     break;
                 }
             }
-                
+
             uint8_t* plug_end = o;
 
-            fn (plug_start, 
+            fn (plug_start,
                 plug_end,
                 0,              // Reloc distance == 0 as this is non-compacting
                 profiling_context,
@@ -26070,15 +26067,15 @@ void gc_heap::relocate_phase (int condemned_gen_number,
 // This compares to see if tree is the current pinned plug and returns info
 // for this pinned plug. Also advances the pinned queue if that's the case.
 //
-// We don't change the values of the plug info if tree is not the same as 
+// We don't change the values of the plug info if tree is not the same as
 // the current pinned plug - the caller is responsible for setting the right
 // values to begin with.
 //
-// POPO TODO: We are keeping this temporarily as this is also used by realloc 
-// where it passes FALSE to deque_p, change it to use the same optimization 
+// POPO TODO: We are keeping this temporarily as this is also used by realloc
+// where it passes FALSE to deque_p, change it to use the same optimization
 // as relocate. Not as essential since realloc is already a slow path.
 mark* gc_heap::get_next_pinned_entry (uint8_t* tree,
-                                      BOOL* has_pre_plug_info_p, 
+                                      BOOL* has_pre_plug_info_p,
                                       BOOL* has_post_plug_info_p,
                                       BOOL deque_p)
 {
@@ -26096,8 +26093,8 @@ mark* gc_heap::get_next_pinned_entry (uint8_t* tree,
                 deque_pinned_plug();
             }
 
-            dprintf (3, ("found a pinned plug %Ix, pre: %d, post: %d", 
-                tree, 
+            dprintf (3, ("found a pinned plug %Ix, pre: %d, post: %d",
+                tree,
                 (*has_pre_plug_info_p ? 1 : 0),
                 (*has_post_plug_info_p ? 1 : 0)));
 
@@ -26109,7 +26106,7 @@ mark* gc_heap::get_next_pinned_entry (uint8_t* tree,
 }
 
 // This also deques the oldest entry and update the oldest plug
-mark* gc_heap::get_oldest_pinned_entry (BOOL* has_pre_plug_info_p, 
+mark* gc_heap::get_oldest_pinned_entry (BOOL* has_pre_plug_info_p,
                                         BOOL* has_post_plug_info_p)
 {
     mark* oldest_entry = oldest_pin();
@@ -26139,7 +26136,7 @@ void  gc_heap::gcmemcopy (uint8_t* dest, uint8_t* src, size_t len, BOOL copy_car
     if (dest != src)
     {
 #ifdef BACKGROUND_GC
-        if (current_c_gc_state == c_gc_state_marking) 
+        if (current_c_gc_state == c_gc_state_marking)
         {
             //TODO: should look to see whether we should consider changing this
             // to copy a consecutive region of the mark array instead.
@@ -26201,7 +26198,7 @@ void gc_heap::compact_plug (uint8_t* plug, size_t size, BOOL check_last_object_p
         }
     }
 #else // FEATURE_STRUCTALIGN
-    size_t unused_arr_size = 0; 
+    size_t unused_arr_size = 0;
     BOOL  already_padded_p = FALSE;
 #ifdef SHORT_PLUGS
     if (is_plug_padded (plug))
@@ -26216,13 +26213,13 @@ void gc_heap::compact_plug (uint8_t* plug, size_t size, BOOL check_last_object_p
         unused_arr_size += switch_alignment_size (already_padded_p);
     }
 
-    if (unused_arr_size != 0) 
+    if (unused_arr_size != 0)
     {
         make_unused_array (reloc_plug - unused_arr_size, unused_arr_size);
 
         if (brick_of (reloc_plug - unused_arr_size) != brick_of (reloc_plug))
         {
-            dprintf (3, ("fix B for padding: %Id: %Ix->%Ix", 
+            dprintf (3, ("fix B for padding: %Id: %Ix->%Ix",
                 unused_arr_size, (reloc_plug - unused_arr_size), reloc_plug));
             // The alignment padding is straddling one or more bricks;
             // it has to be the last "object" of its first brick.
@@ -26267,14 +26264,14 @@ void gc_heap::compact_plug (uint8_t* plug, size_t size, BOOL check_last_object_p
 
     if (brick_of (reloc_plug) != current_reloc_brick)
     {
-        dprintf (3, ("last reloc B: %Ix, current reloc B: %Ix", 
+        dprintf (3, ("last reloc B: %Ix, current reloc B: %Ix",
             current_reloc_brick, brick_of (reloc_plug)));
 
         if (args->before_last_plug)
         {
             dprintf (3,(" fixing last brick %Ix to point to last plug %Ix(%Ix)",
                      current_reloc_brick,
-                     args->before_last_plug, 
+                     args->before_last_plug,
                      (args->before_last_plug - brick_address (current_reloc_brick))));
 
             {
@@ -26311,7 +26308,7 @@ void gc_heap::compact_plug (uint8_t* plug, size_t size, BOOL check_last_object_p
         current_reloc_brick = end_brick;
         dprintf (3, ("setting before last to %Ix, last brick to %Ix",
             args->before_last_plug, current_reloc_brick));
-    } 
+    }
     else
     {
         dprintf (3, ("still in the same brick: %Ix", end_brick));
@@ -26366,9 +26363,9 @@ void gc_heap::compact_in_brick (uint8_t* tree, compact_args* args)
         uint8_t*  gap = (plug - gap_size);
         uint8_t*  last_plug_end = gap;
         size_t last_plug_size = (last_plug_end - args->last_plug);
-        dprintf (3, ("tree: %Ix, last_plug: %Ix, gap: %Ix(%Ix), last_plug_end: %Ix, size: %Ix", 
+        dprintf (3, ("tree: %Ix, last_plug: %Ix, gap: %Ix(%Ix), last_plug_end: %Ix, size: %Ix",
             tree, args->last_plug, gap, gap_size, last_plug_end, last_plug_size));
-        
+
         BOOL check_last_object_p = (args->is_shortened || has_pre_plug_info_p);
         if (!check_last_object_p)
         {
@@ -26460,7 +26457,7 @@ void gc_heap::compact_phase (int condemned_gen_number,
         args.src_gennum = ((current_heap_segment == ephemeral_heap_segment) ? -1 : 2);
     }
 
-    dprintf (2,("---- Compact Phase: %Ix(%Ix)----", 
+    dprintf (2,("---- Compact Phase: %Ix(%Ix)----",
         first_condemned_address, brick_of (first_condemned_address)));
 
 #ifdef MULTIPLE_HEAPS
@@ -26527,7 +26524,7 @@ void gc_heap::compact_phase (int condemned_gen_number,
             }
             {
                 int  brick_entry =  brick_table [ current_brick ];
-                dprintf (3, ("B: %Ix(%Ix)->%Ix", 
+                dprintf (3, ("B: %Ix(%Ix)->%Ix",
                     current_brick, (size_t)brick_entry, (brick_address (current_brick) + brick_entry - 1)));
 
                 if (brick_entry >= 0)
@@ -26862,7 +26859,7 @@ void gc_heap::verify_mark_array_cleared (uint8_t* begin, uint8_t* end, uint32_t*
     {
         if (mark_array_addr[markw])
         {
-            dprintf  (1, ("The mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared", 
+            dprintf  (1, ("The mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared",
                             markw, mark_array_addr[markw], mark_word_address (markw)));
             FATAL_GC_ERROR();
         }
@@ -26880,7 +26877,7 @@ void gc_heap::verify_mark_array_cleared (heap_segment* seg, uint32_t* mark_array
     verify_mark_array_cleared (heap_segment_mem (seg), heap_segment_reserved (seg), mark_array_addr);
 }
 
-BOOL gc_heap::commit_mark_array_new_seg (gc_heap* hp, 
+BOOL gc_heap::commit_mark_array_new_seg (gc_heap* hp,
                                          heap_segment* seg,
                                          uint32_t* new_card_table,
                                          uint8_t* new_lowest_address)
@@ -26936,7 +26933,7 @@ BOOL gc_heap::commit_mark_array_new_seg (gc_heap* hp,
             uint32_t* ct = &new_card_table[card_word (gcard_of (new_lowest_address))];
             uint32_t* ma = (uint32_t*)((uint8_t*)card_table_mark_array (ct) - size_mark_array_of (0, new_lowest_address));
 
-            dprintf (GC_TABLE_LOG, ("table realloc-ed: %Ix->%Ix, MA: %Ix->%Ix", 
+            dprintf (GC_TABLE_LOG, ("table realloc-ed: %Ix->%Ix, MA: %Ix->%Ix",
                                     hp->card_table, new_card_table,
                                     hp->mark_array, ma));
 
@@ -26975,7 +26972,7 @@ BOOL gc_heap::commit_mark_array_by_range (uint8_t* begin, uint8_t* end, uint32_t
     if (virtual_commit (commit_start, size))
     {
         // We can only verify the mark array is cleared from begin to end, the first and the last
-        // page aren't necessarily all cleared 'cause they could be used by other segments or 
+        // page aren't necessarily all cleared 'cause they could be used by other segments or
         // card bundle.
         verify_mark_array_cleared (begin, end, mark_array_addr);
         return TRUE;
@@ -27029,7 +27026,7 @@ BOOL gc_heap::commit_mark_array_bgc_init (uint32_t* mark_array_addr)
 {
     UNREFERENCED_PARAMETER(mark_array_addr);
 
-    dprintf (GC_TABLE_LOG, ("BGC init commit: lowest: %Ix, highest: %Ix, mark_array: %Ix", 
+    dprintf (GC_TABLE_LOG, ("BGC init commit: lowest: %Ix, highest: %Ix, mark_array: %Ix",
                             lowest_address, highest_address, mark_array));
 
     generation* gen = generation_of (max_generation);
@@ -27054,11 +27051,11 @@ BOOL gc_heap::commit_mark_array_bgc_init (uint32_t* mark_array_addr)
         if (!(seg->flags & heap_segment_flags_ma_committed))
         {
             // For ro segments they could always be only partially in range so we'd
-            // be calling this at the beginning of every BGC. We are not making this 
+            // be calling this at the beginning of every BGC. We are not making this
             // more efficient right now - ro segments are currently only used by redhawk.
             if (heap_segment_read_only_p (seg))
             {
-                if ((heap_segment_mem (seg) >= lowest_address) && 
+                if ((heap_segment_mem (seg) >= lowest_address) &&
                     (heap_segment_reserved (seg) <= highest_address))
                 {
                     if (commit_mark_array_by_seg (seg, mark_array))
@@ -27086,7 +27083,7 @@ BOOL gc_heap::commit_mark_array_bgc_init (uint32_t* mark_array_addr)
             }
             else
             {
-                // For normal segments they are by design completely in range so just 
+                // For normal segments they are by design completely in range so just
                 // commit the whole mark array for each seg.
                 if (commit_mark_array_by_seg (seg, mark_array))
                 {
@@ -27145,7 +27142,7 @@ BOOL gc_heap::commit_new_mark_array (uint32_t* new_mark_array_addr)
         if (!commit_mark_array_with_check (new_heap_segment, new_mark_array_addr))
         {
             return FALSE;
-        }        
+        }
     }
 #endif //MULTIPLE_HEAPS
 
@@ -27175,7 +27172,7 @@ BOOL gc_heap::commit_new_mark_array_global (uint32_t* new_mark_array)
 void gc_heap::decommit_mark_array_by_seg (heap_segment* seg)
 {
     // if BGC is disabled (the finalize watchdog does this at shutdown), the mark array could have
-    // been set to NULL. 
+    // been set to NULL.
     if (mark_array == NULL)
     {
         return;
@@ -27214,12 +27211,12 @@ void gc_heap::decommit_mark_array_by_seg (heap_segment* seg)
                                 decommit_start, decommit_end,
                                 size));
 #endif //SIMPLE_DPRINTF
-        
+
         if (decommit_start < decommit_end)
         {
             if (!virtual_decommit (decommit_start, size))
             {
-                dprintf (GC_TABLE_LOG, ("decommit on %Ix for %Id bytes failed", 
+                dprintf (GC_TABLE_LOG, ("decommit on %Ix for %Id bytes failed",
                                         decommit_start, size));
                 assert (!"decommit failed");
             }
@@ -27325,7 +27322,7 @@ void gc_heap::background_mark_phase ()
         // first can change the states and call restart_vm.
         // this is not true - we can't let the EE run when we are scanning stack.
         // since we now allow reset ww to run concurrently and have a join for it,
-        // we can do restart ee on the 1st thread that got here. Make sure we handle the 
+        // we can do restart ee on the 1st thread that got here. Make sure we handle the
         // sizedref handles correctly.
 #ifdef MULTIPLE_HEAPS
         bgc_t_join.join(this, gc_join_restart_ee);
@@ -27480,7 +27477,7 @@ void gc_heap::background_mark_phase ()
             int i;
             for (i = 0; i < n_heaps; i++)
             {
-                dprintf (3, ("heap %d overflow max is %Ix, min is %Ix", 
+                dprintf (3, ("heap %d overflow max is %Ix, min is %Ix",
                     i,
                     g_heaps[i]->background_max_overflow_address,
                     g_heaps[i]->background_min_overflow_address));
@@ -27728,15 +27725,15 @@ void gc_heap::background_mark_phase ()
 
     gen0_bricks_cleared = FALSE;
 
-    dprintf (2, ("end of bgc mark: loh: %d, soh: %d", 
-                 generation_size (max_generation + 1), 
+    dprintf (2, ("end of bgc mark: loh: %d, soh: %d",
+                 generation_size (max_generation + 1),
                  generation_sizes (generation_of (max_generation))));
 
     for (int gen_idx = max_generation; gen_idx <= (max_generation + 1); gen_idx++)
     {
         generation* gen = generation_of (gen_idx);
         dynamic_data* dd = dynamic_data_of (gen_idx);
-        dd_begin_data_size (dd) = generation_size (gen_idx) - 
+        dd_begin_data_size (dd) = generation_size (gen_idx) -
                                    (generation_free_list_space (gen) + generation_free_obj_space (gen)) -
                                    Align (size (generation_allocation_start (gen)));
         dd_survived_size (dd) = 0;
@@ -27767,8 +27764,8 @@ void gc_heap::background_mark_phase ()
             heap_segment_background_allocated (seg) = heap_segment_allocated (seg);
         }
 
-        dprintf (2, ("seg %Ix background allocated is %Ix", 
-                      heap_segment_mem (seg), 
+        dprintf (2, ("seg %Ix background allocated is %Ix",
+                      heap_segment_mem (seg),
                       heap_segment_background_allocated (seg)));
         seg = heap_segment_next_rw (seg);
     }
@@ -27782,8 +27779,8 @@ void gc_heap::background_mark_phase ()
         mark_time = finish - start;
 #endif //TIME_GC
 
-    dprintf (2, ("end of bgc mark: gen2 free list space: %d, free obj space: %d", 
-        generation_free_list_space (generation_of (max_generation)), 
+    dprintf (2, ("end of bgc mark: gen2 free list space: %d, free obj space: %d",
+        generation_free_list_space (generation_of (max_generation)),
         generation_free_obj_space (generation_of (max_generation))));
 
     dprintf(2,("---- (GC%d)End of background mark phase ----", VolatileLoad(&settings.gc_index)));
@@ -27852,7 +27849,7 @@ inline uint8_t* gc_heap::high_page ( heap_segment* seg, BOOL concurrent_p)
                      heap_segment_allocated (seg));
         return align_lower_page (end);
     }
-    else 
+    else
     {
         return heap_segment_allocated (seg);
     }
@@ -27933,16 +27930,16 @@ void gc_heap::revisit_written_page (uint8_t* page,
 
         uint8_t* next_o =  o + Align (s, align_const);
 
-        if (next_o >= start_address) 
+        if (next_o >= start_address)
         {
 #ifdef MULTIPLE_HEAPS
             if (concurrent_p)
             {
-                // We set last_object here for SVR BGC here because SVR BGC has more than 
-                // one GC thread. When we have more than one GC thread we would run into this 
+                // We set last_object here for SVR BGC here because SVR BGC has more than
+                // one GC thread. When we have more than one GC thread we would run into this
                 // situation if we skipped unmarked objects:
-                // bgc thread 1 calls GWW, and detect object X not marked so it would skip it 
-                // for revisit. 
+                // bgc thread 1 calls GWW, and detect object X not marked so it would skip it
+                // for revisit.
                 // bgc thread 2 marks X and all its current children.
                 // user thread comes along and dirties more (and later) pages in X.
                 // bgc thread 1 calls GWW again and gets those later pages but it will not mark anything
@@ -27980,7 +27977,7 @@ void gc_heap::revisit_written_page (uint8_t* page,
                 (next_o > min (high_address, page + WRITE_WATCH_UNIT_SIZE)))
             {
                 // We need to not skip the object here because of this corner scenario:
-                // A large object was being allocated during BGC mark so we first made it 
+                // A large object was being allocated during BGC mark so we first made it
                 // into a free object, then cleared its memory. In this loop we would detect
                 // that it's a free object which normally we would skip. But by the next time
                 // we call GetWriteWatch we could still be on this object and the object had
@@ -27996,7 +27993,7 @@ void gc_heap::revisit_written_page (uint8_t* page,
                 // revisit_written_pages() continues, it cannot skip now-valid objects in this
                 // region.
                 no_more_loop_p = TRUE;
-                goto end_limit;                
+                goto end_limit;
             }
         }
 end_limit:
@@ -28086,7 +28083,7 @@ void gc_heap::revisit_written_pages (BOOL concurrent_p, BOOL reset_only_p)
                 if (reset_only_p)
                 {
                     dprintf (GTC_LOG, ("h%d: tdp: %Id", heap_number, total_dirtied_pages));
-                } 
+                }
                 else
                 {
                     dprintf (GTC_LOG, ("h%d: LOH: dp:%Id; mo: %Id", heap_number, total_dirtied_pages, total_marked_objects));
@@ -28112,7 +28109,7 @@ void gc_heap::revisit_written_pages (BOOL concurrent_p, BOOL reset_only_p)
             if ((heap_segment_mem (seg) >= background_saved_lowest_address) ||
                 (heap_segment_reserved (seg) <= background_saved_highest_address))
             {
-                dprintf (3, ("h%d: sseg: %Ix(-%Ix)", heap_number, 
+                dprintf (3, ("h%d: sseg: %Ix(-%Ix)", heap_number,
                     heap_segment_mem (seg), heap_segment_reserved (seg)));
                 skip_seg_p = TRUE;
             }
@@ -28128,7 +28125,7 @@ void gc_heap::revisit_written_pages (BOOL concurrent_p, BOOL reset_only_p)
                 dprintf (3, ("h%d: reset only starting %Ix", heap_number, base_address));
             }
 
-            dprintf (3, ("h%d: starting: %Ix, seg %Ix-%Ix", heap_number, base_address, 
+            dprintf (3, ("h%d: starting: %Ix, seg %Ix-%Ix", heap_number, base_address,
                 heap_segment_mem (seg), heap_segment_reserved (seg)));
 
 
@@ -28176,7 +28173,7 @@ void gc_heap::revisit_written_pages (BOOL concurrent_p, BOOL reset_only_p)
                     {
                         total_dirtied_pages += bcount;
 
-                        dprintf (3, ("Found %d pages [%Ix, %Ix[", 
+                        dprintf (3, ("Found %d pages [%Ix, %Ix[",
                                         bcount, (size_t)base_address, (size_t)high_address));
                     }
 
@@ -28185,7 +28182,7 @@ void gc_heap::revisit_written_pages (BOOL concurrent_p, BOOL reset_only_p)
                         for (unsigned i = 0; i < bcount; i++)
                         {
                             uint8_t* page = (uint8_t*)background_written_addresses[i];
-                            dprintf (3, ("looking at page %d at %Ix(h: %Ix)", i, 
+                            dprintf (3, ("looking at page %d at %Ix(h: %Ix)", i,
                                 (size_t)page, (size_t)high_address));
                             if (page < high_address)
                             {
@@ -28332,7 +28329,7 @@ void gc_heap::background_promote_callback (Object** ppObject, ScanContext* sc,
 void gc_heap::mark_absorb_new_alloc()
 {
     fix_allocation_contexts (FALSE);
-    
+
     gen0_bricks_cleared = FALSE;
 
     clear_gen0_bricks();
@@ -28434,7 +28431,7 @@ BOOL gc_heap::create_bgc_thread_support()
 {
     BOOL ret = FALSE;
     uint8_t** parr;
-    
+
     if (!gc_lh_block_event.CreateManualEventNoThrow(FALSE))
     {
         goto cleanup;
@@ -28590,8 +28587,8 @@ void gc_heap::bgc_thread_function()
             FALSE);
         dprintf (2, ("gc thread: finished waiting"));
 
-        // not calling disable_preemptive here 'cause we 
-        // can't wait for GC complete here - RestartEE will be called 
+        // not calling disable_preemptive here 'cause we
+        // can't wait for GC complete here - RestartEE will be called
         // when we've done the init work.
 
         if (result == WAIT_TIMEOUT)
@@ -28624,7 +28621,7 @@ void gc_heap::bgc_thread_function()
             break;
         }
         recursive_gc_sync::begin_background();
-        dprintf (2, ("beginning of bgc: gen2 FL: %d, FO: %d, frag: %d", 
+        dprintf (2, ("beginning of bgc: gen2 FL: %d, FO: %d, frag: %d",
             generation_free_list_space (generation_of (max_generation)),
             generation_free_obj_space (generation_of (max_generation)),
             dd_fragmentation (dynamic_data_of (max_generation))));
@@ -28641,7 +28638,7 @@ void gc_heap::bgc_thread_function()
         {
             enter_spin_lock (&gc_lock);
             dprintf (SPINLOCK_LOG, ("bgc Egc"));
-            
+
             bgc_start_event.Reset();
             do_post_gc();
 #ifdef MULTIPLE_HEAPS
@@ -28694,7 +28691,7 @@ void gc_heap::bgc_thread_function()
 #endif //MULTIPLE_HEAPS
         }
         // We can't disable preempt here because there might've been a GC already
-        // started and decided to do a BGC and waiting for a BGC thread to restart 
+        // started and decided to do a BGC and waiting for a BGC thread to restart
         // vm. That GC will be waiting in wait_to_proceed and we are waiting for it
         // to restart the VM so we deadlock.
         //gc_heap::disable_preemptive (true);
@@ -28717,13 +28714,13 @@ bool gc_heap::bgc_tuning::stepping_trigger (uint32_t current_memory_load, size_t
     bool stepping_trigger_p = false;
     if (use_stepping_trigger_p)
     {
-        dprintf (BGC_TUNING_LOG, ("current ml: %d, goal: %d", 
+        dprintf (BGC_TUNING_LOG, ("current ml: %d, goal: %d",
             current_memory_load, memory_load_goal));
-        // We don't go all the way up to mem goal because if we do we could end up with every 
+        // We don't go all the way up to mem goal because if we do we could end up with every
         // BGC being triggered by stepping all the way up to goal, and when we actually reach
         // goal we have no time to react 'cause the next BGC could already be over goal.
         if ((current_memory_load <= (memory_load_goal * 2 / 3)) ||
-            ((memory_load_goal > current_memory_load) && 
+            ((memory_load_goal > current_memory_load) &&
              ((memory_load_goal - current_memory_load) > (stepping_interval * 3))))
         {
             int memory_load_delta = (int)current_memory_load - (int)last_stepping_mem_load;
@@ -28781,7 +28778,7 @@ bool gc_heap::bgc_tuning::should_trigger_bgc_loh()
                     current_alloc, current_gen_calc->last_bgc_end_alloc,
                     (current_alloc - current_gen_calc->last_bgc_end_alloc),
                     current_gen_calc->alloc_to_trigger));
-    
+
             if (trigger_p)
             {
                 dprintf (BGC_TUNING_LOG, ("BTL3: LOH detected (%Id - %Id) >= %Id, TRIGGER",
@@ -28805,14 +28802,14 @@ bool gc_heap::bgc_tuning::should_trigger_bgc()
     {
         // TODO: this should be an assert because if the reason was reason_bgc_tuning_loh,
         // we should have already set to condemn max_generation but I'm keeping it
-        // for now in case we are reverting it for other reasons. 
+        // for now in case we are reverting it for other reasons.
         bgc_tuning::next_bgc_p = true;
         dprintf (BGC_TUNING_LOG, ("BTL LOH triggered"));
         return true;
     }
 
-    if (!bgc_tuning::next_bgc_p && 
-        !fl_tuning_triggered && 
+    if (!bgc_tuning::next_bgc_p &&
+        !fl_tuning_triggered &&
         (gc_heap::settings.entry_memory_load >= (memory_load_goal * 2 / 3)) &&
         (gc_heap::full_gc_counts[gc_type_background] >= 2))
     {
@@ -28820,7 +28817,7 @@ bool gc_heap::bgc_tuning::should_trigger_bgc()
 
         gen_calc[0].first_alloc_to_trigger = gc_heap::get_total_servo_alloc (max_generation);
         gen_calc[1].first_alloc_to_trigger = gc_heap::get_total_servo_alloc (max_generation + 1);
-        dprintf (BGC_TUNING_LOG, ("BTL[GTC] mem high enough: %d(goal: %d), %Id BGCs done, g2a=%Id, g3a=%Id, trigger FL tuning!", 
+        dprintf (BGC_TUNING_LOG, ("BTL[GTC] mem high enough: %d(goal: %d), %Id BGCs done, g2a=%Id, g3a=%Id, trigger FL tuning!",
             gc_heap::settings.entry_memory_load, memory_load_goal,
             gc_heap::full_gc_counts[gc_type_background],
             gen_calc[0].first_alloc_to_trigger,
@@ -28918,7 +28915,7 @@ void gc_heap::bgc_tuning::update_bgc_start (int gen_number, size_t num_gen1s_sin
     double physical_gen_flr = (double)current_bgc_fl_size * 100.0 / (double)total_generation_size;
 
     ptrdiff_t artificial_additional_fl = 0;
-    
+
     if (fl_tuning_triggered)
     {
         artificial_additional_fl = ((current_gen_calc->end_gen_size_goal > total_generation_size) ? (current_gen_calc->end_gen_size_goal - total_generation_size) : 0);
@@ -28929,7 +28926,7 @@ void gc_heap::bgc_tuning::update_bgc_start (int gen_number, size_t num_gen1s_sin
     current_gen_calc->current_bgc_start_flr = (double)current_bgc_fl_size * 100.0 / (double)total_generation_size;
 
     size_t current_alloc = get_total_servo_alloc (gen_number);
-    dprintf (BGC_TUNING_LOG, ("BTL%d: st a: %Id, la: %Id", 
+    dprintf (BGC_TUNING_LOG, ("BTL%d: st a: %Id, la: %Id",
         gen_number, current_alloc, current_gen_stats->last_alloc));
     current_gen_stats->last_alloc_end_to_start = current_alloc - current_gen_stats->last_alloc;
     current_gen_stats->last_alloc = current_alloc;
@@ -28937,8 +28934,8 @@ void gc_heap::bgc_tuning::update_bgc_start (int gen_number, size_t num_gen1s_sin
     current_gen_calc->actual_alloc_to_trigger = current_alloc - current_gen_calc->last_bgc_end_alloc;
 
     dprintf (BGC_TUNING_LOG, ("BTL%d: st: %Id g1s (%Id->%Id/gen1) since end, flr: %.3f(afl: %Id, %.3f)",
-             gen_number, actual_num_gen1s_to_trigger, 
-             current_gen_stats->last_alloc_end_to_start, 
+             gen_number, actual_num_gen1s_to_trigger,
+             current_gen_stats->last_alloc_end_to_start,
              (num_gen1s_since_end ? (current_gen_stats->last_alloc_end_to_start / num_gen1s_since_end) : 0),
              current_gen_calc->current_bgc_start_flr, artificial_additional_fl, physical_gen_flr));
 }
@@ -28951,11 +28948,11 @@ void gc_heap::bgc_tuning::record_bgc_start()
     size_t elapsed_time_so_far = GetHighPrecisionTimeStamp() - start_time;
 
     // Note that younger gen's collection count is always updated with older gen's collections.
-    // So to calcuate the actual # of gen1 occurred we really should take the # of gen2s into 
+    // So to calcuate the actual # of gen1 occurred we really should take the # of gen2s into
     // acccount (and deduct from gen1's collection count). But right now I am using it for stats.
     size_t current_gen1_index = get_current_gc_index (max_generation - 1);
 
-    dprintf (BGC_TUNING_LOG, ("BTL: g2t[st][g1 %Id]: %0.3f minutes", 
+    dprintf (BGC_TUNING_LOG, ("BTL: g2t[st][g1 %Id]: %0.3f minutes",
         current_gen1_index,
         (double)elapsed_time_so_far / (double)1000 / (double)60));
 
@@ -29032,19 +29029,19 @@ void gc_heap::bgc_tuning::update_bgc_sweep_start (int gen_number, size_t num_gen
     current_gen_calc->current_bgc_sweep_flr = (double)current_bgc_fl_size * 100.0 / (double)total_generation_size;
 
     size_t current_alloc = get_total_servo_alloc (gen_number);
-    dprintf (BGC_TUNING_LOG, ("BTL%d: sw a: %Id, la: %Id", 
+    dprintf (BGC_TUNING_LOG, ("BTL%d: sw a: %Id, la: %Id",
         gen_number, current_alloc, current_gen_stats->last_alloc));
     current_gen_stats->last_alloc_start_to_sweep = current_alloc - current_gen_stats->last_alloc;
     // We are resetting gen2 alloc at sweep start.
-    current_gen_stats->last_alloc = 0; 
+    current_gen_stats->last_alloc = 0;
 
 #ifdef SIMPLE_DPRINTF
     dprintf (BGC_TUNING_LOG, ("BTL%d: sflr: %.3f%%->%.3f%% (%Id->%Id, %Id->%Id) (%Id:%Id-%Id/gen1) since start (afl: %Id, %.3f)",
              gen_number,
              current_gen_calc->last_bgc_flr, current_gen_calc->current_bgc_sweep_flr,
-             current_gen_calc->last_bgc_size, total_generation_size, 
+             current_gen_calc->last_bgc_size, total_generation_size,
              current_gen_stats->last_bgc_fl_size, current_bgc_fl_size,
-             num_gen1s_since_start, current_gen_stats->last_alloc_start_to_sweep, 
+             num_gen1s_since_start, current_gen_stats->last_alloc_start_to_sweep,
              (num_gen1s_since_start? (current_gen_stats->last_alloc_start_to_sweep / num_gen1s_since_start) : 0),
              artificial_additional_fl, physical_gen_flr));
 #endif //SIMPLE_DPRINTF
@@ -29060,7 +29057,7 @@ void gc_heap::bgc_tuning::record_bgc_sweep_start()
     gen1_index_last_bgc_sweep = current_gen1_index;
 
     size_t elapsed_time_so_far = GetHighPrecisionTimeStamp() - start_time;
-    dprintf (BGC_TUNING_LOG, ("BTL: g2t[sw][g1 %Id]: %0.3f minutes", 
+    dprintf (BGC_TUNING_LOG, ("BTL: g2t[sw][g1 %Id]: %0.3f minutes",
         current_gen1_index,
         (double)elapsed_time_so_far / (double)1000 / (double)60));
 
@@ -29089,11 +29086,11 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
 
     // This is usually 0 unless a GC happened where we joined at the end of sweep
     size_t current_alloc = get_total_servo_alloc (gen_number);
-    //dprintf (BGC_TUNING_LOG, ("BTL%d: current fl alloc: %Id, last recorded alloc: %Id, last_bgc_end_alloc: %Id", 
-    dprintf (BGC_TUNING_LOG, ("BTL%d: en a: %Id, la: %Id, lbgca: %Id", 
+    //dprintf (BGC_TUNING_LOG, ("BTL%d: current fl alloc: %Id, last recorded alloc: %Id, last_bgc_end_alloc: %Id",
+    dprintf (BGC_TUNING_LOG, ("BTL%d: en a: %Id, la: %Id, lbgca: %Id",
         gen_number, current_alloc, current_gen_stats->last_alloc, current_gen_calc->last_bgc_end_alloc));
 
-    double current_bgc_surv_rate = (current_bgc_begin_data_size == 0) ? 
+    double current_bgc_surv_rate = (current_bgc_begin_data_size == 0) ?
                                     0 : ((double)current_bgc_surv_size * 100.0 / (double)current_bgc_begin_data_size);
 
     current_gen_stats->last_alloc_sweep_to_end = current_alloc - current_gen_stats->last_alloc;
@@ -29125,13 +29122,13 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
 
     dprintf (BGC_TUNING_LOG, ("BTL%d-en[g1: %Id, g2: %Id]: end fl: %Id (%Id: S-%Id, %.3f%%->%.3f%%)",
             gen_number,
-            gen1_index, gen2_index, current_bgc_fl, 
+            gen1_index, gen2_index, current_bgc_fl,
             total_generation_size, current_bgc_surv_size,
             current_gen_stats->last_bgc_surv_rate, current_bgc_surv_rate));
 
     dprintf (BGC_TUNING_LOG, ("BTLS%d sflr: %.3f, end-start: %Id(%Id), start-sweep: %Id(%Id), sweep-end: %Id(%Id)",
             gen_number,
-            current_gen_calc->current_bgc_sweep_flr, 
+            current_gen_calc->current_bgc_sweep_flr,
             (gen1_index_last_bgc_start - gen1_index_last_bgc_end), current_gen_stats->last_alloc_end_to_start,
             (gen1_index_last_bgc_sweep - gen1_index_last_bgc_start), current_gen_stats->last_alloc_start_to_sweep,
             num_gen1s_since_sweep, current_gen_stats->last_alloc_sweep_to_end));
@@ -29171,11 +29168,11 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
             {
                 if (current_gen_calc->above_goal_accu_error > max_alloc_to_trigger)
                 {
-                    dprintf (BGC_TUNING_LOG, ("g%d: ae TB! %.1f->%.1f", gen_number, current_gen_calc->above_goal_accu_error, max_alloc_to_trigger)); 
+                    dprintf (BGC_TUNING_LOG, ("g%d: ae TB! %.1f->%.1f", gen_number, current_gen_calc->above_goal_accu_error, max_alloc_to_trigger));
                 }
                 else if (current_gen_calc->above_goal_accu_error < min_alloc_to_trigger)
                 {
-                    dprintf (BGC_TUNING_LOG, ("g%d: ae TS! %.1f->%.1f", gen_number, current_gen_calc->above_goal_accu_error, min_alloc_to_trigger)); 
+                    dprintf (BGC_TUNING_LOG, ("g%d: ae TS! %.1f->%.1f", gen_number, current_gen_calc->above_goal_accu_error, min_alloc_to_trigger));
                 }
 
                 current_gen_calc->above_goal_accu_error = min (max_alloc_to_trigger, current_gen_calc->above_goal_accu_error);
@@ -29184,7 +29181,7 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
                 double above_goal_ki_gain = above_goal_ki * above_goal_distance * current_bgc_fl;
                 double temp_accu_error = current_gen_calc->above_goal_accu_error + above_goal_ki_gain;
                 // anti-windup
-                if ((temp_accu_error > min_alloc_to_trigger) && 
+                if ((temp_accu_error > min_alloc_to_trigger) &&
                     (temp_accu_error < max_alloc_to_trigger))
                 {
                     current_gen_calc->above_goal_accu_error = temp_accu_error;
@@ -29192,8 +29189,8 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
                 else
                 {
                     //dprintf (BGC_TUNING_LOG, ("alloc accu err + %.1f=%.1f, exc",
-                    dprintf (BGC_TUNING_LOG, ("g%d: aae + %.1f=%.1f, exc", gen_number, 
-                            above_goal_ki_gain, 
+                    dprintf (BGC_TUNING_LOG, ("g%d: aae + %.1f=%.1f, exc", gen_number,
+                            above_goal_ki_gain,
                             temp_accu_error));
                 }
             }
@@ -29205,12 +29202,12 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
                 // la is last alloc_to_trigger, +%Id is the diff between la and the new alloc.
                 // laa is the last actual alloc (gen_actual_alloc_to_trigger), +%Id is the diff between la and laa.
                 dprintf (BGC_TUNING_LOG, ("BTL%d: sflr %.3f above * %.4f * %Id = %Id bytes in alloc, la: %Id(+%Id), laa: %Id(+%Id)",
-                        gen_number, 
+                        gen_number,
                         (current_gen_calc->current_bgc_sweep_flr - (double)gen_sweep_flr_goal),
                         adjusted_above_goal_kp,
                         current_bgc_fl,
                         (size_t)current_alloc_to_trigger,
-                        saved_alloc_to_trigger, 
+                        saved_alloc_to_trigger,
                         (size_t)(current_alloc_to_trigger - (double)saved_alloc_to_trigger),
                         gen_actual_alloc_to_trigger,
                         (gen_actual_alloc_to_trigger - saved_alloc_to_trigger)));
@@ -29219,7 +29216,7 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
                 {
                     current_alloc_to_trigger += current_gen_calc->above_goal_accu_error;
                     dprintf (BGC_TUNING_LOG, ("BTL%d: +accu err %Id=%Id",
-                            gen_number, 
+                            gen_number,
                             (size_t)(current_gen_calc->above_goal_accu_error),
                             (size_t)current_alloc_to_trigger));
                 }
@@ -29266,7 +29263,7 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
                 current_gen_calc->alloc_to_trigger = (size_t)((double)gen_actual_alloc_to_trigger * (1 + adjust_ratio));
 
                 dprintf (BGC_TUNING_LOG, ("BTL%d: kd %.3f, reduced it to %.3f * %Id, adjust %Id->%Id",
-                        gen_number, saved_adjust_ratio, 
+                        gen_number, saved_adjust_ratio,
                         adjust_ratio, gen_actual_alloc_to_trigger,
                         saved_alloc_to_trigger, current_gen_calc->alloc_to_trigger));
             }
@@ -29275,14 +29272,14 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
             {
                 saved_alloc_to_trigger = current_gen_calc->alloc_to_trigger;
                 size_t gen_smoothed_alloc_to_trigger = current_gen_calc->smoothed_alloc_to_trigger;
-                double current_num_gen1s_smooth_factor = (num_gen1s_smooth_factor > (double)num_bgcs_since_tuning_trigger) ? 
+                double current_num_gen1s_smooth_factor = (num_gen1s_smooth_factor > (double)num_bgcs_since_tuning_trigger) ?
                                                         (double)num_bgcs_since_tuning_trigger : num_gen1s_smooth_factor;
-                current_gen_calc->smoothed_alloc_to_trigger = (size_t)((double)saved_alloc_to_trigger / current_num_gen1s_smooth_factor + 
+                current_gen_calc->smoothed_alloc_to_trigger = (size_t)((double)saved_alloc_to_trigger / current_num_gen1s_smooth_factor +
                     ((double)gen_smoothed_alloc_to_trigger / current_num_gen1s_smooth_factor) * (current_num_gen1s_smooth_factor - 1.0));
 
-                dprintf (BGC_TUNING_LOG, ("BTL%d: smoothed %Id / %.3f + %Id / %.3f * %.3f adjust %Id->%Id", 
+                dprintf (BGC_TUNING_LOG, ("BTL%d: smoothed %Id / %.3f + %Id / %.3f * %.3f adjust %Id->%Id",
                     gen_number, saved_alloc_to_trigger, current_num_gen1s_smooth_factor,
-                    gen_smoothed_alloc_to_trigger, current_num_gen1s_smooth_factor, 
+                    gen_smoothed_alloc_to_trigger, current_num_gen1s_smooth_factor,
                     (current_num_gen1s_smooth_factor - 1.0),
                     saved_alloc_to_trigger, current_gen_calc->smoothed_alloc_to_trigger));
                 current_gen_calc->alloc_to_trigger = current_gen_calc->smoothed_alloc_to_trigger;
@@ -29300,7 +29297,7 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
 
                 if (use_this_loop_p)
                 {
-                    // if we adjust down we want ff to be bigger, so the alloc will be even smaller; 
+                    // if we adjust down we want ff to be bigger, so the alloc will be even smaller;
                     // if we adjust up want ff to be smaller, so the alloc will also be smaller;
                     // the idea is we want to be slower at increase than decrease
                     double ff_step = above_goal_ff * 0.5;
@@ -29312,8 +29309,8 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
 
                     double adjusted_ff_ratio = ff_ratio * adjusted_above_goal_ff;
                     current_gen_calc->alloc_to_trigger = saved_alloc_to_trigger + (size_t)((double)saved_alloc_to_trigger * adjusted_ff_ratio);
-                    dprintf (BGC_TUNING_LOG, ("BTL%d: ff (%.3f / %.3f - 1) * %.3f = %.3f adjust %Id->%Id", 
-                        gen_number, next_end_to_sweep_flr, current_end_to_sweep_flr, adjusted_above_goal_ff, adjusted_ff_ratio, 
+                    dprintf (BGC_TUNING_LOG, ("BTL%d: ff (%.3f / %.3f - 1) * %.3f = %.3f adjust %Id->%Id",
+                        gen_number, next_end_to_sweep_flr, current_end_to_sweep_flr, adjusted_above_goal_ff, adjusted_ff_ratio,
                         saved_alloc_to_trigger, current_gen_calc->alloc_to_trigger));
                 }
             }
@@ -29342,7 +29339,7 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
         {
             // we can't do the above comparison - we could be in the situation where
             // we haven't done any alloc.
-            dprintf (BGC_TUNING_LOG, ("BTL%d: ag, revert %Id->%Id", 
+            dprintf (BGC_TUNING_LOG, ("BTL%d: ag, revert %Id->%Id",
                 gen_number, current_gen_calc->alloc_to_trigger, last_gen_alloc_to_trigger));
             current_gen_calc->alloc_to_trigger = last_gen_alloc_to_trigger;
         }
@@ -29357,9 +29354,9 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
 
         current_gen_calc->alloc_to_trigger = max (first_alloc, min_first_alloc);
 
-        dprintf (BGC_TUNING_LOG, ("BTL%d[g1: %Id]: BGC end, trigger FL, set gen%d alloc to max (0.75 of first: %Id, 5%% fl: %Id), actual alloc: %Id", 
-            gen_number, gen1_index, gen_number, 
-            first_alloc, min_first_alloc, 
+        dprintf (BGC_TUNING_LOG, ("BTL%d[g1: %Id]: BGC end, trigger FL, set gen%d alloc to max (0.75 of first: %Id, 5%% fl: %Id), actual alloc: %Id",
+            gen_number, gen1_index, gen_number,
+            first_alloc, min_first_alloc,
             current_gen_calc->actual_alloc_to_trigger));
     }
 
@@ -29371,7 +29368,7 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
                               current_bgc_end_data[tuning_data_index].gen_flr,
                               current_gen_stats->last_gen_increase_flr,
                               current_bgc_surv_rate,
-                              actual_num_gen1s_to_trigger, 
+                              actual_num_gen1s_to_trigger,
                               num_gen1s_bgc_end,
                               gen_actual_alloc_to_trigger,
                               current_gen_calc->alloc_to_trigger));
@@ -29385,7 +29382,7 @@ void gc_heap::bgc_tuning::calculate_tuning (int gen_number, bool use_this_loop_p
 
     current_gen_stats->last_bgc_physical_size = data->gen_physical_size;
     current_gen_stats->last_alloc_end_to_start = 0;
-    current_gen_stats->last_alloc_start_to_sweep = 0; 
+    current_gen_stats->last_alloc_start_to_sweep = 0;
     current_gen_stats->last_alloc_sweep_to_end = 0;
     current_gen_stats->last_alloc = current_alloc;
     current_gen_stats->last_bgc_fl_size = current_bgc_end_data[tuning_data_index].gen_fl_size;
@@ -29410,13 +29407,13 @@ void gc_heap::bgc_tuning::init_bgc_end_data (int gen_number, bool use_this_loop_
 
         if (current_gen_calc->actual_alloc_to_trigger > current_gen_calc->alloc_to_trigger)
         {
-            dprintf (BGC_TUNING_LOG, ("BTL%d: gen alloc also exceeded %Id (la: %Id), no action", 
+            dprintf (BGC_TUNING_LOG, ("BTL%d: gen alloc also exceeded %Id (la: %Id), no action",
                 gen_number, current_gen_calc->actual_alloc_to_trigger, current_gen_calc->alloc_to_trigger));
         }
         else
         {
             // We will deduct the missing portion from alloc to fl, simulating that we consumed it.
-            size_t remaining_alloc = current_gen_calc->alloc_to_trigger - 
+            size_t remaining_alloc = current_gen_calc->alloc_to_trigger -
                                      current_gen_calc->actual_alloc_to_trigger;
 
             // now re-calc current_bgc_sweep_flr
@@ -29429,7 +29426,7 @@ void gc_heap::bgc_tuning::init_bgc_end_data (int gen_number, bool use_this_loop_
             if (sweep_fl_size < remaining_alloc)
             {
                 dprintf (BGC_TUNING_LOG, ("BTL%d: sweep fl %Id < remain alloc %Id", gen_number, sweep_fl_size, remaining_alloc));
-                // TODO: this is saying that we didn't have enough fl to accommodate the 
+                // TODO: this is saying that we didn't have enough fl to accommodate the
                 // remaining alloc which is suspicious. To set remaining_alloc to
                 // something slightly smaller is only so that we could continue with
                 // our calculation but this is something we should look into.
@@ -29443,7 +29440,7 @@ void gc_heap::bgc_tuning::init_bgc_end_data (int gen_number, bool use_this_loop_
             double signed_new_current_bgc_sweep_flr = (double)signed_new_sweep_fl_size * 100.0 / (double)gen_size;
 
             dprintf (BGC_TUNING_LOG, ("BTL%d: sg: %Id(%Id), sfl: %Id->%Id(%Id)(%.3f->%.3f(%.3f)), la: %Id, aa: %Id",
-                gen_number, gen_size, physical_size, sweep_fl_size, 
+                gen_number, gen_size, physical_size, sweep_fl_size,
                 new_sweep_fl_size, signed_new_sweep_fl_size,
                 sweep_flr, new_current_bgc_sweep_flr, signed_new_current_bgc_sweep_flr,
                 current_gen_calc->alloc_to_trigger, current_gen_calc->actual_alloc_to_trigger));
@@ -29454,7 +29451,7 @@ void gc_heap::bgc_tuning::init_bgc_end_data (int gen_number, bool use_this_loop_
             // TODO: NOTE this is duplicated in calculate_tuning except I am not * 100.0 here.
             size_t current_bgc_surv_size = get_total_surv_size (gen_number);
             size_t current_bgc_begin_data_size = get_total_begin_data_size (gen_number);
-            double current_bgc_surv_rate = (current_bgc_begin_data_size == 0) ? 
+            double current_bgc_surv_rate = (current_bgc_begin_data_size == 0) ?
                                             0 : ((double)current_bgc_surv_size / (double)current_bgc_begin_data_size);
 
             size_t remaining_alloc_surv = (size_t)((double)remaining_alloc * current_bgc_surv_rate);
@@ -29478,7 +29475,7 @@ void gc_heap::bgc_tuning::calc_end_bgc_fl (int gen_number)
 {
     int index = gen_number - max_generation;
     bgc_size_data* data = &current_bgc_end_data[index];
-    
+
     tuning_calculation* current_gen_calc = &gen_calc[gen_number - max_generation];
 
     size_t virtual_size = current_gen_calc->end_gen_size_goal;
@@ -29496,8 +29493,8 @@ void gc_heap::bgc_tuning::calc_end_bgc_fl (int gen_number)
     data->gen_fl_size = end_gen_fl_size;
     data->gen_flr = (double)(data->gen_fl_size) * 100.0 / (double)(data->gen_size);
 
-    dprintf (BGC_TUNING_LOG, ("BTL%d: vfl: %Id, size %Id->%Id, fl %Id->%Id, flr %.3f->%.3f", 
-        gen_number, virtual_fl_size, 
+    dprintf (BGC_TUNING_LOG, ("BTL%d: vfl: %Id, size %Id->%Id, fl %Id->%Id, flr %.3f->%.3f",
+        gen_number, virtual_fl_size,
         data->gen_physical_size, data->gen_size,
         data->gen_physical_fl_size, data->gen_fl_size,
         data->gen_physical_flr, data->gen_flr));
@@ -29508,7 +29505,7 @@ double gc_heap::bgc_tuning::calculate_ml_tuning (uint64_t current_available_phys
 {
     ptrdiff_t error = (ptrdiff_t)(current_available_physical - available_memory_goal);
 
-    // This is questionable as gen0/1 and other processes are consuming memory 
+    // This is questionable as gen0/1 and other processes are consuming memory
     // too
     size_t gen2_physical_size = current_bgc_end_data[0].gen_physical_size;
     size_t gen3_physical_size = current_bgc_end_data[1].gen_physical_size;
@@ -29522,12 +29519,12 @@ double gc_heap::bgc_tuning::calculate_ml_tuning (uint64_t current_available_phys
     bool include_in_i_p = ((error_ratio > 0.005) || (error_ratio < -0.005));
 
     dprintf (BGC_TUNING_LOG, ("total phy %Id, mem goal: %Id, curr phy: %Id, g2 phy: %Id, g3 phy: %Id",
-            (size_t)total_physical_mem, (size_t)available_memory_goal, 
+            (size_t)total_physical_mem, (size_t)available_memory_goal,
             (size_t)current_available_physical,
             gen2_physical_size - gen3_physical_size));
-    dprintf (BGC_TUNING_LOG, ("BTL: Max output: %Id, ER %Id / %Id = %.3f, %s", 
+    dprintf (BGC_TUNING_LOG, ("BTL: Max output: %Id, ER %Id / %Id = %.3f, %s",
             (size_t)max_output,
-            error, available_memory_goal, error_ratio, 
+            error, available_memory_goal, error_ratio,
             (include_in_i_p ? "inc" : "exc")));
 
     if (include_in_i_p)
@@ -29599,8 +29596,8 @@ void gc_heap::bgc_tuning::set_total_gen_sizes (bool use_gen2_loop_p, bool use_ge
 
     if (panic_activated_p)
     {
-        dprintf (BGC_TUNING_LOG, ("BTL: exceeded slack %Id >= (%Id + %Id)", 
-            (size_t)current_memory_load, (size_t)memory_load_goal, 
+        dprintf (BGC_TUNING_LOG, ("BTL: exceeded slack %Id >= (%Id + %Id)",
+            (size_t)current_memory_load, (size_t)memory_load_goal,
             (size_t)memory_load_goal_slack));
     }
 
@@ -29619,13 +29616,13 @@ void gc_heap::bgc_tuning::set_total_gen_sizes (bool use_gen2_loop_p, bool use_ge
             gen2_ratio_correction -= ratio_correction_step;
         }
 
-        dprintf (BGC_TUNING_LOG, ("BTL: rc: g2 ratio %.3f%% + %d%% = %.3f%%", 
+        dprintf (BGC_TUNING_LOG, ("BTL: rc: g2 ratio %.3f%% + %d%% = %.3f%%",
             (gen2_size_ratio * 100.0), (int)(gen2_ratio_correction * 100.0), ((gen2_size_ratio + gen2_ratio_correction) * 100.0)));
 
         gen2_ratio_correction = min (0.99, gen2_ratio_correction);
         gen2_ratio_correction = max (-0.99, gen2_ratio_correction);
 
-        dprintf (BGC_TUNING_LOG, ("BTL: rc again: g2 ratio %.3f%% + %d%% = %.3f%%", 
+        dprintf (BGC_TUNING_LOG, ("BTL: rc again: g2 ratio %.3f%% + %d%% = %.3f%%",
             (gen2_size_ratio * 100.0), (int)(gen2_ratio_correction * 100.0), ((gen2_size_ratio + gen2_ratio_correction) * 100.0)));
 
         gen2_size_ratio += gen2_ratio_correction;
@@ -29679,8 +29676,8 @@ void gc_heap::bgc_tuning::set_total_gen_sizes (bool use_gen2_loop_p, bool use_ge
     calc_end_bgc_fl (max_generation + 1);
 
 #ifdef SIMPLE_DPRINTF
-    dprintf (BGC_TUNING_LOG, ("BTL: ml: %d (g: %d)(%s), a: %I64d (g: %I64d, elg: %Id+%Id=%Id, %Id+%Id=%Id, pi=%Id), vfl: %Id=%Id+%Id", 
-        current_memory_load, memory_load_goal, 
+    dprintf (BGC_TUNING_LOG, ("BTL: ml: %d (g: %d)(%s), a: %I64d (g: %I64d, elg: %Id+%Id=%Id, %Id+%Id=%Id, pi=%Id), vfl: %Id=%Id+%Id",
+        current_memory_load, memory_load_goal,
         ((current_available_physical > available_memory_goal) ? "above" : "below"),
         current_available_physical, available_memory_goal,
         gen2_physical_size, gen2_virtual_fl_size, gen_calc[0].end_gen_size_goal,
@@ -29715,9 +29712,9 @@ void gc_heap::bgc_tuning::convert_to_fl (bool use_gen2_loop_p, bool use_gen3_loo
     set_total_gen_sizes (use_gen2_loop_p, use_gen3_loop_p);
 
     dprintf (BGC_TUNING_LOG, ("BTL: gen2 %Id, fl %Id(%.3f)->%Id; gen3 %Id, fl %Id(%.3f)->%Id, %Id BGCs",
-        current_bgc_end_data[0].gen_size, current_bgc_end_data[0].gen_fl_size, 
+        current_bgc_end_data[0].gen_size, current_bgc_end_data[0].gen_fl_size,
         current_bgc_end_data[0].gen_flr, gen_calc[0].end_gen_size_goal,
-        current_bgc_end_data[1].gen_size, current_bgc_end_data[1].gen_fl_size, 
+        current_bgc_end_data[1].gen_size, current_bgc_end_data[1].gen_fl_size,
         current_bgc_end_data[1].gen_flr, gen_calc[1].end_gen_size_goal,
         current_bgc_count));
 }
@@ -29729,7 +29726,7 @@ void gc_heap::bgc_tuning::record_and_adjust_bgc_end()
 
     size_t elapsed_time_so_far = GetHighPrecisionTimeStamp() - start_time;
     size_t current_gen1_index = get_current_gc_index (max_generation - 1);
-    dprintf (BGC_TUNING_LOG, ("BTL: g2t[en][g1 %Id]: %0.3f minutes", 
+    dprintf (BGC_TUNING_LOG, ("BTL: g2t[en][g1 %Id]: %0.3f minutes",
         current_gen1_index,
         (double)elapsed_time_so_far / (double)1000 / (double)60));
 
@@ -29740,8 +29737,8 @@ void gc_heap::bgc_tuning::record_and_adjust_bgc_end()
 
     bool use_gen2_loop_p = (settings.reason == reason_bgc_tuning_soh);
     bool use_gen3_loop_p = (settings.reason == reason_bgc_tuning_loh);
-    dprintf (BGC_TUNING_LOG, ("BTL: reason: %d, gen2 loop: %s; gen3 loop: %s, promoted %Id bytes", 
-        (((settings.reason != reason_bgc_tuning_soh) && (settings.reason != reason_bgc_tuning_loh)) ? 
+    dprintf (BGC_TUNING_LOG, ("BTL: reason: %d, gen2 loop: %s; gen3 loop: %s, promoted %Id bytes",
+        (((settings.reason != reason_bgc_tuning_soh) && (settings.reason != reason_bgc_tuning_loh)) ?
             saved_bgc_tuning_reason : settings.reason),
         (use_gen2_loop_p ? "yes" : "no"),
         (use_gen3_loop_p ? "yes" : "no"),
@@ -29826,7 +29823,7 @@ void gc_heap::clear_card_for_addresses (uint8_t* start_address, uint8_t* end_add
 inline
 void gc_heap::copy_cards (size_t dst_card,
                           size_t src_card,
-                          size_t end_card, 
+                          size_t end_card,
                           BOOL nextp)
 {
     // If the range is empty, this function is a no-op - with the subtlety that
@@ -29979,8 +29976,8 @@ void gc_heap::copy_mark_bits_for_addresses (uint8_t* dest, uint8_t* src, size_t 
             //    FATAL_GC_ERROR();
             //}
 
-            background_mark (dest_o, 
-                             background_saved_lowest_address, 
+            background_mark (dest_o,
+                             background_saved_lowest_address,
                              background_saved_highest_address);
             dprintf (3, ("bc*%Ix*bc, b*%Ix*b", (size_t)src_o, (size_t)(dest_o)));
         }
@@ -29998,7 +29995,7 @@ void gc_heap::fix_brick_to_highest (uint8_t* o, uint8_t* next_o)
     size_t b = 1 + new_current_brick;
     size_t limit = brick_of (next_o);
     //dprintf(3,(" fixing brick %Ix to point to object %Ix, till %Ix(%Ix)",
-    dprintf(3,("b:%Ix->%Ix-%Ix", 
+    dprintf(3,("b:%Ix->%Ix-%Ix",
                new_current_brick, (size_t)o, (size_t)next_o));
     while (b < limit)
     {
@@ -30078,8 +30075,8 @@ uint8_t* gc_heap::find_first_object (uint8_t* start, uint8_t* first_object)
     }
 
     size_t bo = brick_of (o);
-    //dprintf (3, ("Looked at %Id objects, fixing brick [%Ix-[%Ix", 
-    dprintf (3, ("%Id o, [%Ix-[%Ix", 
+    //dprintf (3, ("Looked at %Id objects, fixing brick [%Ix-[%Ix",
+    dprintf (3, ("%Id o, [%Ix-[%Ix",
         n_o, bo, brick));
     if (bo < brick)
     {
@@ -30136,7 +30133,7 @@ BOOL gc_heap::find_card_dword (size_t& cardw, size_t cardw_end)
             {
                 // a whole bundle was explored and is empty
                 dprintf  (3, ("gc: %d, find_card_dword clear bundle: %Ix cardw:[%Ix,%Ix[",
-                        dd_collection_count (dynamic_data_of (0)), 
+                        dd_collection_count (dynamic_data_of (0)),
                         cardb, card_bundle_cardw (cardb),
                         card_bundle_cardw (cardb+1)));
                 card_bundle_clear (cardb);
@@ -30183,7 +30180,7 @@ BOOL gc_heap::find_card(uint32_t* card_table,
     uint32_t* last_card_word;
     uint32_t card_word_value;
     uint32_t bit_position;
-    
+
     if (card_word (card) >= card_word_end)
         return FALSE;
 
@@ -30195,7 +30192,7 @@ BOOL gc_heap::find_card(uint32_t* card_table,
     {
         bit_position = 0;
 #ifdef CARD_BUNDLE
-        // Using the card bundle, go through the remaining card words between here and 
+        // Using the card bundle, go through the remaining card words between here and
         // card_word_end until we find one that is non-zero.
         size_t lcw = card_word(card) + 1;
         if (gc_heap::find_card_dword (lcw, card_word_end) == FALSE)
@@ -30239,7 +30236,7 @@ BOOL gc_heap::find_card(uint32_t* card_table,
             card_word_value = card_word_value / 2;
         }
     }
-    
+
     // card is the card word index * card size + the bit index within the card
     card = (last_card_word - &card_table[0]) * card_word_width + bit_position;
 
@@ -30264,7 +30261,7 @@ BOOL gc_heap::find_card(uint32_t* card_table,
     } while (card_word_value & 1);
 
     end_card = (last_card_word - &card_table [0])* card_word_width + bit_position;
-    
+
     //dprintf (3, ("find_card: [%Ix, %Ix[ set", card, end_card));
     dprintf (3, ("fc: [%Ix, %Ix[", card, end_card));
     return TRUE;
@@ -30379,7 +30376,7 @@ gc_heap::mark_through_cards_helper (uint8_t** poo, size_t& n_gen,
 }
 
 BOOL gc_heap::card_transition (uint8_t* po, uint8_t* end, size_t card_word_end,
-                               size_t& cg_pointers_found, 
+                               size_t& cg_pointers_found,
                                size_t& n_eph, size_t& n_card_set,
                                size_t& card, size_t& end_card,
                                BOOL& foundp, uint8_t*& start_address,
@@ -30538,8 +30535,8 @@ void gc_heap::mark_through_cards_for_segments (card_fn fn, BOOL relocating CARD_
 
     while (soh_seg)
     {
-        dprintf (3, ("seg %Ix, bgc_alloc: %Ix, alloc: %Ix", 
-            soh_seg, 
+        dprintf (3, ("seg %Ix, bgc_alloc: %Ix, alloc: %Ix",
+            soh_seg,
             heap_segment_background_allocated (soh_seg),
             heap_segment_allocated (soh_seg)));
 
@@ -30555,7 +30552,7 @@ void gc_heap::mark_through_cards_for_segments (card_fn fn, BOOL relocating CARD_
     int           curr_gen_number   = max_generation;
     uint8_t*      gen_boundary      = generation_allocation_start(generation_of(curr_gen_number - 1));
     uint8_t*      next_boundary     = compute_next_boundary(gc_low, curr_gen_number, relocating);
-    
+
     heap_segment* seg               = heap_segment_rw (generation_start_segment (oldest_gen));
     PREFIX_ASSUME(seg != NULL);
 
@@ -30727,7 +30724,7 @@ void gc_heap::mark_through_cards_for_segments (card_fn fn, BOOL relocating CARD_
                     if (card_of (o) > card)
                     {
                         passed_end_card_p = card_transition (o, end, card_word_end,
-                            cg_pointers_found, 
+                            cg_pointers_found,
                             n_eph, n_card_set,
                             card, end_card,
                             foundp, start_address,
@@ -30763,7 +30760,7 @@ void gc_heap::mark_through_cards_for_segments (card_fn fn, BOOL relocating CARD_
                             goto end_object;
                         }
                         else
-                            goto end_limit;                            
+                            goto end_limit;
                     }
                 }
 
@@ -30785,13 +30782,13 @@ go_through_refs:
                                  {
                                      BOOL passed_end_card_p  = card_transition ((uint8_t*)poo, end,
                                             card_word_end,
-                                            cg_pointers_found, 
+                                            cg_pointers_found,
                                             n_eph, n_card_set,
                                             card, end_card,
                                             foundp, start_address,
                                             limit, total_cards_cleared
                                             CARD_MARKING_STEALING_ARGS(card_mark_enumerator, seg, card_word_end));
-                                    
+
                                      if (passed_end_card_p)
                                      {
                                          if (foundp && (card_address (card) < next_o))
@@ -30838,12 +30835,12 @@ go_through_refs:
     if (!relocating)
     {
         generation_skip_ratio = ((n_eph > 400)? (int)(((float)n_gen / (float)n_eph) * 100) : 100);
-        dprintf (3, ("Msoh: cross: %Id, useful: %Id, cards set: %Id, cards cleared: %Id, ratio: %d", 
+        dprintf (3, ("Msoh: cross: %Id, useful: %Id, cards set: %Id, cards cleared: %Id, ratio: %d",
             n_eph, n_gen , n_card_set, total_cards_cleared, generation_skip_ratio));
     }
     else
     {
-        dprintf (3, ("R: Msoh: cross: %Id, useful: %Id, cards set: %Id, cards cleared: %Id, ratio: %d", 
+        dprintf (3, ("R: Msoh: cross: %Id, useful: %Id, cards set: %Id, cards cleared: %Id, ratio: %d",
             n_gen, n_eph, n_card_set, total_cards_cleared, generation_skip_ratio));
     }
 }
@@ -30858,7 +30855,7 @@ size_t gc_heap::dump_buckets (size_t* ordered_indices, int count, size_t* total_
         total_items += ordered_indices[i];
         *total_size += ordered_indices[i] << (MIN_INDEX_POWER2 + i);
         dprintf (SEG_REUSE_LOG_0, ("[%d]%4d 2^%2d", heap_number, ordered_indices[i], (MIN_INDEX_POWER2 + i)));
-    } 
+    }
     dprintf (SEG_REUSE_LOG_0, ("[%d]Total %d items, total size is 0x%Ix", heap_number, total_items, *total_size));
     return total_items;
 }
@@ -30890,10 +30887,10 @@ void gc_heap::count_plug (size_t last_plug_size, uint8_t*& last_plug)
         total_ephemeral_plugs += plug_size;
         size_t plug_size_power2 = round_up_power2 (plug_size);
         ordered_plug_indices[relative_index_power2_plug (plug_size_power2)]++;
-        dprintf (SEG_REUSE_LOG_1, ("[%d]count_plug: adding 0x%Ix - %Id (2^%d) to ordered plug array", 
-            heap_number, 
-            last_plug, 
-            plug_size, 
+        dprintf (SEG_REUSE_LOG_1, ("[%d]count_plug: adding 0x%Ix - %Id (2^%d) to ordered plug array",
+            heap_number,
+            last_plug,
+            plug_size,
             (relative_index_power2_plug (plug_size_power2) + MIN_INDEX_POWER2)));
     }
 }
@@ -30966,7 +30963,7 @@ void gc_heap::build_ordered_plug_indices ()
         else
             deque_pinned_plug();
     }
-    
+
     update_oldest_pinned_plug();
 
     while (current_brick <= end_brick)
@@ -30992,17 +30989,17 @@ void gc_heap::build_ordered_plug_indices ()
     total_ephemeral_plugs += extra_size;
     dprintf (SEG_REUSE_LOG_0, ("Making sure we can fit a large object after fitting all plugs"));
     ordered_plug_indices[relative_index_power2_plug (round_up_power2 (extra_size))]++;
-    
+
     memcpy (saved_ordered_plug_indices, ordered_plug_indices, sizeof(ordered_plug_indices));
 
 #ifdef SEG_REUSE_STATS
     dprintf (SEG_REUSE_LOG_0, ("Plugs:"));
     size_t total_plug_power2 = 0;
     dump_buckets (ordered_plug_indices, MAX_NUM_BUCKETS, &total_plug_power2);
-    dprintf (SEG_REUSE_LOG_0, ("plugs: 0x%Ix (rounded up to 0x%Ix (%d%%))", 
-                total_ephemeral_plugs, 
-                total_plug_power2, 
-                (total_ephemeral_plugs ? 
+    dprintf (SEG_REUSE_LOG_0, ("plugs: 0x%Ix (rounded up to 0x%Ix (%d%%))",
+                total_ephemeral_plugs,
+                total_plug_power2,
+                (total_ephemeral_plugs ?
                     (total_plug_power2 * 100 / total_ephemeral_plugs) :
                     0)));
     dprintf (SEG_REUSE_LOG_0, ("-------------------"));
@@ -31056,7 +31053,7 @@ void gc_heap::trim_free_spaces_indices ()
         ordered_free_space_indices[i] = 0;
     }
 
-    memcpy (saved_ordered_free_space_indices, 
+    memcpy (saved_ordered_free_space_indices,
             ordered_free_space_indices,
             sizeof(ordered_free_space_indices));
 }
@@ -31082,7 +31079,7 @@ BOOL gc_heap::can_fit_in_spaces_p (size_t* ordered_blocks, int small_index, size
         return FALSE;
     }
 
-    dprintf (SEG_REUSE_LOG_1, ("[%d]Fitting %Id 2^%d plugs into %Id 2^%d free spaces", 
+    dprintf (SEG_REUSE_LOG_1, ("[%d]Fitting %Id 2^%d plugs into %Id 2^%d free spaces",
         heap_number,
         small_blocks, (small_index + MIN_INDEX_POWER2),
         big_spaces, (big_index + MIN_INDEX_POWER2)));
@@ -31090,14 +31087,14 @@ BOOL gc_heap::can_fit_in_spaces_p (size_t* ordered_blocks, int small_index, size
     size_t big_to_small = big_spaces << (big_index - small_index);
 
     ptrdiff_t extra_small_spaces = big_to_small - small_blocks;
-    dprintf (SEG_REUSE_LOG_1, ("[%d]%d 2^%d spaces can fit %d 2^%d blocks", 
+    dprintf (SEG_REUSE_LOG_1, ("[%d]%d 2^%d spaces can fit %d 2^%d blocks",
         heap_number,
         big_spaces, (big_index + MIN_INDEX_POWER2), big_to_small, (small_index + MIN_INDEX_POWER2)));
     BOOL can_fit = (extra_small_spaces >= 0);
 
-    if (can_fit) 
+    if (can_fit)
     {
-        dprintf (SEG_REUSE_LOG_1, ("[%d]Can fit with %d 2^%d extras blocks", 
+        dprintf (SEG_REUSE_LOG_1, ("[%d]Can fit with %d 2^%d extras blocks",
             heap_number,
             extra_small_spaces, (small_index + MIN_INDEX_POWER2)));
     }
@@ -31114,7 +31111,7 @@ BOOL gc_heap::can_fit_in_spaces_p (size_t* ordered_blocks, int small_index, size
         {
             if (extra_small_spaces & 1)
             {
-                dprintf (SEG_REUSE_LOG_1, ("[%d]Increasing # of 2^%d spaces from %d to %d", 
+                dprintf (SEG_REUSE_LOG_1, ("[%d]Increasing # of 2^%d spaces from %d to %d",
                     heap_number,
                     (i + MIN_INDEX_POWER2), ordered_spaces[i], (ordered_spaces[i] + 1)));
                 ordered_spaces[i] += 1;
@@ -31122,17 +31119,17 @@ BOOL gc_heap::can_fit_in_spaces_p (size_t* ordered_blocks, int small_index, size
             extra_small_spaces >>= 1;
         }
 
-        dprintf (SEG_REUSE_LOG_1, ("[%d]Finally increasing # of 2^%d spaces from %d to %d", 
+        dprintf (SEG_REUSE_LOG_1, ("[%d]Finally increasing # of 2^%d spaces from %d to %d",
             heap_number,
             (i + MIN_INDEX_POWER2), ordered_spaces[i], (ordered_spaces[i] + extra_small_spaces)));
         ordered_spaces[i] += extra_small_spaces;
     }
     else
     {
-        dprintf (SEG_REUSE_LOG_1, ("[%d]Decreasing # of 2^%d blocks from %d to %d", 
+        dprintf (SEG_REUSE_LOG_1, ("[%d]Decreasing # of 2^%d blocks from %d to %d",
             heap_number,
-            (small_index + MIN_INDEX_POWER2), 
-            ordered_blocks[small_index], 
+            (small_index + MIN_INDEX_POWER2),
+            ordered_blocks[small_index],
             (ordered_blocks[small_index] - big_to_small)));
         ordered_blocks[small_index] -= big_to_small;
     }
@@ -31188,14 +31185,14 @@ void gc_heap::build_ordered_free_spaces (heap_segment* seg)
 {
     assert (bestfit_seg);
 
-    //bestfit_seg->add_buckets (MAX_NUM_BUCKETS - free_space_buckets + MIN_INDEX_POWER2, 
-    //                    ordered_free_space_indices + (MAX_NUM_BUCKETS - free_space_buckets), 
-    //                    free_space_buckets, 
+    //bestfit_seg->add_buckets (MAX_NUM_BUCKETS - free_space_buckets + MIN_INDEX_POWER2,
+    //                    ordered_free_space_indices + (MAX_NUM_BUCKETS - free_space_buckets),
+    //                    free_space_buckets,
     //                    free_space_items);
 
-    bestfit_seg->add_buckets (MIN_INDEX_POWER2, 
-                        ordered_free_space_indices, 
-                        MAX_NUM_BUCKETS, 
+    bestfit_seg->add_buckets (MIN_INDEX_POWER2,
+                        ordered_free_space_indices,
+                        MAX_NUM_BUCKETS,
                         free_space_items);
 
     assert (settings.condemned_generation == max_generation);
@@ -31213,7 +31210,7 @@ void gc_heap::build_ordered_free_spaces (heap_segment* seg)
     while (!pinned_plug_que_empty_p())
     {
         m = oldest_pin();
-        if ((pinned_plug (m) >= first_address) && 
+        if ((pinned_plug (m) >= first_address) &&
             (pinned_plug (m) < end_address) &&
             (pinned_len (m) >= eph_gen_starts))
         {
@@ -31264,16 +31261,16 @@ BOOL gc_heap::try_best_fit (BOOL end_of_segment_p)
         trim_free_spaces_indices ();
     }
 
-    BOOL can_bestfit = can_fit_all_blocks_p (ordered_plug_indices, 
-                                             ordered_free_space_indices, 
+    BOOL can_bestfit = can_fit_all_blocks_p (ordered_plug_indices,
+                                             ordered_free_space_indices,
                                              MAX_NUM_BUCKETS);
 
     return can_bestfit;
 }
 
-BOOL gc_heap::best_fit (size_t free_space, 
-                        size_t largest_free_space, 
-                        size_t additional_space, 
+BOOL gc_heap::best_fit (size_t free_space,
+                        size_t largest_free_space,
+                        size_t additional_space,
                         BOOL* use_additional_space)
 {
     dprintf (SEG_REUSE_LOG_0, ("gen%d: trying best fit mechanism", settings.condemned_generation));
@@ -31328,22 +31325,22 @@ BOOL gc_heap::best_fit (size_t free_space,
 #ifdef SEG_REUSE_STATS
     dprintf (SEG_REUSE_LOG_0, ("Free spaces:"));
     size_t total_free_space_power2 = 0;
-    size_t total_free_space_items = 
-        dump_buckets (ordered_free_space_indices, 
+    size_t total_free_space_items =
+        dump_buckets (ordered_free_space_indices,
                       MAX_NUM_BUCKETS,
                       &total_free_space_power2);
     dprintf (SEG_REUSE_LOG_0, ("currently max free spaces is %Id", max_free_space_items));
 
     dprintf (SEG_REUSE_LOG_0, ("Ephemeral plugs: 0x%Ix, free space: 0x%Ix (rounded down to 0x%Ix (%Id%%)), additional free_space: 0x%Ix",
-                total_ephemeral_plugs, 
-                free_space, 
-                total_free_space_power2, 
+                total_ephemeral_plugs,
+                free_space,
+                total_free_space_power2,
                 (free_space ? (total_free_space_power2 * 100 / free_space) : 0),
                 additional_space));
 
     size_t saved_all_free_space_indices[MAX_NUM_BUCKETS];
-    memcpy (saved_all_free_space_indices, 
-            ordered_free_space_indices, 
+    memcpy (saved_all_free_space_indices,
+            ordered_free_space_indices,
             sizeof(saved_all_free_space_indices));
 
 #endif // SEG_REUSE_STATS
@@ -31385,7 +31382,7 @@ BOOL gc_heap::best_fit (size_t free_space,
 #endif // SEG_REUSE_STATS
                 goto adjust;
             }
-            
+
             dprintf (SEG_REUSE_LOG_0, ("Adding end of segment (2^%d)", (relative_free_space_index + MIN_INDEX_POWER2)));
             ordered_free_space_indices[relative_free_space_index]++;
             use_bestfit = try_best_fit(TRUE);
@@ -31394,13 +31391,13 @@ BOOL gc_heap::best_fit (size_t free_space,
                 free_space_items++;
                 // Since we might've trimmed away some of the free spaces we had, we should see
                 // if we really need to use end of seg space - if it's the same or smaller than
-                // the largest space we trimmed we can just add that one back instead of 
+                // the largest space we trimmed we can just add that one back instead of
                 // using end of seg.
                 if (relative_free_space_index > trimmed_free_space_index)
                 {
                     *use_additional_space = TRUE;
                 }
-                else 
+                else
                 {
                     // If the addition space is <= than the last trimmed space, we
                     // should just use that last trimmed space instead.
@@ -31428,7 +31425,7 @@ adjust:
         {
             max_free_space_items += max_free_space_items / 2;
             dprintf (SEG_REUSE_LOG_0, ("----Temporarily increasing max free spaces to %Id", max_free_space_items));
-            memcpy (ordered_free_space_indices, 
+            memcpy (ordered_free_space_indices,
                     saved_all_free_space_indices,
                     sizeof(ordered_free_space_indices));
             if (try_best_fit(FALSE))
@@ -31467,9 +31464,9 @@ adjust:
     return use_bestfit;
 }
 
-BOOL gc_heap::process_free_space (heap_segment* seg, 
+BOOL gc_heap::process_free_space (heap_segment* seg,
                          size_t free_space,
-                         size_t min_free_size, 
+                         size_t min_free_size,
                          size_t min_cont_size,
                          size_t* total_free_space,
                          size_t* largest_free_space)
@@ -31478,14 +31475,14 @@ BOOL gc_heap::process_free_space (heap_segment* seg,
     *largest_free_space = max (*largest_free_space, free_space);
 
 #ifdef SIMPLE_DPRINTF
-    dprintf (SEG_REUSE_LOG_1, ("free space len: %Ix, total free space: %Ix, largest free space: %Ix", 
+    dprintf (SEG_REUSE_LOG_1, ("free space len: %Ix, total free space: %Ix, largest free space: %Ix",
                 free_space, *total_free_space, *largest_free_space));
 #endif //SIMPLE_DPRINTF
 
     if ((*total_free_space >= min_free_size) && (*largest_free_space >= min_cont_size))
     {
 #ifdef SIMPLE_DPRINTF
-        dprintf (SEG_REUSE_LOG_0, ("(gen%d)total free: %Ix(min: %Ix), largest free: %Ix(min: %Ix). Found segment %Ix to reuse without bestfit", 
+        dprintf (SEG_REUSE_LOG_0, ("(gen%d)total free: %Ix(min: %Ix), largest free: %Ix(min: %Ix). Found segment %Ix to reuse without bestfit",
             settings.condemned_generation,
             *total_free_space, min_free_size, *largest_free_space, min_cont_size,
             (size_t)seg));
@@ -31507,7 +31504,7 @@ BOOL gc_heap::expand_reused_seg_p()
 {
     BOOL reused_seg = FALSE;
     int heap_expand_mechanism = gc_data_per_heap.get_mechanism (gc_heap_expand);
-    if ((heap_expand_mechanism == expand_reuse_bestfit) || 
+    if ((heap_expand_mechanism == expand_reuse_bestfit) ||
         (heap_expand_mechanism == expand_reuse_normal))
     {
         reused_seg = TRUE;
@@ -31536,7 +31533,7 @@ BOOL gc_heap::can_expand_into_p (heap_segment* seg, size_t min_free_size, size_t
 
     end_address -= end_extra_space;
 
-    dprintf (SEG_REUSE_LOG_0, ("can_expand_into_p(gen%d): min free: %Ix, min continuous: %Ix", 
+    dprintf (SEG_REUSE_LOG_0, ("can_expand_into_p(gen%d): min free: %Ix, min continuous: %Ix",
         settings.condemned_generation, min_free_size, min_cont_size));
     size_t eph_gen_starts = eph_gen_starts_size;
 
@@ -31545,12 +31542,12 @@ BOOL gc_heap::can_expand_into_p (heap_segment* seg, size_t min_free_size, size_t
         size_t free_space = 0;
         size_t largest_free_space = free_space;
         dprintf (SEG_REUSE_LOG_0, ("can_expand_into_p: gen2: testing segment [%Ix %Ix", first_address, end_address));
-        //Look through the pinned plugs for relevant ones and Look for the right pinned plug to start from. 
+        //Look through the pinned plugs for relevant ones and Look for the right pinned plug to start from.
         //We are going to allocate the generation starts in the 1st free space,
         //so start from the first free space that's big enough for gen starts and a min object size.
-        // If we see a free space that is >= gen starts but < gen starts + min obj size we just don't use it - 
-        // we could use it by allocating the last generation start a bit bigger but 
-        // the complexity isn't worth the effort (those plugs are from gen2 
+        // If we see a free space that is >= gen starts but < gen starts + min obj size we just don't use it -
+        // we could use it by allocating the last generation start a bit bigger but
+        // the complexity isn't worth the effort (those plugs are from gen2
         // already anyway).
         reset_pinned_queue_bos();
         mark* m = 0;
@@ -31560,7 +31557,7 @@ BOOL gc_heap::can_expand_into_p (heap_segment* seg, size_t min_free_size, size_t
         while (!pinned_plug_que_empty_p())
         {
             m = oldest_pin();
-            if ((pinned_plug (m) >= first_address) && 
+            if ((pinned_plug (m) >= first_address) &&
                 (pinned_plug (m) < end_address) &&
                 (pinned_len (m) >= (eph_gen_starts + Align (min_obj_size))))
             {
@@ -31576,9 +31573,9 @@ BOOL gc_heap::can_expand_into_p (heap_segment* seg, size_t min_free_size, size_t
         {
             bestfit_first_pin = pinned_plug (m) - pinned_len (m);
 
-            if (process_free_space (seg, 
-                                    pinned_len (m) - eph_gen_starts, 
-                                    min_free_size, min_cont_size, 
+            if (process_free_space (seg,
+                                    pinned_len (m) - eph_gen_starts,
+                                    min_free_size, min_cont_size,
                                     &free_space, &largest_free_space))
             {
                 return TRUE;
@@ -31596,9 +31593,9 @@ BOOL gc_heap::can_expand_into_p (heap_segment* seg, size_t min_free_size, size_t
                ((pinned_plug (m) >= first_address) && (pinned_plug (m) < end_address)))
         {
             dprintf (3, ("looking at pin %Ix", pinned_plug (m)));
-            if (process_free_space (seg, 
-                                    pinned_len (m), 
-                                    min_free_size, min_cont_size, 
+            if (process_free_space (seg,
+                                    pinned_len (m),
+                                    min_free_size, min_cont_size,
                                     &free_space, &largest_free_space))
             {
                 return TRUE;
@@ -31608,9 +31605,9 @@ BOOL gc_heap::can_expand_into_p (heap_segment* seg, size_t min_free_size, size_t
             m = oldest_pin();
         }
 
-        //try to find space at the end of the segment. 
-        size_t end_space = (end_address - heap_segment_plan_allocated (seg)); 
-        size_t additional_space = ((min_free_size > free_space) ? (min_free_size - free_space) : 0); 
+        //try to find space at the end of the segment.
+        size_t end_space = (end_address - heap_segment_plan_allocated (seg));
+        size_t additional_space = ((min_free_size > free_space) ? (min_free_size - free_space) : 0);
         dprintf (SEG_REUSE_LOG_0, ("end space: %Ix; additional: %Ix", end_space, additional_space));
         if (end_space >= additional_space)
         {
@@ -31622,10 +31619,10 @@ BOOL gc_heap::can_expand_into_p (heap_segment* seg, size_t min_free_size, size_t
                 if (end_space >= min_cont_size)
                 {
                     additional_space = max (min_cont_size, additional_space);
-                    dprintf (SEG_REUSE_LOG_0, ("(gen2)Found segment %Ix to reuse without bestfit, with committing end of seg for eph", 
+                    dprintf (SEG_REUSE_LOG_0, ("(gen2)Found segment %Ix to reuse without bestfit, with committing end of seg for eph",
                         seg));
                 }
-                else 
+                else
                 {
                     if (settings.concurrent)
                     {
@@ -31648,14 +31645,14 @@ BOOL gc_heap::can_expand_into_p (heap_segment* seg, size_t min_free_size, size_t
                             additional_space_bestfit -= eph_gen_starts;
                         }
 
-                        can_fit = best_fit (free_space, 
+                        can_fit = best_fit (free_space,
                                             largest_free_space,
-                                            additional_space_bestfit, 
+                                            additional_space_bestfit,
                                             &commit_end_of_seg);
 
                         if (can_fit)
                         {
-                            dprintf (SEG_REUSE_LOG_0, ("(gen2)Found segment %Ix to reuse with bestfit, %s committing end of seg", 
+                            dprintf (SEG_REUSE_LOG_0, ("(gen2)Found segment %Ix to reuse with bestfit, %s committing end of seg",
                                 seg, (commit_end_of_seg ? "with" : "without")));
                         }
                         else
@@ -31677,25 +31674,25 @@ BOOL gc_heap::can_expand_into_p (heap_segment* seg, size_t min_free_size, size_t
                 {
                     dprintf (2, ("Couldn't commit end of segment?!"));
                     use_bestfit = FALSE;
- 
+
                     return FALSE;
                 }
 
                 if (use_bestfit)
                 {
-                    // We increase the index here because growing heap segment could create a discrepency with 
+                    // We increase the index here because growing heap segment could create a discrepency with
                     // the additional space we used (could be bigger).
-                    size_t free_space_end_of_seg = 
+                    size_t free_space_end_of_seg =
                         heap_segment_committed (seg) - heap_segment_plan_allocated (seg);
                     int relative_free_space_index = relative_index_power2_free_space (round_down_power2 (free_space_end_of_seg));
                     saved_ordered_free_space_indices[relative_free_space_index]++;
                 }
             }
-        
+
             if (use_bestfit)
             {
-                memcpy (ordered_free_space_indices, 
-                        saved_ordered_free_space_indices, 
+                memcpy (ordered_free_space_indices,
+                        saved_ordered_free_space_indices,
                         sizeof(ordered_free_space_indices));
                 max_free_space_items = max (MIN_NUM_FREE_SPACES, free_space_items * 3 / 2);
                 max_free_space_items = min (MAX_NUM_FREE_SPACES, max_free_space_items);
@@ -31725,8 +31722,8 @@ BOOL gc_heap::can_expand_into_p (heap_segment* seg, size_t min_free_size, size_t
                 free_list = gen_allocator->alloc_list_head_of (a_l_idx);
                 while (free_list)
                 {
-                    if ((free_list >= first_address) && 
-                        (free_list < end_address) && 
+                    if ((free_list >= first_address) &&
+                        (free_list < end_address) &&
                         (unused_array_size (free_list) >= eph_gen_starts))
                     {
                         goto next;
@@ -31742,9 +31739,9 @@ next:
         if (free_list)
         {
             init_ordered_free_space_indices ();
-            if (process_free_space (seg, 
-                                    unused_array_size (free_list) - eph_gen_starts + Align (min_obj_size), 
-                                    min_free_size, min_cont_size, 
+            if (process_free_space (seg,
+                                    unused_array_size (free_list) - eph_gen_starts + Align (min_obj_size),
+                                    min_free_size, min_cont_size,
                                     &free_space, &largest_free_space))
             {
                 return TRUE;
@@ -31765,9 +31762,9 @@ next:
             while (free_list)
             {
                 if ((free_list >= first_address) && (free_list < end_address) &&
-                    process_free_space (seg, 
-                                        unused_array_size (free_list), 
-                                        min_free_size, min_cont_size, 
+                    process_free_space (seg,
+                                        unused_array_size (free_list),
+                                        min_free_size, min_cont_size,
                                         &free_space, &largest_free_space))
                 {
                     return TRUE;
@@ -31782,7 +31779,7 @@ next:
             }
             else
                 break;
-        } 
+        }
 
         dprintf (SEG_REUSE_LOG_0, ("(gen1)Couldn't fit, total free space is %Ix", free_space));
         return FALSE;
@@ -31940,7 +31937,7 @@ void gc_heap::realloc_in_brick (uint8_t* tree, uint8_t*& last_plug,
     int   left_node = node_left_child (tree);
     int   right_node = node_right_child (tree);
 
-    dprintf (3, ("ra: tree: %Ix, last_pin_gap: %Ix, last_p: %Ix, L: %d, R: %d", 
+    dprintf (3, ("ra: tree: %Ix, last_pin_gap: %Ix, last_p: %Ix, L: %d, R: %d",
         tree, last_pinned_gap, last_plug, left_node, right_node));
 
     if (left_node)
@@ -31957,9 +31954,9 @@ void gc_heap::realloc_in_brick (uint8_t* tree, uint8_t*& last_plug,
 
         BOOL has_pre_plug_info_p = FALSE;
         BOOL has_post_plug_info_p = FALSE;
-        mark* pinned_plug_entry = get_next_pinned_entry (tree, 
+        mark* pinned_plug_entry = get_next_pinned_entry (tree,
                                                          &has_pre_plug_info_p,
-                                                         &has_post_plug_info_p, 
+                                                         &has_post_plug_info_p,
                                                          FALSE);
 
         // We only care about the pre plug info 'cause that's what decides if the last plug is shortened.
@@ -32008,7 +32005,7 @@ gc_heap::realloc_plugs (generation* consing_gen, heap_segment* seg,
             generation* gen = generation_of (gen_number);
             if (0 == generation_plan_allocation_start (gen))
             {
-                generation_plan_allocation_start (gen) = 
+                generation_plan_allocation_start (gen) =
                     bestfit_first_pin + (max_generation - gen_number - 1) * Align (min_obj_size);
                 generation_plan_allocation_start_size (gen) = Align (min_obj_size);
                 assert (generation_plan_allocation_start (gen));
@@ -32109,7 +32106,7 @@ void gc_heap::set_expand_in_full_gc (int condemned_gen_number)
 {
     if (!should_expand_in_full_gc)
     {
-        if ((condemned_gen_number != max_generation) && 
+        if ((condemned_gen_number != max_generation) &&
             (settings.pause_mode != pause_low_latency) &&
             (settings.pause_mode != pause_sustained_low_latency))
         {
@@ -32122,9 +32119,9 @@ void gc_heap::save_ephemeral_generation_starts()
 {
     for (int ephemeral_generation = 0; ephemeral_generation < max_generation; ephemeral_generation++)
     {
-        saved_ephemeral_plan_start[ephemeral_generation] = 
+        saved_ephemeral_plan_start[ephemeral_generation] =
             generation_plan_allocation_start (generation_of (ephemeral_generation));
-        saved_ephemeral_plan_start_size[ephemeral_generation] = 
+        saved_ephemeral_plan_start_size[ephemeral_generation] =
             generation_plan_allocation_start_size (generation_of (ephemeral_generation));
     }
 }
@@ -32215,11 +32212,11 @@ generation* gc_heap::expand_heap (int condemned_generation,
 #endif // FEATURE_STRUCTALIGN
 #ifdef RESPECT_LARGE_ALIGNMENT
             //Since the generation start can be larger than min_obj_size
-            //The alignment could be switched. 
+            //The alignment could be switched.
             eph_size += switch_alignment_size(FALSE);
 #endif //RESPECT_LARGE_ALIGNMENT
             //Since the generation start can be larger than min_obj_size
-            //Compare the alignment of the first object in gen1 
+            //Compare the alignment of the first object in gen1
             if (grow_heap_segment (new_seg, heap_segment_mem (new_seg) + eph_size) == 0)
             {
                 fgm_result.set_fgm (fgm_commit_eph_segment, eph_size, FALSE);
@@ -32349,8 +32346,8 @@ void gc_heap::set_static_data()
         dd->min_size = sdata->min_size;
 
         dprintf (GTC_LOG, ("PM: %d, gen%d:  min: %Id, max: %Id, fr_l: %Id, fr_b: %d%%",
-            settings.pause_mode,i, 
-            dd->min_size, dd_max_size (dd), 
+            settings.pause_mode,i,
+            dd->min_size, dd_max_size (dd),
             sdata->fragmentation_limit, (int)(sdata->fragmentation_burden_limit * 100)));
     }
 }
@@ -32459,10 +32456,10 @@ float gc_heap::surv_to_growth (float cst, float limit, float max_limit)
 }
 
 
-//if the allocation budget wasn't exhausted, the new budget may be wrong because the survival may 
-//not be correct (collection happened too soon). Correct with a linear estimation based on the previous 
-//value of the budget 
-static size_t linear_allocation_model (float allocation_fraction, size_t new_allocation, 
+//if the allocation budget wasn't exhausted, the new budget may be wrong because the survival may
+//not be correct (collection happened too soon). Correct with a linear estimation based on the previous
+//value of the budget
+static size_t linear_allocation_model (float allocation_fraction, size_t new_allocation,
                                        size_t previous_desired_allocation, size_t collection_count)
 {
     if ((allocation_fraction < 0.95) && (allocation_fraction > 0.0))
@@ -32470,7 +32467,7 @@ static size_t linear_allocation_model (float allocation_fraction, size_t new_all
         dprintf (2, ("allocation fraction: %d", (int)(allocation_fraction/100.0)));
         new_allocation = (size_t)(allocation_fraction*new_allocation + (1.0-allocation_fraction)*previous_desired_allocation);
     }
-#if 0 
+#if 0
     size_t smoothing = 3; // exponential smoothing factor
     if (smoothing  > collection_count)
         smoothing  = collection_count;
@@ -32490,7 +32487,7 @@ size_t gc_heap::desired_new_allocation (dynamic_data* dd,
     if (dd_begin_data_size (dd) == 0)
     {
         size_t new_allocation = dd_min_size (dd);
-        current_gc_data_per_heap->gen_data[gen_number].new_allocation = new_allocation;        
+        current_gc_data_per_heap->gen_data[gen_number].new_allocation = new_allocation;
         return new_allocation;
     }
     else
@@ -32529,7 +32526,7 @@ size_t gc_heap::desired_new_allocation (dynamic_data* dd,
             {
                 new_allocation  =  max((new_size - current_size), min_gc_size);
 
-                new_allocation = linear_allocation_model (allocation_fraction, new_allocation, 
+                new_allocation = linear_allocation_model (allocation_fraction, new_allocation,
                                                           dd_desired_allocation (dd), dd_collection_count (dd));
 
                 if (
@@ -32558,8 +32555,8 @@ size_t gc_heap::desired_new_allocation (dynamic_data* dd,
                 {
                     size_t loh_allocated = 0;
                     size_t loh_committed = committed_size (true, &loh_allocated);
-                    dprintf (1, ("GC#%Id h%d, GMI: LOH budget, LOH commit %Id (obj %Id, frag %Id), total commit: %Id (recorded: %Id)", 
-                        (size_t)settings.gc_index, heap_number, 
+                    dprintf (1, ("GC#%Id h%d, GMI: LOH budget, LOH commit %Id (obj %Id, frag %Id), total commit: %Id (recorded: %Id)",
+                        (size_t)settings.gc_index, heap_number,
                         loh_committed, loh_allocated,
                         dd_fragmentation (dynamic_data_of (max_generation + 1)),
                         get_total_committed_size(), (current_total_committed - current_total_committed_bookkeeping)));
@@ -32577,8 +32574,8 @@ size_t gc_heap::desired_new_allocation (dynamic_data* dd,
                 }
 
                 //try to avoid OOM during large object allocation
-                new_allocation = max (min(max((new_size - current_size), dd_desired_allocation (dynamic_data_of (max_generation))), 
-                                          (size_t)available_free), 
+                new_allocation = max (min(max((new_size - current_size), dd_desired_allocation (dynamic_data_of (max_generation))),
+                                          (size_t)available_free),
                                       max ((current_size/4), min_gc_size));
 
                 new_allocation = linear_allocation_model (allocation_fraction, new_allocation,
@@ -32593,7 +32590,7 @@ size_t gc_heap::desired_new_allocation (dynamic_data* dd,
             f = surv_to_growth (cst, limit, max_limit);
             new_allocation = (size_t) min (max ((f * (survivors)), min_gc_size), max_size);
 
-            new_allocation = linear_allocation_model (allocation_fraction, new_allocation, 
+            new_allocation = linear_allocation_model (allocation_fraction, new_allocation,
                                                       dd_desired_allocation (dd), dd_collection_count (dd));
 
             if (gen_number == 0)
@@ -32603,7 +32600,7 @@ size_t gc_heap::desired_new_allocation (dynamic_data* dd,
 
                     //printf ("%f, %Id\n", cst, new_allocation);
                     size_t free_space = generation_free_list_space (generation_of (gen_number));
-                    // DTREVIEW - is min_gc_size really a good choice? 
+                    // DTREVIEW - is min_gc_size really a good choice?
                     // on 64-bit this will almost always be true.
                     dprintf (GTC_LOG, ("frag: %Id, min: %Id", free_space, min_gc_size));
                     if (free_space > min_gc_size)
@@ -32625,7 +32622,7 @@ size_t gc_heap::desired_new_allocation (dynamic_data* dd,
             }
         }
 
-        size_t new_allocation_ret = 
+        size_t new_allocation_ret =
             Align (new_allocation, get_alignment_constant (!(gen_number == (max_generation+1))));
         int gen_data_index = gen_number;
         gc_generation_data* gen_data = &(current_gc_data_per_heap->gen_data[gen_data_index]);
@@ -32768,8 +32765,8 @@ size_t gc_heap::trim_youngest_desired (uint32_t memory_load,
 {
     if (memory_load < MAX_ALLOWED_MEM_LOAD)
     {
-        // If the total of memory load and gen0 budget exceeds 
-        // our max memory load limit, trim the gen0 budget so the total 
+        // If the total of memory load and gen0 budget exceeds
+        // our max memory load limit, trim the gen0 budget so the total
         // is the max memory load limit.
         size_t remain_memory_load = (MAX_ALLOWED_MEM_LOAD - memory_load) * mem_one_percent;
         return min (total_new_allocation, remain_memory_load);
@@ -32804,9 +32801,9 @@ size_t gc_heap::joined_youngest_desired (size_t new_allocation)
             settings.exit_memory_load = memory_load;
             dprintf (2, ("Current memory load: %d", memory_load));
 
-            size_t final_total = 
+            size_t final_total =
                 trim_youngest_desired (memory_load, total_new_allocation, total_min_allocation);
-            size_t max_new_allocation = 
+            size_t max_new_allocation =
 #ifdef MULTIPLE_HEAPS
                                          dd_max_size (g_heaps[0]->dynamic_data_of (0));
 #else //MULTIPLE_HEAPS
@@ -32824,7 +32821,7 @@ size_t gc_heap::joined_youngest_desired (size_t new_allocation)
 
     return final_new_allocation;
 }
-#endif // BIT64 
+#endif // BIT64
 
 inline
 gc_history_per_heap* gc_heap::get_gc_data_per_heap()
@@ -32927,7 +32924,7 @@ void gc_heap::compute_new_dynamic_data (int gen_number)
     {
         dd = dynamic_data_of (max_generation+1);
         total_gen_size = generation_size (max_generation + 1);
-        dd_fragmentation (dd) = generation_free_list_space (large_object_generation) + 
+        dd_fragmentation (dd) = generation_free_list_space (large_object_generation) +
                                 generation_free_obj_space (large_object_generation);
         dd_current_size (dd) = total_gen_size - dd_fragmentation (dd);
         dd_survived_size (dd) = dd_current_size (dd);
@@ -33009,7 +33006,7 @@ void gc_heap::decommit_ephemeral_segment_pages()
 
     if (settings.condemned_generation >= (max_generation-1))
     {
-        size_t new_slack_space = 
+        size_t new_slack_space =
 #ifdef BIT64
                     max(min(min(soh_segment_size/32, dd_max_size(dd)), (generation_size (max_generation) / 10)), dd_desired_allocation(dd));
 #else
@@ -33017,13 +33014,13 @@ void gc_heap::decommit_ephemeral_segment_pages()
                     dd_desired_allocation (dd);
 #else
                     dd_max_size (dd);
-#endif //FEATURE_CORECLR                                    
+#endif //FEATURE_CORECLR
 #endif // BIT64
 
         slack_space = min (slack_space, new_slack_space);
     }
 
-    decommit_heap_segment_pages (ephemeral_heap_segment, slack_space);    
+    decommit_heap_segment_pages (ephemeral_heap_segment, slack_space);
 
     gc_history_per_heap* current_gc_data_per_heap = get_gc_data_per_heap();
     current_gc_data_per_heap->extra_gen0_committed = heap_segment_committed (ephemeral_heap_segment) - heap_segment_allocated (ephemeral_heap_segment);
@@ -33081,7 +33078,7 @@ size_t gc_heap::generation_fragmentation (generation* gen,
     return frag;
 }
 
-// for SOH this returns the total sizes of the generation and its 
+// for SOH this returns the total sizes of the generation and its
 // younger generation(s).
 // for LOH this returns just LOH size.
 size_t gc_heap::generation_sizes (generation* gen)
@@ -33118,7 +33115,7 @@ size_t gc_heap::estimated_reclaim (int gen_number)
     dprintf (GTC_LOG, ("h%d gen%d total size: %Id, est dead space: %Id (s: %d, allocated: %Id), frag: %Id",
                 heap_number, gen_number,
                 gen_total_size,
-                est_gen_free, 
+                est_gen_free,
                 (int)(dd_surv (dd) * 100),
                 gen_allocated,
                 dd_fragmentation (dd)));
@@ -33138,8 +33135,8 @@ BOOL gc_heap::decide_on_compacting (int condemned_gen_number,
     float  fragmentation_burden = ( ((0 == fragmentation) || (0 == gen_sizes)) ? (0.0f) :
                                     (float (fragmentation) / gen_sizes) );
 
-    dprintf (GTC_LOG, ("h%d g%d fragmentation: %Id (%d%%)", 
-        heap_number, settings.condemned_generation, 
+    dprintf (GTC_LOG, ("h%d g%d fragmentation: %Id (%d%%)",
+        heap_number, settings.condemned_generation,
         fragmentation, (int)(fragmentation_burden * 100.0)));
 
 #if defined(STRESS_HEAP) && !defined(FEATURE_REDHAWK)
@@ -33150,7 +33147,7 @@ BOOL gc_heap::decide_on_compacting (int condemned_gen_number,
         should_compact = TRUE;
 
 #ifdef GC_STATS
-    // in GC stress "mix" mode, for stress induced collections make sure we 
+    // in GC stress "mix" mode, for stress induced collections make sure we
     // keep sweeps and compactions relatively balanced. do not (yet) force sweeps
     // against the GC's determination, as it may lead to premature OOMs.
     if (g_pConfig->IsGCStressMix() && settings.stress_induced)
@@ -33230,7 +33227,7 @@ BOOL gc_heap::decide_on_compacting (int condemned_gen_number,
     if (!should_compact)
     {
         // We are not putting this in dt_high_frag_p because it's not exactly
-        // high fragmentation - it's just enough planned fragmentation for us to 
+        // high fragmentation - it's just enough planned fragmentation for us to
         // want to compact. Also the "fragmentation" we are talking about here
         // is different from anywhere else.
         BOOL frag_exceeded = ((fragmentation >= dd_fragmentation_limit (dd)) &&
@@ -33259,7 +33256,7 @@ BOOL gc_heap::decide_on_compacting (int condemned_gen_number,
 #ifdef MULTIPLE_HEAPS
             num_heaps = gc_heap::n_heaps;
 #endif // MULTIPLE_HEAPS
-            
+
             ptrdiff_t reclaim_space = generation_size(max_generation) - generation_plan_size(max_generation);
 
             if((settings.entry_memory_load >= high_memory_load_th) && (settings.entry_memory_load < v_high_memory_load_th))
@@ -33303,7 +33300,7 @@ BOOL gc_heap::decide_on_compacting (int condemned_gen_number,
 #ifdef BIT64
             (high_memory && !should_compact) ||
 #endif // BIT64
-            (generation_plan_allocation_start (generation_of (max_generation - 1)) >= 
+            (generation_plan_allocation_start (generation_of (max_generation - 1)) >=
                 generation_allocation_start (generation_of (max_generation - 1))))
         {
             dprintf (1, ("gen1 start %Ix->%Ix, gen2 size %Id->%Id, lock elevation",
@@ -33363,8 +33360,8 @@ BOOL gc_heap::sufficient_space_end_seg (uint8_t* start, uint8_t* seg_end, size_t
             }
 
             dprintf (2, ("h%d end seg %Id, but only %Id left in HARD LIMIT commit, required: %Id %s on eph (%d)",
-                heap_number, end_seg_space, 
-                left_in_commit, end_space_required, 
+                heap_number, end_seg_space,
+                left_in_commit, end_space_required,
                 (can_fit ? "ok" : "short"), (int)tp));
         }
         else
@@ -33374,7 +33371,7 @@ BOOL gc_heap::sufficient_space_end_seg (uint8_t* start, uint8_t* seg_end, size_t
     return can_fit;
 }
 
-// After we did a GC we expect to have at least this 
+// After we did a GC we expect to have at least this
 // much space at the end of the segment to satisfy
 // a reasonable amount of allocation requests.
 size_t gc_heap::end_space_after_gc()
@@ -33392,33 +33389,33 @@ BOOL gc_heap::ephemeral_gen_fit_p (gc_tuning_point tp)
         start = (settings.concurrent ? alloc_allocated : heap_segment_allocated (ephemeral_heap_segment));
         if (settings.concurrent)
         {
-            dprintf (GTC_LOG, ("%Id left at the end of ephemeral segment (alloc_allocated)", 
+            dprintf (GTC_LOG, ("%Id left at the end of ephemeral segment (alloc_allocated)",
                 (size_t)(heap_segment_reserved (ephemeral_heap_segment) - alloc_allocated)));
         }
         else
         {
-            dprintf (GTC_LOG, ("%Id left at the end of ephemeral segment (allocated)", 
+            dprintf (GTC_LOG, ("%Id left at the end of ephemeral segment (allocated)",
                 (size_t)(heap_segment_reserved (ephemeral_heap_segment) - heap_segment_allocated (ephemeral_heap_segment))));
         }
     }
     else if (tp == tuning_deciding_expansion)
     {
         start = heap_segment_plan_allocated (ephemeral_heap_segment);
-        dprintf (GTC_LOG, ("%Id left at the end of ephemeral segment based on plan", 
+        dprintf (GTC_LOG, ("%Id left at the end of ephemeral segment based on plan",
             (size_t)(heap_segment_reserved (ephemeral_heap_segment) - start)));
     }
     else
     {
         assert (tp == tuning_deciding_full_gc);
-        dprintf (GTC_LOG, ("FGC: %Id left at the end of ephemeral segment (alloc_allocated)", 
+        dprintf (GTC_LOG, ("FGC: %Id left at the end of ephemeral segment (alloc_allocated)",
             (size_t)(heap_segment_reserved (ephemeral_heap_segment) - alloc_allocated)));
         start = alloc_allocated;
     }
-    
+
     if (start == 0) // empty ephemeral generations
     {
         assert (tp == tuning_deciding_expansion);
-        // if there are no survivors in the ephemeral segment, 
+        // if there are no survivors in the ephemeral segment,
         // this should be the beginning of ephemeral segment.
         start = generation_allocation_pointer (generation_of (max_generation));
         assert (start == heap_segment_mem (ephemeral_heap_segment));
@@ -33438,9 +33435,9 @@ BOOL gc_heap::ephemeral_gen_fit_p (gc_tuning_point tp)
 
         eph_size += gen_min_sizes;
 
-        dprintf (3, ("h%d deciding on expansion, need %Id (gen0: %Id, 2*min: %Id)", 
+        dprintf (3, ("h%d deciding on expansion, need %Id (gen0: %Id, 2*min: %Id)",
             heap_number, gen0size, gen_min_sizes, eph_size));
-        
+
         // We must find room for one large object and enough room for gen0size
         if ((size_t)(heap_segment_reserved (ephemeral_heap_segment) - start) > eph_size)
         {
@@ -33617,7 +33614,7 @@ CObjectHeader* gc_heap::allocate_large_object (size_t jsize, uint32_t flags, int
             {
                 dprintf (3, ("Setting mark bit at address %Ix",
                             (size_t)(&mark_array [mark_word_of (result)])));
-    
+
                 mark_array_set_marked (result);
             }
         }
@@ -33817,7 +33814,7 @@ void gc_heap::set_mem_verify (uint8_t* start, uint8_t* end, uint8_t b)
 #endif //VERIFY_HEAP
 }
 
-void gc_heap::generation_delete_heap_segment (generation* gen, 
+void gc_heap::generation_delete_heap_segment (generation* gen,
                                               heap_segment* seg,
                                               heap_segment* prev_seg,
                                               heap_segment* next_seg)
@@ -33827,8 +33824,8 @@ void gc_heap::generation_delete_heap_segment (generation* gen,
     {
         dprintf (3, ("Preparing empty large segment %Ix for deletion", (size_t)seg));
 
-        // We cannot thread segs in here onto freeable_large_heap_segment because 
-        // grow_brick_card_tables could be committing mark array which needs to read 
+        // We cannot thread segs in here onto freeable_large_heap_segment because
+        // grow_brick_card_tables could be committing mark array which needs to read
         // the seg list. So we delay it till next time we suspend EE.
         seg->flags |= heap_segment_flags_loh_delete;
         // Since we will be decommitting the seg, we need to prevent heap verification
@@ -33855,7 +33852,7 @@ void gc_heap::generation_delete_heap_segment (generation* gen,
     set_mem_verify (heap_segment_allocated (seg) - plug_skew, heap_segment_used (seg), 0xbb);
 }
 
-void gc_heap::process_background_segment_end (heap_segment* seg, 
+void gc_heap::process_background_segment_end (heap_segment* seg,
                                           generation* gen,
                                           uint8_t* last_plug_end,
                                           heap_segment* start_seg,
@@ -33866,14 +33863,14 @@ void gc_heap::process_background_segment_end (heap_segment* seg,
     uint8_t* background_allocated = heap_segment_background_allocated (seg);
     BOOL loh_p = heap_segment_loh_p (seg);
 
-    dprintf (3, ("Processing end of background segment [%Ix, %Ix[(%Ix[)", 
+    dprintf (3, ("Processing end of background segment [%Ix, %Ix[(%Ix[)",
                 (size_t)heap_segment_mem (seg), background_allocated, allocated));
 
     if (!loh_p && (allocated != background_allocated))
     {
         assert (gen != large_object_generation);
 
-        dprintf (3, ("Make a free object before newly promoted objects [%Ix, %Ix[", 
+        dprintf (3, ("Make a free object before newly promoted objects [%Ix, %Ix[",
                     (size_t)last_plug_end, background_allocated));
         thread_gap (last_plug_end, background_allocated - last_plug_end, generation_of (max_generation));
 
@@ -33881,7 +33878,7 @@ void gc_heap::process_background_segment_end (heap_segment* seg,
         fix_brick_to_highest (last_plug_end, background_allocated);
 
         // When we allowed fgc's during going through gaps, we could have erased the brick
-        // that corresponds to bgc_allocated 'cause we had to update the brick there, 
+        // that corresponds to bgc_allocated 'cause we had to update the brick there,
         // recover it here.
         fix_brick_to_highest (background_allocated, background_allocated);
     }
@@ -33926,7 +33923,7 @@ void gc_heap::process_background_segment_end (heap_segment* seg,
     bgc_verify_mark_array_cleared (seg);
 }
 
-void gc_heap::process_n_background_segments (heap_segment* seg, 
+void gc_heap::process_n_background_segments (heap_segment* seg,
                                              heap_segment* prev_seg,
                                              generation* gen)
 {
@@ -33946,7 +33943,7 @@ void gc_heap::process_n_background_segments (heap_segment* seg,
             if (heap_segment_allocated (seg) == heap_segment_mem (seg))
             {
                 // This can happen - if we have a LOH segment where nothing survived
-                // or a SOH segment allocated by a gen1 GC when BGC was going where 
+                // or a SOH segment allocated by a gen1 GC when BGC was going where
                 // nothing survived last time we did a gen1 GC.
                 generation_delete_heap_segment (gen, seg, prev_seg, next_seg);
             }
@@ -33964,8 +33961,8 @@ void gc_heap::process_n_background_segments (heap_segment* seg,
 inline
 BOOL gc_heap::fgc_should_consider_object (uint8_t* o,
                                           heap_segment* seg,
-                                          BOOL consider_bgc_mark_p, 
-                                          BOOL check_current_sweep_p, 
+                                          BOOL consider_bgc_mark_p,
+                                          BOOL check_current_sweep_p,
                                           BOOL check_saved_sweep_p)
 {
     // the logic for this function must be kept in sync with the analogous function
@@ -33994,7 +33991,7 @@ BOOL gc_heap::fgc_should_consider_object (uint8_t* o,
             if (!check_saved_sweep_p)
             {
                 uint8_t* background_allocated = heap_segment_background_allocated (seg);
-                // if this was the saved ephemeral segment, check_saved_sweep_p 
+                // if this was the saved ephemeral segment, check_saved_sweep_p
                 // would've been true.
                 assert (heap_segment_background_allocated (seg) != saved_sweep_ephemeral_start);
                 // background_allocated could be 0 for the new segments acquired during bgc
@@ -34019,8 +34016,8 @@ BOOL gc_heap::fgc_should_consider_object (uint8_t* o,
 // consider_bgc_mark_p tells you if you need to care about the bgc mark bit at all
 // if it's TRUE, check_current_sweep_p tells you if you should consider the
 // current sweep position or not.
-void gc_heap::should_check_bgc_mark (heap_segment* seg, 
-                                     BOOL* consider_bgc_mark_p, 
+void gc_heap::should_check_bgc_mark (heap_segment* seg,
+                                     BOOL* consider_bgc_mark_p,
                                      BOOL* check_current_sweep_p,
                                      BOOL* check_saved_sweep_p)
 {
@@ -34032,7 +34029,7 @@ void gc_heap::should_check_bgc_mark (heap_segment* seg,
 
     if (current_c_gc_state == c_gc_state_planning)
     {
-        // We are doing the current_sweep_pos comparison here because we have yet to 
+        // We are doing the current_sweep_pos comparison here because we have yet to
         // turn on the swept flag for the segment but in_range_for_segment will return
         // FALSE if the address is the same as reserved.
         if ((seg->flags & heap_segment_flags_swept) || (current_sweep_pos == heap_segment_reserved (seg)))
@@ -34053,7 +34050,7 @@ void gc_heap::should_check_bgc_mark (heap_segment* seg,
 
             if (in_range_for_segment (current_sweep_pos, seg))
             {
-                dprintf (3, ("current sweep pos is %Ix and within seg %Ix", 
+                dprintf (3, ("current sweep pos is %Ix and within seg %Ix",
                               current_sweep_pos, seg));
                 *check_current_sweep_p = TRUE;
             }
@@ -34082,7 +34079,7 @@ void gc_heap::background_ephemeral_sweep()
     {
         generation* gen_to_reset = generation_of (i);
         assert (generation_free_list_space (gen_to_reset) == 0);
-        // Can only assert free_list_space is 0, not free_obj_space as the allocator could have added 
+        // Can only assert free_list_space is 0, not free_obj_space as the allocator could have added
         // something there.
     }
 
@@ -34093,7 +34090,7 @@ void gc_heap::background_ephemeral_sweep()
         //Skip the generation gap object
         o = o + Align(size (o), align_const);
         uint8_t* end = ((i > 0) ?
-                     generation_allocation_start (generation_of (i - 1)) : 
+                     generation_allocation_start (generation_of (i - 1)) :
                      heap_segment_allocated (ephemeral_heap_segment));
 
         uint8_t* plug_end = o;
@@ -34172,7 +34169,7 @@ void gc_heap::background_ephemeral_sweep()
             fix_brick_to_highest (plug_end, end);
         }
 
-        dd_fragmentation (dynamic_data_of (i)) = 
+        dd_fragmentation (dynamic_data_of (i)) =
             generation_free_list_space (current_gen) + generation_free_obj_space (current_gen);
     }
 
@@ -34230,8 +34227,8 @@ void gc_heap::background_sweep()
         generation_free_obj_space (gen_to_reset) = 0;
         generation_free_list_allocated (gen_to_reset) = 0;
         generation_end_seg_allocated (gen_to_reset) = 0;
-        generation_condemned_allocated (gen_to_reset) = 0; 
-        generation_sweep_allocated (gen_to_reset) = 0; 
+        generation_condemned_allocated (gen_to_reset) = 0;
+        generation_sweep_allocated (gen_to_reset) = 0;
         //reset the allocation so foreground gc can allocate into older generation
         generation_allocation_pointer (gen_to_reset)= 0;
         generation_allocation_limit (gen_to_reset) = 0;
@@ -34272,7 +34269,7 @@ void gc_heap::background_sweep()
 #ifdef MULTIPLE_HEAPS
     bgc_t_join.join(this, gc_join_restart_ee);
     if (bgc_t_join.joined())
-#endif //MULTIPLE_HEAPS 
+#endif //MULTIPLE_HEAPS
     {
 #ifdef MULTIPLE_HEAPS
         dprintf(2, ("Starting BGC threads for resuming EE"));
@@ -34300,8 +34297,8 @@ void gc_heap::background_sweep()
 #endif //MULTIPLE_HEAPS
     {
 #ifdef FEATURE_EVENT_TRACE
-        bgc_heap_walk_for_etw_p = GCEventStatus::IsEnabled(GCEventProvider_Default, 
-                                                           GCEventKeyword_GCHeapSurvivalAndMovement, 
+        bgc_heap_walk_for_etw_p = GCEventStatus::IsEnabled(GCEventProvider_Default,
+                                                           GCEventKeyword_GCHeapSurvivalAndMovement,
                                                            GCEventLevel_Information);
 #endif //FEATURE_EVENT_TRACE
 
@@ -34348,13 +34345,13 @@ void gc_heap::background_sweep()
                     // regardless of whether we saw in bgc mark or not
                     // because we don't allow LOH allocations during bgc
                     // sweep anyway - the LOH segments can't change.
-                    process_background_segment_end (seg, gen, plug_end, 
+                    process_background_segment_end (seg, gen, plug_end,
                                                     start_seg, &delete_p);
                 }
                 else
                 {
                     assert (heap_segment_background_allocated (seg) != 0);
-                    process_background_segment_end (seg, gen, plug_end, 
+                    process_background_segment_end (seg, gen, plug_end,
                                                     start_seg, &delete_p);
 
                     assert (next_seg || !delete_p);
@@ -34377,7 +34374,7 @@ void gc_heap::background_sweep()
             seg = next_seg;
 
             dprintf (GTC_LOG, ("seg: %Ix, next_seg: %Ix, prev_seg: %Ix", seg, next_seg, prev_seg));
-            
+
             if (seg == 0)
             {
                 generation_allocation_segment (gen) = heap_segment_rw (generation_start_segment (gen));
@@ -34443,7 +34440,7 @@ void gc_heap::background_sweep()
                 plug_end = o;
                 current_sweep_pos = o;
                 next_sweep_obj = o;
-                
+
                 allow_fgc();
                 end = background_next_end (seg, (gen == large_object_generation));
                 dprintf (2, ("bgs: seg: %Ix, [%Ix, %Ix[%Ix", (size_t)seg,
@@ -34525,17 +34522,17 @@ void gc_heap::background_sweep()
 
     dprintf (GTC_LOG, ("h%d: S: loh: %Id, soh: %Id", heap_number, total_loh_size, total_soh_size));
 
-    dprintf (GTC_LOG, ("end of bgc sweep: gen2 FL: %Id, FO: %Id", 
+    dprintf (GTC_LOG, ("end of bgc sweep: gen2 FL: %Id, FO: %Id",
         generation_free_list_space (generation_of (max_generation)),
         generation_free_obj_space (generation_of (max_generation))));
-    dprintf (GTC_LOG, ("h%d: end of bgc sweep: gen3 FL: %Id, FO: %Id", 
+    dprintf (GTC_LOG, ("h%d: end of bgc sweep: gen3 FL: %Id, FO: %Id",
         heap_number,
         generation_free_list_space (generation_of (max_generation + 1)),
         generation_free_obj_space (generation_of (max_generation + 1))));
 
     FIRE_EVENT(BGC2ndConEnd);
     concurrent_print_time_delta ("background sweep");
-    
+
     heap_segment* reset_seg = heap_segment_rw (generation_start_segment (generation_of (max_generation)));
     PREFIX_ASSUME(reset_seg != NULL);
 
@@ -34549,9 +34546,9 @@ void gc_heap::background_sweep()
     generation* loh_gen = generation_of (max_generation + 1);
     generation_allocation_segment (loh_gen) = heap_segment_rw (generation_start_segment (loh_gen));
 
-    // We calculate dynamic data here because if we wait till we signal the lh event, 
+    // We calculate dynamic data here because if we wait till we signal the lh event,
     // the allocation thread can change the fragmentation and we may read an intermediate
-    // value (which can be greater than the generation size). Plus by that time it won't 
+    // value (which can be greater than the generation size). Plus by that time it won't
     // be accurate.
     compute_new_dynamic_data (max_generation);
 
@@ -34563,7 +34560,7 @@ void gc_heap::background_sweep()
 #endif //MULTIPLE_HEAPS
     {
         // TODO: We are using this join just to set the state. Should
-        // look into eliminating it - check to make sure things that use 
+        // look into eliminating it - check to make sure things that use
         // this state can live with per heap state like should_check_bgc_mark.
         current_c_gc_state = c_gc_state_free;
 
@@ -34624,7 +34621,7 @@ void gc_heap::sweep_large_objects ()
 
 
     dprintf (3, ("sweeping large objects"));
-    dprintf (3, ("seg: %Ix, [%Ix, %Ix[, starting from %Ix", 
+    dprintf (3, ("seg: %Ix, [%Ix, %Ix[, starting from %Ix",
                  (size_t)seg,
                  (size_t)heap_segment_mem (seg),
                  (size_t)heap_segment_allocated (seg),
@@ -34905,7 +34902,7 @@ void gc_heap::mark_through_cards_for_large_objects (card_fn fn,
                     if (card_of (o) > card)
                     {
                         passed_end_card_p = card_transition (o, end, card_word_end,
-                            cg_pointers_found, 
+                            cg_pointers_found,
                             n_eph, n_card_set,
                             card, end_card,
                             foundp, start_address,
@@ -34935,7 +34932,7 @@ void gc_heap::mark_through_cards_for_large_objects (card_fn fn,
                         {
                             goto go_through_refs;
                         }
-                        else 
+                        else
                         {
                             goto end_object;
                         }
@@ -34956,7 +34953,7 @@ go_through_refs:
                            {
                                 BOOL passed_end_card_p  = card_transition ((uint8_t*)poo, end,
                                         card_word_end,
-                                        cg_pointers_found, 
+                                        cg_pointers_found,
                                         n_eph, n_card_set,
                                         card, end_card,
                                         foundp, start_address,
@@ -35003,12 +35000,12 @@ go_through_refs:
                                       (int)(((float)n_gen / (float)n_eph) * 100) : 100),
                                      generation_skip_ratio);
 
-        dprintf (3, ("Mloh: cross: %Id, useful: %Id, cards cleared: %Id, cards set: %Id, ratio: %d", 
+        dprintf (3, ("Mloh: cross: %Id, useful: %Id, cards cleared: %Id, cards set: %Id, ratio: %d",
              n_eph, n_gen, total_cards_cleared, n_card_set, generation_skip_ratio));
     }
     else
     {
-        dprintf (3, ("R: Mloh: cross: %Id, useful: %Id, cards set: %Id, ratio: %d", 
+        dprintf (3, ("R: Mloh: cross: %Id, useful: %Id, cards set: %Id, ratio: %d",
              n_eph, n_gen, n_card_set, generation_skip_ratio));
     }
 }
@@ -35212,7 +35209,7 @@ void gc_heap::descr_generations (BOOL begin_gc_p)
                       dd_fragmentation (dynamic_data_of (curr_gen_number)),
                       generation_free_list_space (generation_of (curr_gen_number)),
                       generation_free_obj_space (generation_of (curr_gen_number)),
-                      (total_gen_size ? 
+                      (total_gen_size ?
                         (int)(((double)dd_fragmentation (dynamic_data_of (curr_gen_number)) / (double)total_gen_size) * 100) :
                         0),
                       (begin_gc_p ? ("") : (settings.compaction ? "(compact)" : "(sweep)")),
@@ -35385,8 +35382,8 @@ BOOL IsValidObject99(uint8_t *pObject)
     return(TRUE);
 }
 
-#ifdef BACKGROUND_GC 
-BOOL gc_heap::bgc_mark_array_range (heap_segment* seg, 
+#ifdef BACKGROUND_GC
+BOOL gc_heap::bgc_mark_array_range (heap_segment* seg,
                                     BOOL whole_seg_p,
                                     uint8_t** range_beg,
                                     uint8_t** range_end)
@@ -35423,7 +35420,7 @@ void gc_heap::bgc_verify_mark_array_cleared (heap_segment* seg)
             {
                 if (mark_array [markw])
                 {
-                    dprintf  (3, ("The mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared", 
+                    dprintf  (3, ("The mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared",
                                     markw, mark_array [markw], mark_word_address (markw)));
                     FATAL_GC_ERROR();
                 }
@@ -35505,7 +35502,7 @@ void gc_heap::clear_all_mark_array()
 
     generation* gen = generation_of (max_generation);
     heap_segment* seg = heap_segment_rw (generation_start_segment (gen));
-    
+
     while (1)
     {
         if (seg == 0)
@@ -35525,7 +35522,7 @@ void gc_heap::clear_all_mark_array()
         uint8_t* range_end = 0;
 
         if (bgc_mark_array_range (seg, (seg == ephemeral_heap_segment), &range_beg, &range_end))
-        { 
+        {
             size_t markw = mark_word_of (range_beg);
             size_t markw_end = mark_word_of (range_end);
             size_t size_total = (markw_end - markw) * sizeof (uint32_t);
@@ -35562,14 +35559,14 @@ void gc_heap::clear_all_mark_array()
         seg = heap_segment_next_rw (seg);
     }
 
-    //size_t end_time = GetHighPrecisionTimeStamp() - begin_time; 
+    //size_t end_time = GetHighPrecisionTimeStamp() - begin_time;
 
     //printf ("took %Id ms to clear %Id bytes\n", end_time, num_dwords_written*sizeof(uint32_t));
 
 #endif //MARK_ARRAY
 }
 
-#endif //BACKGROUND_GC 
+#endif //BACKGROUND_GC
 
 void gc_heap::verify_mark_array_cleared (heap_segment* seg)
 {
@@ -35582,7 +35579,7 @@ void gc_heap::verify_mark_array_cleared (heap_segment* seg)
     {
         if (mark_array [markw])
         {
-            dprintf  (3, ("The mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared", 
+            dprintf  (3, ("The mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared",
                             markw, mark_array [markw], mark_word_address (markw)));
             FATAL_GC_ERROR();
         }
@@ -35598,7 +35595,7 @@ void gc_heap::verify_mark_array_cleared ()
     {
         generation* gen = generation_of (max_generation);
         heap_segment* seg = heap_segment_rw (generation_start_segment (gen));
-        
+
         while (1)
         {
             if (seg == 0)
@@ -35628,7 +35625,7 @@ void gc_heap::verify_seg_end_mark_array_cleared()
     {
         generation* gen = generation_of (max_generation);
         heap_segment* seg = heap_segment_rw (generation_start_segment (gen));
-        
+
         while (1)
         {
             if (seg == 0)
@@ -35667,7 +35664,7 @@ void gc_heap::verify_seg_end_mark_array_cleared()
             {
                 if (mark_array [markw])
                 {
-                    dprintf  (3, ("The mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared", 
+                    dprintf  (3, ("The mark bits at 0x%Ix:0x%Ix(addr: 0x%Ix) were not cleared",
                                     markw, mark_array [markw], mark_word_address (markw)));
                     FATAL_GC_ERROR();
                 }
@@ -35707,7 +35704,7 @@ void gc_heap::verify_soh_segment_list()
 // This function can be called at any foreground GCs or blocking GCs. For background GCs,
 // it can be called at the end of the final marking; and at any point during background
 // sweep.
-// NOTE - to be able to call this function during background sweep, we need to temporarily 
+// NOTE - to be able to call this function during background sweep, we need to temporarily
 // NOT clear the mark array bits as we go.
 void gc_heap::verify_partial ()
 {
@@ -35769,7 +35766,7 @@ void gc_heap::verify_partial ()
                                 FATAL_GC_ERROR();
                             }
 
-                            if (!pMT->SanityCheck()) 
+                            if (!pMT->SanityCheck())
                             {
                                 bad_ref_p = TRUE;
                                 dprintf (3, ("Bad member of %Ix %Ix",
@@ -35797,12 +35794,12 @@ void gc_heap::verify_partial ()
 
     //printf ("didn't find any large object large enough...\n");
     //printf ("finished verifying loh\n");
-#endif //BACKGROUND_GC 
+#endif //BACKGROUND_GC
 }
 
 #ifdef VERIFY_HEAP
 
-void 
+void
 gc_heap::verify_free_lists ()
 {
     for (int gen_num = 0; gen_num <= max_generation+1; gen_num++)
@@ -35843,11 +35840,11 @@ gc_heap::verify_free_lists ()
                                  (size_t)free_list));
                     FATAL_GC_ERROR();
                 }
-                    
+
                 prev = free_list;
                 free_list = free_list_slot (free_list);
             }
-            //verify the sanity of the tail 
+            //verify the sanity of the tail
             uint8_t* tail = gen_alloc->alloc_list_tail_of (a_l_number);
             if (!((tail == 0) || (tail == prev)))
             {
@@ -35878,7 +35875,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
     BOOL            large_brick_p = TRUE;
     size_t          curr_brick = 0;
     size_t          prev_brick = (size_t)-1;
-    int             curr_gen_num = max_generation+1;    
+    int             curr_gen_num = max_generation+1;
     heap_segment*   seg = heap_segment_in_range (generation_start_segment (generation_of (curr_gen_num ) ));
 
     PREFIX_ASSUME(seg != NULL);
@@ -35911,15 +35908,15 @@ gc_heap::verify_heap (BOOL begin_gc_p)
 #endif //MULTIPLE_HEAPS
 
     UNREFERENCED_PARAMETER(begin_gc_p);
-#ifdef BACKGROUND_GC 
-    dprintf (2,("[%s]GC#%d(%s): Verifying heap - begin", 
+#ifdef BACKGROUND_GC
+    dprintf (2,("[%s]GC#%d(%s): Verifying heap - begin",
         (begin_gc_p ? "BEG" : "END"),
-        VolatileLoad(&settings.gc_index), 
+        VolatileLoad(&settings.gc_index),
         (settings.concurrent ? "BGC" : (recursive_gc_sync::background_running_p() ? "FGC" : "NGC"))));
 #else
-    dprintf (2,("[%s]GC#%d: Verifying heap - begin", 
+    dprintf (2,("[%s]GC#%d: Verifying heap - begin",
                 (begin_gc_p ? "BEG" : "END"), VolatileLoad(&settings.gc_index)));
-#endif //BACKGROUND_GC 
+#endif //BACKGROUND_GC
 
 #ifndef MULTIPLE_HEAPS
     if ((ephemeral_low != generation_allocation_start (generation_of (max_generation - 1))) ||
@@ -35948,7 +35945,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
                     uint8_t* clear_start = heap_segment_allocated (seg1) - plug_skew;
                     if (heap_segment_used (seg1) > clear_start)
                     {
-                        dprintf (3, ("setting end of seg %Ix: [%Ix-[%Ix to 0xaa", 
+                        dprintf (3, ("setting end of seg %Ix: [%Ix-[%Ix to 0xaa",
                                     heap_segment_mem (seg1),
                                     clear_start ,
                                     heap_segment_used (seg1)));
@@ -36078,7 +36075,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
                 }
                 break;
             }
-            
+
             if ((curr_object >= next_boundary) && (curr_gen_num > 0))
             {
                 curr_gen_num--;
@@ -36298,7 +36295,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
     }
 
 #ifdef BACKGROUND_GC
-    dprintf (2, ("(%s)(%s)(%s) total_objects_verified is %Id, total_objects_verified_deep is %Id", 
+    dprintf (2, ("(%s)(%s)(%s) total_objects_verified is %Id, total_objects_verified_deep is %Id",
                  (settings.concurrent ? "BGC" : (recursive_gc_sync::background_running_p () ? "FGC" : "NGC")),
                  (begin_gc_p ? "BEG" : "END"),
                  ((current_c_gc_state == c_gc_state_planning) ? "in plan" : "not in plan"),
@@ -36308,7 +36305,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
         assert (total_objects_verified == total_objects_verified_deep);
     }
 #endif //BACKGROUND_GC
-    
+
     verify_free_lists();
 
 #ifdef FEATURE_PREMORTEM_FINALIZATION
@@ -36335,7 +36332,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
 #endif //MULTIPLE_HEAPS
     }
 
-#ifdef BACKGROUND_GC 
+#ifdef BACKGROUND_GC
     if (!settings.concurrent)
     {
         if (current_c_gc_state == c_gc_state_planning)
@@ -36350,12 +36347,12 @@ gc_heap::verify_heap (BOOL begin_gc_p)
     {
         verify_mark_array_cleared();
     }
-    dprintf (2,("GC%d(%s): Verifying heap - end", 
-        VolatileLoad(&settings.gc_index), 
+    dprintf (2,("GC%d(%s): Verifying heap - end",
+        VolatileLoad(&settings.gc_index),
         (settings.concurrent ? "BGC" : (recursive_gc_sync::background_running_p() ? "FGC" : "NGC"))));
 #else
     dprintf (2,("GC#d: Verifying heap - end", VolatileLoad(&settings.gc_index)));
-#endif //BACKGROUND_GC 
+#endif //BACKGROUND_GC
 }
 
 #endif  //VERIFY_HEAP
@@ -36515,7 +36512,7 @@ HRESULT GCHeap::Initialize()
     CreatedObjectCount = 0;
 #endif //TRACE_GC
 
-    bool is_restricted; 
+    bool is_restricted;
     gc_heap::total_physical_mem = GCToOSInterface::GetPhysicalMemoryLimit (&is_restricted);
 
 #ifdef BIT64
@@ -36543,7 +36540,7 @@ HRESULT GCHeap::Initialize()
         }
     }
 
-    //printf ("heap_hard_limit is %Id, total physical mem: %Id, %s restricted\n", 
+    //printf ("heap_hard_limit is %Id, total physical mem: %Id, %s restricted\n",
     //    gc_heap::heap_hard_limit, gc_heap::total_physical_mem, (is_restricted ? "is" : "is not"));
 #endif //BIT64
 
@@ -36577,7 +36574,7 @@ HRESULT GCHeap::Initialize()
     }
 
     nhp_from_config = static_cast<uint32_t>(GCConfig::GetHeapCount());
-    
+
     g_num_active_processors = GCToOSInterface::GetCurrentProcessCpuCount();
 
     if (nhp_from_config)
@@ -36618,7 +36615,7 @@ HRESULT GCHeap::Initialize()
         seg_size = gc_heap::get_segment_size_hard_limit (&nhp, (nhp_from_config == 0));
         gc_heap::soh_segment_size = seg_size;
         large_seg_size = gc_heap::use_large_pages_p ? seg_size : seg_size * 2;
-        
+
         if (gc_heap::use_large_pages_p)
             gc_heap::min_segment_size = min_segment_size_hard_limit;
     }
@@ -36629,9 +36626,9 @@ HRESULT GCHeap::Initialize()
         large_seg_size = get_valid_segment_size (TRUE);
     }
 
-    dprintf (1, ("%d heaps, soh seg size: %Id mb, loh: %Id mb\n", 
+    dprintf (1, ("%d heaps, soh seg size: %Id mb, loh: %Id mb\n",
         nhp,
-        (seg_size / (size_t)1024 / 1024), 
+        (seg_size / (size_t)1024 / 1024),
         (large_seg_size / 1024 / 1024)));
 
     gc_heap::min_loh_segment_size = large_seg_size;
@@ -36667,8 +36664,8 @@ HRESULT GCHeap::Initialize()
     else
     {
         // We should only use this if we are in the "many process" mode which really is only applicable
-        // to very powerful machines - before that's implemented, temporarily I am only enabling this for 80GB+ memory. 
-        // For now I am using an estimate to calculate these numbers but this should really be obtained 
+        // to very powerful machines - before that's implemented, temporarily I am only enabling this for 80GB+ memory.
+        // For now I am using an estimate to calculate these numbers but this should really be obtained
         // programmatically going forward.
         // I am assuming 47 processes using WKS GC and 3 using SVR GC.
         // I am assuming 3 in part due to the "very high memory load" is 97%.
@@ -36687,7 +36684,7 @@ HRESULT GCHeap::Initialize()
 
     gc_heap::pm_stress_on = (GCConfig::GetGCProvModeStress() != 0);
 
-#if defined(BIT64) 
+#if defined(BIT64)
     gc_heap::youngest_gen_desired_th = gc_heap::mem_one_percent;
 #endif // BIT64
 
@@ -36733,7 +36730,7 @@ HRESULT GCHeap::Initialize()
 
     heap_select::init_numa_node_to_heap_map (nhp);
 
-    // If we have more active processors than heaps we still want to initialize some of the 
+    // If we have more active processors than heaps we still want to initialize some of the
     // mapping for the rest of the active processors because user threads can still run on
     // them which means it's important to know their numa nodes and map them to a reasonable
     // heap, ie, we wouldn't want to have all such procs go to heap 0.
@@ -36751,9 +36748,9 @@ HRESULT GCHeap::Initialize()
     if (!GCToOSInterface::GetNumaInfo (&total_numa_nodes_on_machine, &procs_per_numa_node))
     {
         total_numa_nodes_on_machine = 1;
-        
+
         // Note that if we are in cpu groups we need to take the way proc index is calculated
-        // into consideration. It would mean we have more than 64 procs on one numa node - 
+        // into consideration. It would mean we have more than 64 procs on one numa node -
         // this is mostly for testing (if we want to simulate no numa on a numa system).
         // see vm\gcenv.os.cpp GroupProcNo implementation.
         if (GCToOSInterface::GetCPUGroupInfo (&total_cpu_groups_on_machine, &procs_per_cpu_group))
@@ -36805,7 +36802,10 @@ HRESULT GCHeap::Initialize()
 bool GCHeap::IsPromoted(Object* object)
 {
 #ifdef _DEBUG
-    ((CObjectHeader*)object)->Validate();
+    if (object)
+    {
+        ((CObjectHeader*)object)->Validate();
+    }
 #endif //_DEBUG
 
     uint8_t* o = (uint8_t*)object;
@@ -36883,7 +36883,7 @@ bool GCHeap::IsEphemeral (Object* object)
 }
 
 // Return NULL if can't find next object. When EE is not suspended,
-// the result is not accurate: if the input arg is in gen0, the function could 
+// the result is not accurate: if the input arg is in gen0, the function could
 // return zeroed out memory as next object
 Object * GCHeap::NextObj (Object * object)
 {
@@ -36905,7 +36905,7 @@ Object * GCHeap::NextObj (Object * object)
 
     BOOL large_object_p = heap_segment_loh_p (hs);
     if (large_object_p)
-        return NULL; //could be racing with another core allocating. 
+        return NULL; //could be racing with another core allocating.
 #ifdef MULTIPLE_HEAPS
     gc_heap* hp = heap_segment_heap (hs);
 #else //MULTIPLE_HEAPS
@@ -36913,7 +36913,7 @@ Object * GCHeap::NextObj (Object * object)
 #endif //MULTIPLE_HEAPS
     unsigned int g = hp->object_gennum ((uint8_t*)object);
     if ((g == 0) && hp->settings.demotion)
-        return NULL;//could be racing with another core allocating. 
+        return NULL;//could be racing with another core allocating.
     int align_const = get_alignment_constant (!large_object_p);
     uint8_t* nextobj = o + Align (size (o), align_const);
     if (nextobj <= o) // either overflow or 0 sized object.
@@ -36921,8 +36921,8 @@ Object * GCHeap::NextObj (Object * object)
         return NULL;
     }
 
-    if ((nextobj < heap_segment_mem(hs)) || 
-        (nextobj >= heap_segment_allocated(hs) && hs != hp->ephemeral_heap_segment) || 
+    if ((nextobj < heap_segment_mem(hs)) ||
+        (nextobj >= heap_segment_allocated(hs) && hs != hp->ephemeral_heap_segment) ||
         (nextobj >= hp->alloc_allocated))
     {
         return NULL;
@@ -36937,7 +36937,7 @@ Object * GCHeap::NextObj (Object * object)
 // returns TRUE if the pointer is in one of the GC heaps.
 bool GCHeap::IsHeapPointer (void* vpObject, bool small_heap_only)
 {
-    // removed STATIC_CONTRACT_CAN_TAKE_LOCK here because find_segment 
+    // removed STATIC_CONTRACT_CAN_TAKE_LOCK here because find_segment
     // no longer calls GCEvent::Wait which eventually takes a lock.
 
     uint8_t* object = (uint8_t*) vpObject;
@@ -37005,7 +37005,7 @@ void GCHeap::Promote(Object** ppObject, ScanContext* sc, uint32_t flags)
 
 #ifdef _DEBUG
     ((CObjectHeader*)o)->ValidatePromote(sc, flags);
-#else 
+#else
     UNREFERENCED_PARAMETER(sc);
 #endif //_DEBUG
 
@@ -37031,12 +37031,12 @@ void GCHeap::Relocate (Object** ppObject, ScanContext* sc,
     UNREFERENCED_PARAMETER(sc);
 
     uint8_t* object = (uint8_t*)(Object*)(*ppObject);
-    
+
     THREAD_NUMBER_FROM_CONTEXT;
 
     //dprintf (3, ("Relocate location %Ix\n", (size_t)ppObject));
     dprintf (3, ("R: %Ix", (size_t)ppObject));
-    
+
     if (object == 0)
         return;
 
@@ -37045,7 +37045,7 @@ void GCHeap::Relocate (Object** ppObject, ScanContext* sc,
 #ifdef _DEBUG
     if (!(flags & GC_CALL_INTERIOR))
     {
-        // We cannot validate this object if it's in the condemned gen because it could 
+        // We cannot validate this object if it's in the condemned gen because it could
         // be one of the objects that were overwritten by an artificial gap due to a pinned plug.
         if (!((object >= hp->gc_low) && (object < hp->gc_high)))
         {
@@ -37110,13 +37110,13 @@ static int32_t GCStressStartAtJit = -1;
 // (this number does not include "naturally" occurring GCs).
 static int32_t GCStressMaxFGCsPerBGC = -1;
 
-// CLRRandom implementation can produce FPU exceptions if 
-// the test/application run by CLR is enabling any FPU exceptions. 
-// We want to avoid any unexpected exception coming from stress 
+// CLRRandom implementation can produce FPU exceptions if
+// the test/application run by CLR is enabling any FPU exceptions.
+// We want to avoid any unexpected exception coming from stress
 // infrastructure, so CLRRandom is not an option.
 // The code below is a replicate of CRT rand() implementation.
 // Using CRT rand() is not an option because we will interfere with the user application
-// that may also use it. 
+// that may also use it.
 int StressRNG(int iMaxValue)
 {
     static BOOL bisRandInit = FALSE;
@@ -37245,7 +37245,7 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
                 _ASSERTE(m_StressObjs[i] != 0);
                 unsigned strLen = ((unsigned)loh_size_threshold - 32) / sizeof(WCHAR);
                 unsigned strSize = PtrAlign(StringObject::GetSize(strLen));
-                
+
                 // update the cached type handle before allocating
                 SetTypeHandleOnThreadForAlloc(TypeHandle(g_pStringClass));
                 str = (StringObject*) pGenGCHeap->allocate (strSize, acontext, /*flags*/ 0);
@@ -37276,7 +37276,7 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
             {
                 unsigned sizeToNextObj = (unsigned)Align(size(str));
                 uint8_t* freeObj = ((uint8_t*) str) + sizeToNextObj - sizeOfNewObj;
-                pGenGCHeap->make_unused_array (freeObj, sizeOfNewObj);                    
+                pGenGCHeap->make_unused_array (freeObj, sizeOfNewObj);
                 str->SetStringLength(str->GetStringLength() - (sizeOfNewObj / sizeof(WCHAR)));
             }
             else
@@ -37596,7 +37596,7 @@ GCHeap::Alloc(gc_alloc_context* context, size_t size, uint32_t flags REQD_ALIGN_
 #endif // FEATURE_STRUCTALIGN
 //        ASSERT (newAlloc);
     }
-    else 
+    else
     {
         newAlloc = (Object*) hp->allocate_large_object (size + ComputeMaxStructAlignPadLarge(requiredAlignment), flags, acontext->alloc_bytes_loh);
 #ifdef FEATURE_STRUCTALIGN
@@ -37664,7 +37664,7 @@ GCHeap::GetContainingObject (void *pInteriorPtr, bool fCollectedGenOnly)
     {
         o = NULL;
     }
-    
+
     return (Object *)o;
 }
 
@@ -37691,7 +37691,7 @@ BOOL should_collect_optimized (dynamic_data* dd, BOOL low_memory_p)
 HRESULT
 GCHeap::GarbageCollect (int generation, bool low_memory_p, int mode)
 {
-#if defined(BIT64) 
+#if defined(BIT64)
     if (low_memory_p)
     {
         size_t total_allocated = 0;
@@ -37720,7 +37720,7 @@ GCHeap::GarbageCollect (int generation, bool low_memory_p, int mode)
             return S_OK;
         }
     }
-#endif // BIT64 
+#endif // BIT64
 
 #ifdef MULTIPLE_HEAPS
     gc_heap* hpt = gc_heap::g_heaps[0];
@@ -37755,7 +37755,7 @@ GCHeap::GarbageCollect (int generation, bool low_memory_p, int mode)
         {
             return S_OK;
         }
-        else 
+        else
         {
             BOOL should_collect = FALSE;
             BOOL should_check_loh = (generation == max_generation);
@@ -37763,7 +37763,7 @@ GCHeap::GarbageCollect (int generation, bool low_memory_p, int mode)
             for (int i = 0; i < gc_heap::n_heaps; i++)
             {
                 dynamic_data* dd1 = gc_heap::g_heaps [i]->dynamic_data_of (generation);
-                dynamic_data* dd2 = (should_check_loh ? 
+                dynamic_data* dd2 = (should_check_loh ?
                                      (gc_heap::g_heaps [i]->dynamic_data_of (max_generation + 1)) :
                                      0);
 
@@ -37782,7 +37782,7 @@ GCHeap::GarbageCollect (int generation, bool low_memory_p, int mode)
             should_collect = should_collect_optimized (dd, low_memory_p);
             if (!should_collect && should_check_loh)
             {
-                should_collect = 
+                should_collect =
                     should_collect_optimized (hpt->dynamic_data_of (max_generation + 1), low_memory_p);
             }
 #endif //MULTIPLE_HEAPS
@@ -37800,9 +37800,9 @@ GCHeap::GarbageCollect (int generation, bool low_memory_p, int mode)
 retry:
 
     CurrentCollectionCount = GarbageCollectTry(generation, low_memory_p, mode);
-    
-    if ((mode & collection_blocking) && 
-        (generation == max_generation) && 
+
+    if ((mode & collection_blocking) &&
+        (generation == max_generation) &&
         (gc_heap::full_gc_counts[gc_type_blocking] == BlockingCollectionCountAtEntry))
     {
 #ifdef BACKGROUND_GC
@@ -37826,12 +37826,12 @@ retry:
 size_t
 GCHeap::GarbageCollectTry (int generation, BOOL low_memory_p, int mode)
 {
-    int gen = (generation < 0) ? 
+    int gen = (generation < 0) ?
                max_generation : min (generation, max_generation);
 
     gc_reason reason = reason_empty;
-    
-    if (low_memory_p) 
+
+    if (low_memory_p)
     {
         if (mode & collection_blocking)
         {
@@ -37891,16 +37891,16 @@ void gc_heap::do_pre_gc()
 #ifdef TRACE_GC
     size_t total_allocated_since_last_gc = get_total_allocated_since_last_gc();
 #ifdef BACKGROUND_GC
-    dprintf (1, ("*GC* %d(gen0:%d)(%d)(alloc: %Id)(%s)(%d)", 
-        VolatileLoad(&settings.gc_index), 
+    dprintf (1, ("*GC* %d(gen0:%d)(%d)(alloc: %Id)(%s)(%d)",
+        VolatileLoad(&settings.gc_index),
         dd_collection_count (hp->dynamic_data_of (0)),
         settings.condemned_generation,
         total_allocated_since_last_gc,
         (settings.concurrent ? "BGC" : (recursive_gc_sync::background_running_p() ? "FGC" : "NGC")),
         settings.b_state));
 #else
-    dprintf (1, ("*GC* %d(gen0:%d)(%d)(alloc: %Id)", 
-        VolatileLoad(&settings.gc_index), 
+    dprintf (1, ("*GC* %d(gen0:%d)(%d)(alloc: %Id)",
+        VolatileLoad(&settings.gc_index),
         dd_collection_count(hp->dynamic_data_of(0)),
         settings.condemned_generation,
         total_allocated_since_last_gc));
@@ -37910,7 +37910,7 @@ void gc_heap::do_pre_gc()
     {
         size_t total_heap_committed = get_total_committed_size();
         size_t total_heap_committed_recorded = current_total_committed - current_total_committed_bookkeeping;
-        dprintf (1, ("(%d)GC commit BEG #%Id: %Id (recorded: %Id)", 
+        dprintf (1, ("(%d)GC commit BEG #%Id: %Id (recorded: %Id)",
             settings.condemned_generation,
             (size_t)settings.gc_index, total_heap_committed, total_heap_committed_recorded));
     }
@@ -38082,8 +38082,8 @@ void gc_heap::check_and_adjust_bgc_tuning (int gen_number, size_t physical_size,
         bgc_tuning::tuning_stats* current_gen_stats = &bgc_tuning::gen_stats[gen_number - max_generation];
 
         bool gen_size_inc_p = (total_gen_size > current_gen_calc->last_bgc_size);
-        
-        if ((settings.condemned_generation >= min_gen_to_check) && 
+
+        if ((settings.condemned_generation >= min_gen_to_check) &&
             (settings.condemned_generation != max_generation))
         {
             if (gen_size_inc_p)
@@ -38109,7 +38109,7 @@ void gc_heap::check_and_adjust_bgc_tuning (int gen_number, size_t physical_size,
                         {
                             bgc_tuning::next_bgc_p = true;
                             current_gen_calc->first_alloc_to_trigger = get_total_servo_alloc (gen_number);
-                            dprintf (BGC_TUNING_LOG, ("BTL[g1: %Id] mem high enough: %d(goal: %d), gen%d fl alloc: %Id, trigger BGC!", 
+                            dprintf (BGC_TUNING_LOG, ("BTL[g1: %Id] mem high enough: %d(goal: %d), gen%d fl alloc: %Id, trigger BGC!",
                                 gen1_index, settings.entry_memory_load, bgc_tuning::memory_load_goal,
                                 gen_number, current_gen_calc->first_alloc_to_trigger));
                         }
@@ -38117,7 +38117,7 @@ void gc_heap::check_and_adjust_bgc_tuning (int gen_number, size_t physical_size,
                 }
             }
         }
-        
+
         if ((settings.condemned_generation == max_generation) && !(settings.concurrent))
         {
             size_t total_survived = get_total_surv_size (gen_number);
@@ -38142,7 +38142,7 @@ void gc_heap::check_and_adjust_bgc_tuning (int gen_number, size_t physical_size,
                                     new_gen_flr,
                                     current_gen_stats->last_gen_increase_flr,
                                     current_gc_surv_rate,
-                                    0, 
+                                    0,
                                     0,
                                     0,
                                     current_gen_calc->alloc_to_trigger));
@@ -38155,7 +38155,7 @@ void gc_heap::check_and_adjust_bgc_tuning (int gen_number, size_t physical_size,
             current_gen_calc->last_bgc_end_alloc = 0;
 
             current_gen_stats->last_alloc_end_to_start = 0;
-            current_gen_stats->last_alloc_start_to_sweep = 0; 
+            current_gen_stats->last_alloc_start_to_sweep = 0;
             current_gen_stats->last_alloc_sweep_to_end = 0;
             current_gen_stats->last_bgc_fl_size = total_generation_fl_size;
             current_gen_stats->last_bgc_surv_rate = current_gc_surv_rate;
@@ -38172,7 +38172,7 @@ void gc_heap::get_and_reset_loh_alloc_info()
     total_loh_a_last_bgc = 0;
 
     uint64_t total_loh_a_no_bgc = 0;
-    uint64_t total_loh_a_bgc_marking = 0; 
+    uint64_t total_loh_a_bgc_marking = 0;
     uint64_t total_loh_a_bgc_planning = 0;
 #ifdef MULTIPLE_HEAPS
     for (int i = 0; i < gc_heap::n_heaps; i++)
@@ -38189,7 +38189,7 @@ void gc_heap::get_and_reset_loh_alloc_info()
         total_loh_a_bgc_planning += hp->loh_a_bgc_planning;
         hp->loh_a_bgc_planning = 0;
     }
-    dprintf (2, ("LOH alloc: outside bgc: %I64d; bm: %I64d; bp: %I64d", 
+    dprintf (2, ("LOH alloc: outside bgc: %I64d; bm: %I64d; bp: %I64d",
         total_loh_a_no_bgc,
         total_loh_a_bgc_marking,
         total_loh_a_bgc_planning));
@@ -38220,7 +38220,7 @@ bool gc_heap::is_pm_ratio_exceeded()
     double maxgen_ratio = (double)maxgen_size / (double)total_heap_size;
     double maxgen_frag_ratio = (double)maxgen_frag / (double)maxgen_size;
     dprintf (GTC_LOG, ("maxgen %Id(%d%% total heap), frag: %Id (%d%% maxgen)",
-        maxgen_size, (int)(maxgen_ratio * 100.0), 
+        maxgen_size, (int)(maxgen_ratio * 100.0),
         maxgen_frag, (int)(maxgen_frag_ratio * 100.0)));
 
     bool maxgen_highfrag_p = ((maxgen_ratio > 0.5) && (maxgen_frag_ratio > 0.1));
@@ -38256,7 +38256,7 @@ void gc_heap::do_post_gc()
 #else
     gc_heap* hp = 0;
 #endif //MULTIPLE_HEAPS
-    
+
     GCToEEInterface::GcDone(settings.condemned_generation);
 
     GCToEEInterface::DiagGCEnd(VolatileLoad(&settings.gc_index),
@@ -38271,7 +38271,7 @@ void gc_heap::do_post_gc()
     {
         uint64_t current_available_physical = 0;
         size_t gen2_physical_size = 0;
-        size_t gen3_physical_size = 0; 
+        size_t gen3_physical_size = 0;
         ptrdiff_t gen2_virtual_fl_size = 0;
         ptrdiff_t gen3_virtual_fl_size = 0;
         ptrdiff_t vfl_from_kp = 0;
@@ -38290,8 +38290,8 @@ void gc_heap::do_post_gc()
             gen3_virtual_fl_size = (ptrdiff_t)(total_virtual_fl_size * (1.0 - gen2_size_ratio));
 
 #ifdef SIMPLE_DPRINTF
-            dprintf (BGC_TUNING_LOG, ("BTL: ml: %d (g: %d)(%s), a: %I64d (g: %I64d, elg: %Id+%Id=%Id, %Id+%Id=%Id), vfl: %Id=%Id+%Id(NGC2)", 
-                current_memory_load, bgc_tuning::memory_load_goal, 
+            dprintf (BGC_TUNING_LOG, ("BTL: ml: %d (g: %d)(%s), a: %I64d (g: %I64d, elg: %Id+%Id=%Id, %Id+%Id=%Id), vfl: %Id=%Id+%Id(NGC2)",
+                current_memory_load, bgc_tuning::memory_load_goal,
                 ((current_available_physical > bgc_tuning::available_memory_goal) ? "above" : "below"),
                 current_available_physical, bgc_tuning::available_memory_goal,
                 gen2_physical_size, gen2_virtual_fl_size, (gen2_physical_size + gen2_virtual_fl_size),
@@ -38306,8 +38306,8 @@ void gc_heap::do_post_gc()
 #endif //BGC_SERVO_TUNING
 
 #ifdef SIMPLE_DPRINTF
-    dprintf (1, ("*EGC* %Id(gen0:%Id)(%Id)(%d)(%s)(%s)(%s)(ml: %d->%d)", 
-        VolatileLoad(&settings.gc_index), 
+    dprintf (1, ("*EGC* %Id(gen0:%Id)(%Id)(%d)(%s)(%s)(%s)(ml: %d->%d)",
+        VolatileLoad(&settings.gc_index),
         dd_collection_count(hp->dynamic_data_of(0)),
         GetHighPrecisionTimeStamp(),
         settings.condemned_generation,
@@ -38331,7 +38331,7 @@ void gc_heap::do_post_gc()
     {
         size_t total_heap_committed = get_total_committed_size();
         size_t total_heap_committed_recorded = current_total_committed - current_total_committed_bookkeeping;
-        dprintf (1, ("(%d)GC commit END #%Id: %Id (recorded: %Id), heap %Id, frag: %Id", 
+        dprintf (1, ("(%d)GC commit END #%Id: %Id (recorded: %Id), heap %Id, frag: %Id",
             settings.condemned_generation,
             (size_t)settings.gc_index, total_heap_committed, total_heap_committed_recorded,
             last_gc_heap_size, last_gc_fragmentation));
@@ -38471,7 +38471,7 @@ GCHeap::GarbageCollectGeneration (unsigned int gen, gc_reason reason)
 #endif //COUNT_CYCLES
 #endif //TRACE_GC
 
-        gc_heap::g_low_memory_status = (reason == reason_lowmemory) || 
+        gc_heap::g_low_memory_status = (reason == reason_lowmemory) ||
                                        (reason == reason_lowmemory_blocking) ||
                                        (gc_heap::latency_level == latency_level_memory_footprint);
 
@@ -38575,7 +38575,7 @@ GCHeap::GarbageCollectGeneration (unsigned int gen, gc_reason reason)
 
 #ifdef BACKGROUND_GC
     // We are deciding whether we should fire the alloc wait end event here
-    // because in begin_foreground we could be calling end_foreground 
+    // because in begin_foreground we could be calling end_foreground
     // if we need to retry.
     if (gc_heap::alloc_wait_event_p)
     {
@@ -38607,7 +38607,7 @@ GCHeap::GarbageCollectGeneration (unsigned int gen, gc_reason reason)
     gc_heap::gc_started = FALSE;
     gc_heap::set_gc_done();
     dprintf (SPINLOCK_LOG, ("GC Lgc"));
-    leave_spin_lock (&gc_heap::gc_lock);    
+    leave_spin_lock (&gc_heap::gc_lock);
 #endif //!MULTIPLE_HEAPS
 
 #ifdef FEATURE_PREMORTEM_FINALIZATION
@@ -38783,11 +38783,11 @@ int GCHeap::GetHomeHeapNumber ()
 }
 
 unsigned int GCHeap::GetCondemnedGeneration()
-{ 
+{
     return gc_heap::settings.condemned_generation;
 }
 
-void GCHeap::GetMemoryInfo(uint64_t* highMemLoadThresholdBytes, 
+void GCHeap::GetMemoryInfo(uint64_t* highMemLoadThresholdBytes,
                            uint64_t* totalAvailableMemoryBytes,
                            uint64_t* lastRecordedMemLoadBytes,
                            uint32_t* lastRecordedMemLoadPct,
@@ -38900,7 +38900,7 @@ bool GCHeap::CancelFullGCNotification()
     pGenGCHeap->fgn_loh_percent = 0;
     pGenGCHeap->full_gc_approach_event.Set();
     pGenGCHeap->full_gc_end_event.Set();
-    
+
     return TRUE;
 }
 
@@ -39019,7 +39019,7 @@ size_t gc_heap::get_gen0_min_size()
         // if gen0 size is too large given the available memory, reduce it.
         // Get true cache size, as we don't want to reduce below this.
         size_t trueSize = max(GCToOSInterface::GetCacheSizePerLogicalCpu(TRUE),(256*1024));
-        dprintf (1, ("cache: %Id-%Id", 
+        dprintf (1, ("cache: %Id-%Id",
             GCToOSInterface::GetCacheSizePerLogicalCpu(FALSE),
             GCToOSInterface::GetCacheSizePerLogicalCpu(TRUE)));
 
@@ -39032,7 +39032,7 @@ size_t gc_heap::get_gen0_min_size()
 #endif //SERVER_GC
 
         dprintf (1, ("gen0size: %Id * %d = %Id, physical mem: %Id / 6 = %Id",
-                gen0size, n_heaps, (gen0size * n_heaps), 
+                gen0size, n_heaps, (gen0size * n_heaps),
                 gc_heap::total_physical_mem,
                 gc_heap::total_physical_mem / 6));
 
@@ -39595,7 +39595,7 @@ CFinalize::ScanForFinalization (promote_func* pfn, int gen, BOOL mark_only_p,
     }
     finalizedFound = !IsSegEmpty(FinalizerListSeg) ||
                      !IsSegEmpty(CriticalFinalizerListSeg);
-                    
+
     if (finalizedFound)
     {
         //Promote the f-reachable objects
@@ -39946,16 +39946,16 @@ void initGCShadow()
         return;
 
     size_t len = g_gc_highest_address - g_gc_lowest_address;
-    if (len > (size_t)(g_GCShadowEnd - g_GCShadow)) 
+    if (len > (size_t)(g_GCShadowEnd - g_GCShadow))
     {
         deleteGCShadow();
         g_GCShadowEnd = g_GCShadow = (uint8_t *)GCToOSInterface::VirtualReserve(len, 0, VirtualReserveFlags::None);
         if (g_GCShadow == NULL || !GCToOSInterface::VirtualCommit(g_GCShadow, len))
         {
             _ASSERTE(!"Not enough memory to run HeapVerify level 2");
-            // If after the assert we decide to allow the program to continue 
-            // running we need to be in a state that will not trigger any 
-            // additional AVs while we fail to allocate a shadow segment, i.e. 
+            // If after the assert we decide to allow the program to continue
+            // running we need to be in a state that will not trigger any
+            // additional AVs while we fail to allocate a shadow segment, i.e.
             // ensure calls to updateGCShadow() checkGCWriteBarrier() don't AV
             deleteGCShadow();
             return;
@@ -40010,7 +40010,7 @@ inline void testGCShadow(Object** ptr)
     {
 
         // If you get this assertion, someone updated a GC pointer in the heap without
-        // using the write barrier.  To find out who, check the value of 
+        // using the write barrier.  To find out who, check the value of
         // dd_collection_count (dynamic_data_of (0)). Also
         // note the value of 'ptr'.  Rerun the App that the previous GC just occurred.
         // Then put a data breakpoint for the value of 'ptr'  Then check every write

--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -64,10 +64,10 @@ typedef DPTR(RUNTIME_FUNCTION) PTR_RUNTIME_FUNCTION;
 
 #endif // _TARGET_X86_
 
-// The stride is choosen as maximum value that still gives good page locality of RUNTIME_FUNCTION table touches (only one page of 
+// The stride is choosen as maximum value that still gives good page locality of RUNTIME_FUNCTION table touches (only one page of
 // RUNTIME_FUNCTION table is going to be touched during most IP2MD lookups).
 //
-// Smaller stride values also improve speed of IP2MD lookups, but this improvement is not significant (5% when going 
+// Smaller stride values also improve speed of IP2MD lookups, but this improvement is not significant (5% when going
 // from 8192 to 1024), so the working set / page locality was used as the metric to choose the optimum value.
 //
 #define RUNTIME_FUNCTION_LOOKUP_STRIDE  8192
@@ -88,7 +88,7 @@ typedef DPTR(struct COR_ILMETHOD) PTR_COR_ILMETHOD;
 //
 // CORCOMPILE_IMPORT_SECTION describes image range with references to other assemblies or runtime data structures
 //
-// There is number of different types of these ranges: eagerly initialized at image load vs. lazily initialized at method entry 
+// There is number of different types of these ranges: eagerly initialized at image load vs. lazily initialized at method entry
 // vs. lazily initialized on first use; hot vs. cold, handles vs. code pointers, etc.
 //
 struct CORCOMPILE_IMPORT_SECTION
@@ -205,7 +205,7 @@ enum CorCompileHeaderFlags
     CORCOMPILE_HEADER_IS_READY_TO_RUN           = 0x00000004,
 };
 
-// 
+//
 // !!! INCREMENT THE MAJOR VERSION ANY TIME THERE IS CHANGE IN CORCOMPILE_HEADER STRUCTURE !!!
 //
 #define CORCOMPILE_SIGNATURE     0x0045474E     // 'NGEN'
@@ -263,8 +263,8 @@ struct CORCOMPILE_HEADER
     IMAGE_DATA_DIRECTORY    Dummy4;
 };
 
-// CORCOMPILE_VIRTUAL_SECTION_INFO describes virtual section ranges. This data is used by nidump 
-// and to fire ETW that are used for diagnostics and performance purposes. Some of the questions 
+// CORCOMPILE_VIRTUAL_SECTION_INFO describes virtual section ranges. This data is used by nidump
+// and to fire ETW that are used for diagnostics and performance purposes. Some of the questions
 // these events help answer are like : how effective is IBC training data.
 struct CORCOMPILE_VIRTUAL_SECTION_INFO
 {
@@ -324,7 +324,7 @@ struct CORCOMPILE_VIRTUAL_SECTION_INFO
 // Hot: Items are frequently accessed ( Indicated by either IBC data, or
 //      statically known )
 
-// Warm : Items are less frequently accessed, or frequently accessed 
+// Warm : Items are less frequently accessed, or frequently accessed
 //        but were not touched during IBC profiling.
 
 // Cold : Least frequently accessed /shouldn't not be accessed
@@ -332,7 +332,7 @@ struct CORCOMPILE_VIRTUAL_SECTION_INFO
 //        training ( training scenario )
 
 // HotColdSorted : Sections marked with this category means they contain both
-//                 Hot items and Cold items. The hot items are placed before 
+//                 Hot items and Cold items. The hot items are placed before
 //                 the cold items (Sorted)
 
 #define CORCOMPILE_SECTION_RANGE_TYPES()                     \
@@ -344,12 +344,12 @@ struct CORCOMPILE_VIRTUAL_SECTION_INFO
 
 // IBCUnProfiled: Items in this VirtualSection are statically determined to be cold.
 //                 (IBC Profiling wouldn't have helped put these item in a hot section).
-//                 Items that currently doesn't have IBC probs, or are always put in a specific section 
+//                 Items that currently doesn't have IBC probs, or are always put in a specific section
 //                 regardless of IBC data should fall in this category.
 
 // IBCProfiled: IBC profiling placed items in this section, or
 //              items are NOT placed into a hot section they didn't have IBC profiling data
-//              ( IBC profiling would have helped put these items in a hot section ) 
+//              ( IBC profiling would have helped put these items in a hot section )
 
 #define CORCOMPILE_SECTION_IBCTYPES()                       \
     CORCOMPILE_SECTION_IBCTYPE(IBCUnProfiled, 0x01000000)  \
@@ -364,42 +364,42 @@ struct CORCOMPILE_VIRTUAL_SECTION_INFO
 // 1 byte       1 byte      2 bytes                 --
 // <IBCType> <RangeType> <VirtualSectionType>       --
 // ---------------------------------------------------
-// 
-// 
+//
+//
 // VirtualSections are a CLR concept to aggregate data
 // items that share common properties together (Hot/Cold/Warm, Writeable/
 // Readonly ...etc.). VirtualSections are tagged with some categories when they
 // are created (code:NewVirtualSection)
 // The VirtualSection categorize are described more in VirtualSectionType enum.
 // The categories describe 2 important aspects for each VirtualSection
-// 
+//
 // ***********************************************
 // IBCProfiled v.s NonIBCProfiled Categories.
 // **********************************************
-// 
-// IBCProfiled: Distinguish between sections that IBC profiling data has been used 
-//               to decide the layout of the data items in this section. 
+//
+// IBCProfiled: Distinguish between sections that IBC profiling data has been used
+//               to decide the layout of the data items in this section.
 // NonIBCProfiled: We don't have IBC data for all our datastructures.
 //                  The access pattern/frequency for some data structures
-//                  are statically determined. Sections that contain these data items 
-//                  are marked as NonIBCProfiled. 
+//                  are statically determined. Sections that contain these data items
+//                  are marked as NonIBCProfiled.
 //
 //***************************************************
-// Access Frequency categories 
+// Access Frequency categories
 // **************************************************
 // Hot: Data is frequently accessed
 // Warm: Less frequently accessed than Hot
 // Cold: Should be rarely accessed.
-// 
-// The combination of these 2 sub-categories gives us the following valid categories 
+//
+// The combination of these 2 sub-categories gives us the following valid categories
 // 1-IBCProfiled | Hot: Hot based on IBC profiling data.
 // 2-IBCProfiled | Cold: IBC profiling could have helped make this section hot.
 // 3-NonIBCProfiled | Hot: Statically determined hot.
 // 4-NonIBCProfiled | Warm: Staticaly determined warm.
 // 5-NonIBCProfiled | Cold: Statically determined cold.
-// 
-// We should try to place data items into the correct section based on 
-// the above categorization, this could mean that we might split 
+//
+// We should try to place data items into the correct section based on
+// the above categorization, this could mean that we might split
 // a virtual section into 2 sections if it contains multiple heterogeneous items.
 
 enum ZapVirtualSectionType
@@ -409,7 +409,7 @@ enum ZapVirtualSectionType
 #define CORCOMPILE_SECTION_IBCTYPE(ibcType, flag) ibcType##Section = flag,
     CORCOMPILE_SECTION_IBCTYPES()
 #undef CORCOMPILE_SECTION_IBCTYPE
-    
+
     // <RangeType>
     RangeTypeReservedFlag = 0x00FF0000,
 #define CORCOMPILE_SECTION_RANGE_TYPE(rangeType, flag) rangeType##Range = flag,
@@ -433,9 +433,9 @@ public :
     static UINT8 IBCType(DWORD sectionType) { return (UINT8) ((sectionType & IBCTypeReservedFlag) >> 24); }
     static UINT8 RangeType(DWORD sectionType) { return (UINT8) ((sectionType & RangeTypeReservedFlag) >> 16); }
     static UINT16 VirtualSectionType(DWORD sectionType) { return (UINT16) ((sectionType & VirtualSectionTypeReservedFlag)); }
-    static BOOL IsIBCProfiledColdSection(DWORD sectionType) 
+    static BOOL IsIBCProfiledColdSection(DWORD sectionType)
     {
-        return ((sectionType & ColdRange) == ColdRange) && ((sectionType & IBCProfiledSection) == IBCProfiledSection); 
+        return ((sectionType & ColdRange) == ColdRange) && ((sectionType & IBCProfiledSection) == IBCProfiledSection);
     }
 };
 
@@ -581,14 +581,14 @@ struct CORCOMPILE_CODE_MANAGER_ENTRY
         // Post patchup by the stub, it will point to the actual method body.
         PCODE               m_pTarget;
     };
-	
+
 #elif defined(_TARGET_ARM64_)
     struct  CORCOMPILE_VIRTUAL_IMPORT_THUNK
     {
         // Array of words to do the following:
         //
         // adr         x12, #0            ; Save the current address relative to which we will get slot ID and address to patch.
-        // ldr         x10, [x12, #16]    ; Load the target address. 
+        // ldr         x10, [x12, #16]    ; Load the target address.
         // br          x10                ; Jump to the target
         DWORD                m_rgCode[3];
 
@@ -604,7 +604,7 @@ struct CORCOMPILE_CODE_MANAGER_ENTRY
     {
         // Array of words to do the following:
         // adr         x12, #0            ; Save the current address relative to which we will get slot ID and address to patch.
-        // ldr         x10, [x12, #16]    ; Load the target address. 
+        // ldr         x10, [x12, #16]    ; Load the target address.
         // br          x10                ; Jump to the target
         DWORD                m_rgCode[3];
 
@@ -619,7 +619,7 @@ struct CORCOMPILE_CODE_MANAGER_ENTRY
 
 //
 // GCRefMap blob starts with DWORDs lookup index of relative offsets into the blob. This lookup index is used to limit amount
-// of linear scanning required to find entry in the GCRefMap. The size of this lookup index is 
+// of linear scanning required to find entry in the GCRefMap. The size of this lookup index is
 // <totalNumberOfEntries in the GCRefMap> / GCREFMAP_LOOKUP_STRIDE.
 //
 #define GCREFMAP_LOOKUP_STRIDE 1024
@@ -638,7 +638,7 @@ enum CORCOMPILE_GCREFMAP_TOKENS
 enum CORCOMPILE_FIXUP_BLOB_KIND
 {
     ENCODE_NONE                         = 0,
-    
+
     ENCODE_MODULE_OVERRIDE              = 0x80,     /* When the high bit is set, override of the module immediately follows */
 
     ENCODE_DICTIONARY_LOOKUP_THISOBJ    = 0x07,
@@ -739,7 +739,7 @@ struct CORCOMPILE_EXCEPTION_LOOKUP_TABLE_ENTRY
 
 struct CORCOMPILE_EXCEPTION_LOOKUP_TABLE
 {
-    // pointer to the first element of m_numLookupEntries elements 
+    // pointer to the first element of m_numLookupEntries elements
     CORCOMPILE_EXCEPTION_LOOKUP_TABLE_ENTRY m_Entries[1];
 
     CORCOMPILE_EXCEPTION_LOOKUP_TABLE_ENTRY* ExceptionLookupEntry(unsigned i)
@@ -754,12 +754,12 @@ struct CORCOMPILE_EXCEPTION_CLAUSE
     CorExceptionFlag    Flags;
     DWORD               TryStartPC;
     DWORD               TryEndPC;
-    DWORD               HandlerStartPC;  
-    DWORD               HandlerEndPC;  
+    DWORD               HandlerStartPC;
+    DWORD               HandlerEndPC;
     union {
         mdToken         ClassToken;
         DWORD           FilterOffset;
-    };  
+    };
 };
 
 //lower order bit (HAS_EXCEPTION_INFO_MASK) used to determine if the method has any exception handling
@@ -900,22 +900,16 @@ public:
 
     struct CORBBTPROF_TOKEN_INFO *  GetTokenFlagsData(SectionFormat section)
     {
-        if (this == NULL)
-            return NULL;
         return this->profilingTokenFlagsData[section].data;
     }
 
     DWORD GetTokenFlagsCount(SectionFormat section)
     {
-        if (this == NULL)
-            return 0;
         return this->profilingTokenFlagsData[section].count;
     }
 
     CORBBTPROF_BLOB_ENTRY *  GetBlobStream()
     {
-        if (this == NULL)
-            return NULL;
         return this->blobStream;
     }
 
@@ -1278,11 +1272,11 @@ class ICorCompilePreloader
             ) = 0;
 
     virtual void NoteDeduplicatedCode(
-            CORINFO_METHOD_HANDLE method, 
+            CORINFO_METHOD_HANDLE method,
             CORINFO_METHOD_HANDLE duplicateMethod) = 0;
 
 #ifdef FEATURE_READYTORUN_COMPILER
-    // Returns a compressed encoding of the inline tracking map 
+    // Returns a compressed encoding of the inline tracking map
     // for this compilation
     virtual void GetSerializedInlineTrackingMap(
             IN OUT SBuffer    * pSerializedInlineTrackingMap
@@ -1465,7 +1459,7 @@ class ICorCompileInfo
 #ifdef FEATURE_COMINTEROP
     // Loads a WinRT typeref into the EE and returns
     // a handle to it.  We have to load all typerefs
-    // during dependency computation since assemblyrefs 
+    // during dependency computation since assemblyrefs
     // are meaningless to WinRT.
     virtual HRESULT LoadTypeRefWinRT(
             IMDInternalImport       *pAssemblyImport,
@@ -1641,7 +1635,7 @@ class ICorCompileInfo
 
     // Returns non-null methoddef or memberref token if it is sufficient to encode the method (no generic instantiations, etc.)
     virtual mdToken TryEncodeMethodAsToken(
-            CORINFO_METHOD_HANDLE handle, 
+            CORINFO_METHOD_HANDLE handle,
             CORINFO_RESOLVED_TOKEN * pResolvedToken,
             CORINFO_MODULE_HANDLE * referencingModule) = 0;
 
@@ -1741,7 +1735,7 @@ class ICorCompileInfo
 
 #ifdef FEATURE_READYTORUN_COMPILER
     virtual CORCOMPILE_FIXUP_BLOB_KIND GetFieldBaseOffset(
-            CORINFO_CLASS_HANDLE classHnd, 
+            CORINFO_CLASS_HANDLE classHnd,
             DWORD * pBaseOffset
             ) = 0;
 

--- a/src/inc/sstring.inl
+++ b/src/inc/sstring.inl
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// 
+//
 
 #ifndef _SSTRING_INL_
 #define _SSTRING_INL_
@@ -646,9 +646,6 @@ inline const WCHAR *SString::GetUnicode() const
         SUPPORTS_DAC;
     }
     SS_CONTRACT_END;
-    
-    if (this == NULL)
-        SS_RETURN NULL;
 
     ConvertToUnicode();
 
@@ -686,7 +683,7 @@ inline const WCHAR *SString::GetUnicode(const CIterator &i) const
     SS_CONTRACT_END;
 
     PRECONDITION(CheckPointer(this));
-    
+
     ConvertToUnicode(i);
 
     SS_RETURN i.GetUnicode();
@@ -711,7 +708,7 @@ inline void SString::Append(const SString &s)
 }
 
 inline void SString::Append(const WCHAR *string)
-{    
+{
     SS_CONTRACT_VOID
     {
         GC_NOTRIGGER;
@@ -875,7 +872,7 @@ inline BOOL SString::Match(const CIterator &i, WCHAR c) const
         NOTHROW;
     }
     SS_CONTRACT_END;
-    
+
     // End() will not throw here
     CONTRACT_VIOLATION(ThrowsViolation);
     SS_RETURN (i < End() && i[0] == c);
@@ -924,7 +921,7 @@ inline BOOL SString::Skip(CIterator &i, WCHAR c) const
 
 // Find string within this string. Return TRUE and update iterator if found
 inline BOOL SString::Find(CIterator &i, const WCHAR *string) const
-{    
+{
     SS_CONTRACT(BOOL)
     {
         GC_NOTRIGGER;
@@ -941,7 +938,7 @@ inline BOOL SString::Find(CIterator &i, const WCHAR *string) const
 }
 
 inline BOOL SString::FindASCII(CIterator &i, const CHAR *string) const
-{    
+{
     SS_CONTRACT(BOOL)
     {
         GC_NOTRIGGER;
@@ -958,7 +955,7 @@ inline BOOL SString::FindASCII(CIterator &i, const CHAR *string) const
 }
 
 inline BOOL SString::FindUTF8(CIterator &i, const CHAR *string) const
-{    
+{
     SS_CONTRACT(BOOL)
     {
         GC_NOTRIGGER;
@@ -975,7 +972,7 @@ inline BOOL SString::FindUTF8(CIterator &i, const CHAR *string) const
 }
 
 inline BOOL SString::FindBack(CIterator &i, const WCHAR *string) const
-{    
+{
     SS_CONTRACT(BOOL)
     {
         GC_NOTRIGGER;
@@ -992,7 +989,7 @@ inline BOOL SString::FindBack(CIterator &i, const WCHAR *string) const
 }
 
 inline BOOL SString::FindBackASCII(CIterator &i, const CHAR *string) const
-{    
+{
     SS_CONTRACT(BOOL)
     {
         GC_NOTRIGGER;
@@ -1009,7 +1006,7 @@ inline BOOL SString::FindBackASCII(CIterator &i, const CHAR *string) const
 }
 
 inline BOOL SString::FindBackUTF8(CIterator &i, const CHAR *string) const
-{    
+{
     SS_CONTRACT(BOOL)
     {
         GC_NOTRIGGER;
@@ -1143,7 +1140,7 @@ inline void SString::Trim() const
 
 // RETURN true if the string is empty.
 inline BOOL SString::IsEmpty() const
-{ 
+{
     SS_CONTRACT(BOOL)
     {
         GC_NOTRIGGER;
@@ -1158,7 +1155,7 @@ inline BOOL SString::IsEmpty() const
 
 // RETURN true if the string rep is ASCII.
 inline BOOL SString::IsASCII() const
-{ 
+{
     SS_CONTRACT(BOOL)
     {
         GC_NOTRIGGER;
@@ -1172,7 +1169,7 @@ inline BOOL SString::IsASCII() const
 
 // Get the number of characters in the string (excluding the terminating NULL)
 inline COUNT_T SString::GetCount() const
-{ 
+{
     SS_CONTRACT(COUNT_T)
     {
         GC_NOTRIGGER;
@@ -1231,8 +1228,8 @@ inline WCHAR *SString::GetRawUnicode() const
 
 // Private helper:
 // get the representation (ansi, unicode, utf8)
-inline SString::Representation SString::GetRepresentation() const 
-{ 
+inline SString::Representation SString::GetRepresentation() const
+{
     WRAPPER_NO_CONTRACT;
 
     return (Representation) SBuffer::GetRepresentationField();
@@ -1241,7 +1238,7 @@ inline SString::Representation SString::GetRepresentation() const
 // Private helper.
 // Set the representation.
 inline void SString::SetRepresentation(SString::Representation representation)
-{ 
+{
 #ifdef SSTRING_EXTRA_CHECKS
     CONTRACT_VOID
     {
@@ -1265,8 +1262,8 @@ inline void SString::SetRepresentation(SString::Representation representation)
 
 // Private helper:
 // Get the amount to shift the byte size to get a character count
-inline int SString::GetCharacterSizeShift() const 
-{ 
+inline int SString::GetCharacterSizeShift() const
+{
     WRAPPER_NO_CONTRACT;
 
     // Note that the flag is backwards; we want the default
@@ -1312,9 +1309,9 @@ FORCEINLINE void SString::NullTerminate()
 //----------------------------------------------------------------------------
 // private helper
 // Return true if the string is a literal.
-// A literal string has immutable memory. 
+// A literal string has immutable memory.
 //----------------------------------------------------------------------------
-inline BOOL SString::IsLiteral() const 
+inline BOOL SString::IsLiteral() const
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1324,7 +1321,7 @@ inline BOOL SString::IsLiteral() const
 //----------------------------------------------------------------------------
 // private helper:
 // RETURN true if the string allocated (and should delete) its buffer.
-// IsAllocated() will RETURN false for Literal strings and 
+// IsAllocated() will RETURN false for Literal strings and
 // stack-based strings (the buffer is on the stack)
 //----------------------------------------------------------------------------
 inline BOOL SString::IsAllocated() const
@@ -1338,7 +1335,7 @@ inline BOOL SString::IsAllocated() const
 // Return true after we call OpenBuffer(), but before we close it.
 // All SString operations are illegal while the buffer is open.
 //----------------------------------------------------------------------------
-#if _DEBUG    
+#if _DEBUG
 inline BOOL SString::IsBufferOpen() const
 {
     WRAPPER_NO_CONTRACT;
@@ -1351,7 +1348,7 @@ inline BOOL SString::IsBufferOpen() const
 // Return true if we've scanned the string to see if it is in the ASCII subset.
 //----------------------------------------------------------------------------
 inline BOOL SString::IsASCIIScanned() const
-{    
+{
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
 
@@ -1362,7 +1359,7 @@ inline BOOL SString::IsASCIIScanned() const
 // Set that we've scanned the string to see if it is in the ASCII subset.
 //----------------------------------------------------------------------------
 inline void SString::SetASCIIScanned() const
-{    
+{
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC_HOST_ONLY;
 
@@ -1373,7 +1370,7 @@ inline void SString::SetASCIIScanned() const
 // Return true if we've normalized the string to unicode
 //----------------------------------------------------------------------------
 inline BOOL SString::IsNormalized() const
-{    
+{
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
 
@@ -1384,7 +1381,7 @@ inline BOOL SString::IsNormalized() const
 // Set that we've normalized the string to unicode
 //----------------------------------------------------------------------------
 inline void SString::SetNormalized() const
-{    
+{
     WRAPPER_NO_CONTRACT;
 
     const_cast<SString *>(this)->SBuffer::SetFlag3();
@@ -1394,7 +1391,7 @@ inline void SString::SetNormalized() const
 // Clear normalization
 //----------------------------------------------------------------------------
 inline void SString::ClearNormalized() const
-{    
+{
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC_HOST_ONLY;
 
@@ -1439,10 +1436,10 @@ inline BOOL SString::IsIteratable() const
     STATIC_CONTRACT_GC_NOTRIGGER;
     STATIC_CONTRACT_SUPPORTS_DAC;
 
-    // Note that in many cases ANSI may be fixed width.  However we 
+    // Note that in many cases ANSI may be fixed width.  However we
     // currently still do not allow iterating on them, because we would have to
     // do character-by-character conversion on a character dereference (which must
-    // go to unicode) .  We may want to adjust this going forward to 
+    // go to unicode) .  We may want to adjust this going forward to
     // depending on perf in the non-ASCII but fixed width ANSI case.
 
     return ((GetRepresentation()&REPRESENTATION_VARIABLE_MASK) == 0);
@@ -1455,7 +1452,7 @@ inline BOOL SString::IsIteratable() const
 // count does not include the null-terminator, but the RETURN value does.
 //----------------------------------------------------------------------------
 inline COUNT_T SString::CountToSize(COUNT_T count) const
-{    
+{
     SS_CONTRACT(COUNT_T)
     {
         GC_NOTRIGGER;
@@ -1471,7 +1468,7 @@ inline COUNT_T SString::CountToSize(COUNT_T count) const
 
 //----------------------------------------------------------------------------
 // Private helper.
-// Return the maxmimum count of characters that could fit in a buffer of 
+// Return the maxmimum count of characters that could fit in a buffer of
 // 'size' bytes in the given representation.
 // 'size' includes the null terminator, but the RETURN value does not.
 //----------------------------------------------------------------------------
@@ -1493,7 +1490,7 @@ inline COUNT_T SString::SizeToCount(COUNT_T size) const
 //----------------------------------------------------------------------------
 // Private helper.
 // Return the maxmimum count of characters that could fit in the current
-// buffer including NULL terminator. 
+// buffer including NULL terminator.
 //----------------------------------------------------------------------------
 inline COUNT_T SString::GetBufferSizeInCharIncludeNullChar() const
 {
@@ -1505,7 +1502,7 @@ inline COUNT_T SString::GetBufferSizeInCharIncludeNullChar() const
 }
 
 
- 
+
 //----------------------------------------------------------------------------
 // Assert helper
 // Asser that the iterator is within the given string.
@@ -1543,7 +1540,7 @@ inline CHECK SString::CheckEmpty() const
 //----------------------------------------------------------------------------
 // Check the range of a count
 //----------------------------------------------------------------------------
-inline CHECK SString::CheckCount(COUNT_T count) 
+inline CHECK SString::CheckCount(COUNT_T count)
 {
     CANNOT_HAVE_CONTRACT;
     CHECK(CheckSize(count*sizeof(WCHAR)));
@@ -1568,7 +1565,7 @@ inline CHECK SString::CheckRepresentation(int representation)
 
 #if CHECK_INVARIANTS
 //----------------------------------------------------------------------------
-// Assert helper. Check that the string only uses the ASCII subset of 
+// Assert helper. Check that the string only uses the ASCII subset of
 // codes.
 //----------------------------------------------------------------------------
 inline CHECK SString::CheckASCIIString(const CHAR *string)
@@ -1625,7 +1622,7 @@ inline CHECK SString::InternalInvariant() const
 //----------------------------------------------------------------------------
 // Return a writeable buffer that can store 'countChars'+1 unicode characters.
 // Call CloseBuffer when done.
-//----------------------------------------------------------------------------    
+//----------------------------------------------------------------------------
 inline WCHAR *SString::OpenUnicodeBuffer(COUNT_T countChars)
 {
     SS_CONTRACT(WCHAR*)
@@ -1665,7 +1662,7 @@ inline WCHAR *SString::GetCopyOfUnicodeString()
 
     buffer = new WCHAR[GetCount() +1];
     wcscpy_s(buffer, GetCount() + 1, GetUnicode());
-    
+
     SS_RETURN buffer.Extract();
 }
 
@@ -1721,9 +1718,9 @@ inline UTF8 *SString::OpenUTF8Buffer(COUNT_T countBytes)
 
 //----------------------------------------------------------------------------
 // Private helper to open a raw buffer.
-// Called by public functions to open the buffer in the specific 
+// Called by public functions to open the buffer in the specific
 // representation.
-// While the buffer is opened, all other operations are illegal. Call 
+// While the buffer is opened, all other operations are illegal. Call
 // CloseBuffer() when done.
 //----------------------------------------------------------------------------
 inline void SString::OpenBuffer(SString::Representation representation, COUNT_T countChars)
@@ -1757,7 +1754,7 @@ inline void SString::OpenBuffer(SString::Representation representation, COUNT_T 
 }
 
 //----------------------------------------------------------------------------
-// Get the max size that can be passed to OpenUnicodeBuffer without causing 
+// Get the max size that can be passed to OpenUnicodeBuffer without causing
 // allocations.
 //----------------------------------------------------------------------------
 inline COUNT_T SString::GetUnicodeAllocation()
@@ -1767,16 +1764,16 @@ inline COUNT_T SString::GetUnicodeAllocation()
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
-    } 
+    }
     CONTRACTL_END;
 
     COUNT_T allocation = GetAllocation();
-    return ( (allocation > sizeof(WCHAR)) 
+    return ( (allocation > sizeof(WCHAR))
         ? (allocation - sizeof(WCHAR)) / sizeof(WCHAR) : 0 );
 }
 
 //----------------------------------------------------------------------------
-// Close an open buffer. Assumes that we wrote exactly number of characters 
+// Close an open buffer. Assumes that we wrote exactly number of characters
 // we requested in OpenBuffer.
 //----------------------------------------------------------------------------
 inline void SString::CloseBuffer()
@@ -1801,7 +1798,7 @@ inline void SString::CloseBuffer()
 //----------------------------------------------------------------------------
 // CloseBuffer() tells the SString that we're done using the unsafe buffer.
 // countChars is the count of characters actually used (so we can set m_count).
-// This is important if we request a buffer larger than what we actually 
+// This is important if we request a buffer larger than what we actually
 // used.
 //----------------------------------------------------------------------------
 inline void SString::CloseBuffer(COUNT_T finalCount)
@@ -1852,7 +1849,7 @@ inline void SString::EnsureWritable() const
 }
 
 //-----------------------------------------------------------------------------
-// Convert the internal representation to be a fixed size 
+// Convert the internal representation to be a fixed size
 //-----------------------------------------------------------------------------
 inline void SString::ConvertToFixed() const
 {
@@ -1881,7 +1878,7 @@ inline void SString::ConvertToFixed() const
 }
 
 //-----------------------------------------------------------------------------
-// Convert the internal representation to be an iteratable one (current 
+// Convert the internal representation to be an iteratable one (current
 // requirements here are that it be trivially convertable to unicode chars.)
 //-----------------------------------------------------------------------------
 inline void SString::ConvertToIteratable() const
@@ -1930,7 +1927,7 @@ inline SString::UIterator SString::BeginUnicode()
 
     SS_RETURN UIterator(this, 0);
 }
-        
+
 inline SString::UIterator SString::EndUnicode()
 {
     SS_CONTRACT(SString::UIterator)
@@ -1967,7 +1964,7 @@ FORCEINLINE SString::CIterator SString::Begin() const
 
     SS_RETURN CIterator(this, 0);
 }
-        
+
 FORCEINLINE SString::CIterator SString::End() const
 {
     SS_CONTRACT(SString::CIterator)
@@ -1988,7 +1985,7 @@ FORCEINLINE SString::CIterator SString::End() const
 // Create Iterators on the string.
 //-----------------------------------------------------------------------------
 
-FORCEINLINE SString::Iterator SString::Begin() 
+FORCEINLINE SString::Iterator SString::Begin()
 {
     SS_CONTRACT(SString::Iterator)
     {
@@ -2005,8 +2002,8 @@ FORCEINLINE SString::Iterator SString::Begin()
 
     SS_RETURN Iterator(this, 0);
 }
-        
-FORCEINLINE SString::Iterator SString::End() 
+
+FORCEINLINE SString::Iterator SString::End()
 {
     SS_CONTRACT(SString::Iterator)
     {
@@ -2049,7 +2046,7 @@ inline SString::Index::Index(SString *string, SCOUNT_T index)
         SUPPORTS_DAC;
     }
     SS_CONTRACT_END;
-        
+
     m_characterSizeShift = string->GetCharacterSizeShift();
 
     SS_RETURN;
@@ -2125,7 +2122,7 @@ inline WCHAR SString::Index::operator*() const
 }
 
 inline void SString::Index::operator->() const
-{ 
+{
     LIMITED_METHOD_CONTRACT;
 }
 

--- a/src/jit/_typeinfo.h
+++ b/src/jit/_typeinfo.h
@@ -331,7 +331,6 @@ public:
     typeInfo(ti_types tiType)
     {
         assert((tiType >= TI_BYTE) && (tiType <= TI_NULL));
-        assert(tiType <= TI_FLAG_DATA_MASK);
 
         m_flags = (DWORD)tiType;
         m_cls   = NO_CLASS_HANDLE;

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -17946,10 +17946,6 @@ bool FieldSeqNode::IsConstantIndexFieldSeq()
 
 bool FieldSeqNode::IsPseudoField()
 {
-    if (this == nullptr)
-    {
-        return false;
-    }
     return m_fieldHnd == FieldSeqStore::FirstElemPseudoField || m_fieldHnd == FieldSeqStore::ConstantIndexPseudoField;
 }
 

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -1124,8 +1124,6 @@ void SsaBuilder::AddMemoryDefToHandlerPhis(MemoryKind memoryKind, BasicBlock* bl
             // Is memoryKind live on entry to the handler?
             if ((handler->bbMemoryLiveIn & memoryKindSet(memoryKind)) != 0)
             {
-                assert(handler->bbMemorySsaPhiFunc != nullptr);
-
                 // Add "ssaNum" to the phi args of memoryKind.
                 BasicBlock::MemoryPhiArg*& handlerMemoryPhi = handler->bbMemorySsaPhiFunc[memoryKind];
 

--- a/src/tools/util/tree.h
+++ b/src/tools/util/tree.h
@@ -220,8 +220,6 @@ REDO:
      */
     void Cleanup()
     {
-        if (this == NULL)
-            return ;
         if (lChild != NULL)
         {
             lChild->Cleanup();

--- a/src/utilcode/loaderheap.cpp
+++ b/src/utilcode/loaderheap.cpp
@@ -44,7 +44,7 @@ namespace
 
 //
 // RangeLists are constructed so they can be searched from multiple
-// threads without locking.  They do require locking in order to 
+// threads without locking.  They do require locking in order to
 // be safely modified, though.
 //
 
@@ -53,7 +53,7 @@ RangeList::RangeList()
     WRAPPER_NO_CONTRACT;
 
     InitBlock(&m_starterBlock);
-         
+
     m_firstEmptyBlock = &m_starterBlock;
     m_firstEmptyRange = 0;
 }
@@ -61,7 +61,7 @@ RangeList::RangeList()
 RangeList::~RangeList()
 {
     LIMITED_METHOD_CONTRACT;
-    
+
     RangeListBlock *b = m_starterBlock.next;
 
     while (b != NULL)
@@ -77,7 +77,7 @@ void RangeList::InitBlock(RangeListBlock *b)
     LIMITED_METHOD_CONTRACT;
 
     Range *r = b->ranges;
-    Range *rEnd = r + RANGE_COUNT; 
+    Range *rEnd = r + RANGE_COUNT;
     while (r < rEnd)
         r++->id = NULL;
 
@@ -110,7 +110,7 @@ BOOL RangeList::AddRangeWorker(const BYTE *start, const BYTE *end, void *id)
                 r->start = (TADDR)start;
                 r->end = (TADDR)end;
                 r->id = (TADDR)id;
-                
+
                 r++;
 
                 m_firstEmptyBlock = b;
@@ -122,7 +122,7 @@ BOOL RangeList::AddRangeWorker(const BYTE *start, const BYTE *end, void *id)
         }
 
         //
-        // If there are no more blocks, allocate a 
+        // If there are no more blocks, allocate a
         // new one.
         //
 
@@ -167,7 +167,7 @@ void RangeList::RemoveRangesWorker(void *id, const BYTE* start, const BYTE* end)
     RangeListBlock *b = &m_starterBlock;
     Range *r = b->ranges;
     Range *rEnd = r + RANGE_COUNT;
-    
+
     //
     // Find the first free element, & mark it.
     //
@@ -212,12 +212,12 @@ void RangeList::RemoveRangesWorker(void *id, const BYTE* start, const BYTE* end)
             m_firstEmptyRange = 0;
             m_firstEmptyBlock = &m_starterBlock;
 
-            return; 
+            return;
         }
 
-        // 
+        //
         // Next block.
-        // 
+        //
 
         b = b->next;
         r = b->ranges;
@@ -237,7 +237,7 @@ BOOL RangeList::IsInRangeWorker(TADDR address, TADDR *pID /* = NULL */)
         GC_NOTRIGGER;
     }
     CONTRACTL_END
-        
+
     SUPPORTS_DAC;
 
     RangeListBlock* b = &m_starterBlock;
@@ -253,7 +253,7 @@ BOOL RangeList::IsInRangeWorker(TADDR address, TADDR *pID /* = NULL */)
         while (r < rEnd)
         {
             if (r->id != NULL &&
-                address >= r->start 
+                address >= r->start
                 && address < r->end)
             {
                 if (pID != NULL)
@@ -264,7 +264,7 @@ BOOL RangeList::IsInRangeWorker(TADDR address, TADDR *pID /* = NULL */)
             }
             r++;
         }
-        
+
         //
         // If there are no more blocks, we're done.
         //
@@ -272,9 +272,9 @@ BOOL RangeList::IsInRangeWorker(TADDR address, TADDR *pID /* = NULL */)
         if (b->next == NULL)
             return FALSE;
 
-        // 
+        //
         // Next block.
-        // 
+        //
 
         b = b->next;
         r = b->ranges;
@@ -292,7 +292,7 @@ RangeList::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 
     // This class is almost always contained in something
     // else so there's no enumeration of 'this'.
-    
+
     RangeListBlock* block = &m_starterBlock;
     block->EnumMemoryRegions(flags);
 
@@ -300,12 +300,12 @@ RangeList::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
     {
         block->next.EnumMem();
         block = block->next;
-        
+
         block->EnumMemoryRegions(flags);
     }
 }
 
-void 
+void
 RangeList::RangeListBlock::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 {
     WRAPPER_NO_CONTRACT;
@@ -315,7 +315,7 @@ RangeList::RangeListBlock::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
     TSIZE_T         size;
     int             i;
 
-    // The code below iterates each range stored in the RangeListBlock and 
+    // The code below iterates each range stored in the RangeListBlock and
     // dumps the memory region represented by each range.
     // It is too much memory for a mini-dump, so we just bail out for mini-dumps.
     if (flags == CLRDATA_ENUM_MEM_MINI || flags == CLRDATA_ENUM_MEM_TRIAGE)
@@ -329,8 +329,8 @@ RangeList::RangeListBlock::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
     for (i=0; i<RANGE_COUNT; i++)
     {
         range = &(this->ranges[i]);
-        if (range->id == NULL || range->start == NULL || range->end == NULL || 
-            // just looking at the lower 4bytes is good enough on WIN64 
+        if (range->id == NULL || range->start == NULL || range->end == NULL ||
+            // just looking at the lower 4bytes is good enough on WIN64
             range->start == BADFOOD || range->end == BADFOOD)
         {
             break;
@@ -340,12 +340,12 @@ RangeList::RangeListBlock::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
         _ASSERTE( size < UINT32_MAX );    // ranges should be less than 4gig!
 
         // We can't be sure this entire range is mapped.  For example, the code:StubLinkStubManager
-        // keeps track of all ranges in the code:BaseDomain::m_pStubHeap LoaderHeap, and 
+        // keeps track of all ranges in the code:BaseDomain::m_pStubHeap LoaderHeap, and
         // code:LoaderHeap::UnlockedReservePages adds a range for the entire reserved region, instead
         // of updating the RangeList when pages are committed.  But in that case, the committed region of
         // memory will be enumerated by the LoaderHeap anyway, so it's OK if this fails
         DacEnumMemoryRegion(range->start, size, false);
-    }    
+    }
 }
 
 #endif // #ifdef DACCESS_COMPILE
@@ -652,7 +652,7 @@ class LoaderHeapSniffer
 
             //If none of the above popped up an assert, pop up a generic one.
             _ASSERTE(!("Unexpected AV inside LoaderHeap. The usual reason is that someone overwrote the end of a block or wrote into a freed block.\n"));
-                       
+
         }
 
 };
@@ -665,8 +665,8 @@ class LoaderHeapSniffer
 #define LOADER_HEAP_BEGIN_TRAP_FAULT BOOL __faulted = FALSE; EX_TRY {
 #define LOADER_HEAP_END_TRAP_FAULT   } EX_CATCH {__faulted = TRUE; } EX_END_CATCH(SwallowAllExceptions) if (__faulted) LoaderHeapSniffer::WeGotAFaultNowWhat(pHeap);
 #else
-#define LOADER_HEAP_BEGIN_TRAP_FAULT 
-#define LOADER_HEAP_END_TRAP_FAULT   
+#define LOADER_HEAP_BEGIN_TRAP_FAULT
+#define LOADER_HEAP_END_TRAP_FAULT
 #endif
 
 
@@ -792,7 +792,7 @@ struct LoaderHeapFreeBlock
 
 
     private:
-        // Try to merge pFreeBlock with its immediate successor. Return TRUE if a merge happened. FALSE if no merge happened. 
+        // Try to merge pFreeBlock with its immediate successor. Return TRUE if a merge happened. FALSE if no merge happened.
         static BOOL MergeBlock(LoaderHeapFreeBlock *pFreeBlock, UnlockedLoaderHeap *pHeap)
         {
             STATIC_CONTRACT_NOTHROW;
@@ -866,7 +866,7 @@ inline size_t AllocMem_TotalSize(size_t dwRequestedSize, UnlockedLoaderHeap *pHe
         if (dwSize < sizeof(LoaderHeapFreeBlock))
         {
             dwSize = sizeof(LoaderHeapFreeBlock);
-        } 
+        }
     }
     dwSize = ((dwSize + ALLOC_ALIGN_CONSTANT) & (~ALLOC_ALIGN_CONSTANT));
 
@@ -899,7 +899,7 @@ LoaderHeapValidationTag *AllocMem_GetTag(LPVOID pBlock, size_t dwRequestedSize)
 UnlockedLoaderHeap::UnlockedLoaderHeap(DWORD dwReserveBlockSize,
                                        DWORD dwCommitBlockSize,
                                        const BYTE* dwReservedRegionAddress,
-                                       SIZE_T dwReservedRegionSize, 
+                                       SIZE_T dwReservedRegionSize,
                                        size_t *pPrivatePerfCounter_LoaderBytes,
                                        RangeList *pRangeList,
                                        BOOL fMakeExecutable)
@@ -911,7 +911,7 @@ UnlockedLoaderHeap::UnlockedLoaderHeap(DWORD dwReserveBlockSize,
         FORBID_FAULT;
     }
     CONTRACTL_END;
-    
+
     m_pCurBlock                  = NULL;
     m_pFirstBlock                = NULL;
 
@@ -979,9 +979,9 @@ UnlockedLoaderHeap::~UnlockedLoaderHeap()
         pVirtualAddress = pSearch->pVirtualAddress;
         fReleaseMemory = pSearch->m_fReleaseMemory;
         pNext = pSearch->pNext;
-                
+
         if (fReleaseMemory)
-        {    
+        {
             BOOL fSuccess;
             fSuccess = ClrVirtualFree(pVirtualAddress, 0, MEM_RELEASE);
             _ASSERTE(fSuccess);
@@ -1069,7 +1069,7 @@ BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
         INJECT_FAULT(return FALSE;);
     }
     CONTRACTL_END;
-    
+
     size_t dwSizeToReserve;
 
     // Add sizeof(LoaderHeapBlock)
@@ -1107,7 +1107,7 @@ BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
         // Round to VIRTUAL_ALLOC_RESERVE_GRANULARITY
         dwSizeToReserve = ALIGN_UP(dwSizeToReserve, VIRTUAL_ALLOC_RESERVE_GRANULARITY);
 
-        _ASSERTE(dwSizeToCommit <= dwSizeToReserve);    
+        _ASSERTE(dwSizeToCommit <= dwSizeToReserve);
 
         //
         // Reserve pages
@@ -1120,9 +1120,9 @@ BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
         }
     }
 
-    // When the user passes in the reserved memory, the commit size is 0 and is adjusted to be the sizeof(LoaderHeap). 
+    // When the user passes in the reserved memory, the commit size is 0 and is adjusted to be the sizeof(LoaderHeap).
     // If for some reason this is not true then we just catch this via an assertion and the dev who changed code
-    // would have to add logic here to handle the case when committed mem is more than the reserved mem. One option 
+    // would have to add logic here to handle the case when committed mem is more than the reserved mem. One option
     // could be to leak the users memory and reserve+commit a new block, Another option would be to fail the alloc mem
     // and notify the user to provide more reserved mem.
     _ASSERTE((dwSizeToCommit <= dwSizeToReserve) && "Loaderheap tried to commit more memory than reserved by user");
@@ -1153,8 +1153,8 @@ BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
     // Do this AFTER the commit - otherwise we'll have bogus ranges included.
     if (m_pRangeList != NULL)
     {
-        if (!m_pRangeList->AddRange((const BYTE *) pData, 
-                                    ((const BYTE *) pData) + dwSizeToReserve, 
+        if (!m_pRangeList->AddRange((const BYTE *) pData,
+                                    ((const BYTE *) pData) + dwSizeToReserve,
                                     (void *) this))
         {
 
@@ -1183,7 +1183,7 @@ BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
            pCurBlock->pNext != NULL)
         pCurBlock = pCurBlock->pNext;
 
-    if (pCurBlock != NULL)        
+    if (pCurBlock != NULL)
         m_pCurBlock->pNext = pNewBlock;
     else
         m_pFirstBlock = pNewBlock;
@@ -1197,7 +1197,7 @@ BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
 }
 
 // Get some more committed pages - either commit some more in the current reserved region, or, if it
-// has run out, reserve another set of pages. 
+// has run out, reserve another set of pages.
 // Returns: FALSE if we can't get any more memory
 // TRUE: We can/did get some more memory - check to see if it's sufficient for
 //       the caller's needs (see UnlockedAllocMem for example of use)
@@ -1210,8 +1210,8 @@ BOOL UnlockedLoaderHeap::GetMoreCommittedPages(size_t dwMinSize)
         INJECT_FAULT(return FALSE;);
     }
     CONTRACTL_END;
-    
-    // If we have memory we can use, what are you doing here!  
+
+    // If we have memory we can use, what are you doing here!
     _ASSERTE(dwMinSize > (SIZE_T)(m_pPtrToEndOfCommittedRegion - m_pAllocPtr));
 
     // Does this fit in the reserved region?
@@ -1267,7 +1267,7 @@ void *UnlockedLoaderHeap::UnlockedAllocMem(size_t dwSize
 
     if (pResult == NULL)
         ThrowOutOfMemory();
-    
+
     RETURN pResult;
 }
 
@@ -1297,7 +1297,7 @@ static DWORD ShouldInjectFault()
 #else
 
 #define SHOULD_INJECT_FAULT(return_statement) do { (void)((void *)0); } while (FALSE)
-        
+
 #endif
 
 void *UnlockedLoaderHeap::UnlockedAllocMem_NoThrow(size_t dwSize
@@ -1314,7 +1314,7 @@ void *UnlockedLoaderHeap::UnlockedAllocMem_NoThrow(size_t dwSize
         POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
     CONTRACT_END;
-    
+
     SHOULD_INJECT_FAULT(RETURN NULL);
 
     INDEBUG(size_t dwRequestedSize = dwSize;)
@@ -1346,7 +1346,7 @@ again:
         if (pData)
         {
 #ifdef _DEBUG
-    
+
             BYTE *pAllocatedBytes = (BYTE *)pData;
 #if LOADER_HEAP_DEBUG_BOUNDARY > 0
             // Don't fill the memory we allocated - it is assumed to be zeroed - fill the memory after it
@@ -1380,7 +1380,7 @@ again:
                                                dwSize
                                                );
             }
-    
+
 #endif
 
             EtwAllocRequest(this, pData, dwSize);
@@ -1411,7 +1411,7 @@ void UnlockedLoaderHeap::UnlockedBackoutMem(void *pMem,
         FORBID_FAULT;
     }
     CONTRACTL_END;
-    
+
     // Because the primary use of this function is backout, we'll be nice and
     // define Backout(NULL) be a legal NOP.
     if (pMem == NULL)
@@ -1422,7 +1422,7 @@ void UnlockedLoaderHeap::UnlockedBackoutMem(void *pMem,
 #ifdef _DEBUG
     {
         DEBUG_ONLY_REGION();
-        
+
         LoaderHeapValidationTag *pTag = AllocMem_GetTag(pMem, dwRequestedSize);
 
         if (pTag->m_dwRequestedSize != dwRequestedSize || pTag->m_allocationType != kAllocMem)
@@ -1477,7 +1477,7 @@ void UnlockedLoaderHeap::UnlockedBackoutMem(void *pMem,
                         "Possible causes:\n"
                         "\n"
                         "   - This pointer wasn't allocated from this loaderheap.\n"
-                        "   - This pointer was allocated by AllocAlignedMem and you didn't adjust for the \"extra.\"\n" 
+                        "   - This pointer was allocated by AllocAlignedMem and you didn't adjust for the \"extra.\"\n"
                         "   - This pointer has already been freed.\n"
                         "   - You passed in the wrong size. You must pass the exact same size you passed to AllocMem().\n"
                         "   - Someone wrote past the end of this block making it appear as if one of the above were true.\n"
@@ -1485,7 +1485,7 @@ void UnlockedLoaderHeap::UnlockedBackoutMem(void *pMem,
                 message.Append(buf);
 
             }
-            else 
+            else
             {
                 message.AppendASCII("This memory block is completely unrecognizable.\n");
             }
@@ -1511,7 +1511,7 @@ void UnlockedLoaderHeap::UnlockedBackoutMem(void *pMem,
         DEBUG_ONLY_REGION();
 
         LoaderHeapValidationTag *pTag = m_fExplicitControl ? NULL : AllocMem_GetTag(pMem, dwRequestedSize);
-        
+
 
         LoaderHeapSniffer::RecordEvent(this,
                                        kFreedMem,
@@ -1558,9 +1558,9 @@ void UnlockedLoaderHeap::UnlockedBackoutMem(void *pMem,
 //   UnlockedBackoutMem( ((BYTE*)pMem) - dExtra, dwRequestedSize + dwExtra );
 //
 // If you use the AllocMemHolder or AllocMemTracker, all this is taken care of
-// behind the scenes. 
+// behind the scenes.
 //
-// 
+//
 void *UnlockedLoaderHeap::UnlockedAllocAlignedMem_NoThrow(size_t  dwRequestedSize,
                                                           size_t  alignment,
                                                           size_t *pdwExtra
@@ -1638,7 +1638,7 @@ void *UnlockedLoaderHeap::UnlockedAllocAlignedMem_NoThrow(size_t  dwRequestedSiz
     size_t dwSize = AllocMem_TotalSize( cbAllocSize.Value(), this);
     m_pAllocPtr += dwSize;
 
-    
+
     ((BYTE*&)pResult) += extra;
 
 #ifdef _DEBUG
@@ -1716,7 +1716,7 @@ void *UnlockedLoaderHeap::UnlockedAllocAlignedMem(size_t  dwRequestedSize,
     }
 
     return pResult;
-    
+
 
 }
 
@@ -1784,8 +1784,8 @@ void UnlockedLoaderHeap::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
     PTR_LoaderHeapBlock block = m_pFirstBlock;
     while (block.IsValid())
     {
-        // All we know is the virtual size of this block.  We don't have any way to tell how 
-        // much of this space was actually comitted, so don't expect that this will always 
+        // All we know is the virtual size of this block.  We don't have any way to tell how
+        // much of this space was actually comitted, so don't expect that this will always
         // succeed.
         // @dbgtodo : Ideally we'd reduce the risk of corruption causing problems here.
         //   We could extend LoaderHeapBlock to track a commit size,
@@ -1793,7 +1793,7 @@ void UnlockedLoaderHeap::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
         TADDR addr = dac_cast<TADDR>(block->pVirtualAddress);
         TSIZE_T size = block->dwVirtualSize;
         DacEnumMemoryRegion(addr, size, false);
-        
+
         block = block->pNext;
     }
 }
@@ -1812,7 +1812,7 @@ void UnlockedLoaderHeap::EnumPageRegions (EnumPageRegionsCallback *pCallback, PT
         {
             break;
         }
-        
+
         block = block->pNext;
     }
 }
@@ -1961,7 +1961,7 @@ void LoaderHeapSniffer::ValidateFreeList(UnlockedLoaderHeap *pHeap)
     LoaderHeapFreeBlock *pFree     = pHeap->m_pFirstFreeBlock;
     LoaderHeapFreeBlock *pPrev     = NULL;
 
-   
+
     void                *pBadAddr = NULL;
     LoaderHeapFreeBlock *pProbeThis = NULL;
     const char          *pExpected = NULL;
@@ -2003,7 +2003,7 @@ void LoaderHeapSniffer::ValidateFreeList(UnlockedLoaderHeap *pHeap)
         {
             break;
         }
-         
+
 
 
         pPrev = pFree;
@@ -2023,7 +2023,7 @@ void LoaderHeapSniffer::ValidateFreeList(UnlockedLoaderHeap *pHeap)
                        "    LoaderHeap:                 0x%p\n"
                        "    Suspect address at:         0x%p\n"
                        "    Start of suspect freeblock: 0x%p\n"
-                       "\n"    
+                       "\n"
                        , pBadAddr
                        , pExpected
                        , pHeap
@@ -2063,7 +2063,7 @@ void LoaderHeapSniffer::ValidateFreeList(UnlockedLoaderHeap *pHeap)
             LoaderHeapEvent *pPrevEvent = FindEvent(pHeap, ((BYTE*)pProbeThis) - 1);
 
             int count = 3;
-            while (count-- && 
+            while (count-- &&
                    pPrevEvent != NULL &&
                    ( ((UINT_PTR)pProbeThis) - ((UINT_PTR)(pPrevEvent->m_pMem)) + pPrevEvent->m_dwSize ) < 1024)
             {
@@ -2088,8 +2088,8 @@ void LoaderHeapSniffer::ValidateFreeList(UnlockedLoaderHeap *pHeap)
 
     }
 
-    
-    
+
+
 }
 
 
@@ -2159,9 +2159,9 @@ AllocMemTracker::~AllocMemTracker()
                                                ,pNode->m_allocLineNum
 #endif
                                               );
-    
+
             }
-    
+
             pBlock = pBlock->m_pNext;
         }
     }
@@ -2187,8 +2187,6 @@ void *AllocMemTracker::Track(TaggedMemAllocPtr tmap)
     }
     CONTRACTL_END
 
-    _ASSERTE(this); 
-
     void *pv = Track_NoThrow(tmap);
     if (!pv)
     {
@@ -2205,8 +2203,6 @@ void *AllocMemTracker::Track_NoThrow(TaggedMemAllocPtr tmap)
         INJECT_FAULT(return NULL;);
     }
     CONTRACTL_END
-
-    _ASSERTE(this); 
 
     // Calling Track() after calling SuppressRelease() is almost certainly a bug. You're supposed to call SuppressRelease() only after you're
     // sure no subsequent failure will force you to backout the memory.
@@ -2253,17 +2249,12 @@ void *AllocMemTracker::Track_NoThrow(TaggedMemAllocPtr tmap)
 
     }
     return (void *)tmap;
-    
-
-
 }
 
 
 void AllocMemTracker::SuppressRelease()
 {
     LIMITED_METHOD_CONTRACT;
-
-    _ASSERTE(this); 
 
     m_fReleased = TRUE;
 }

--- a/src/utilcode/sstring.cpp
+++ b/src/utilcode/sstring.cpp
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 // ---------------------------------------------------------------------------
 // SString.cpp
-// 
+//
 
 // ---------------------------------------------------------------------------
 
@@ -40,7 +40,7 @@ void SString::Startup()
     STATIC_CONTRACT_GC_NOTRIGGER;
 
     if (s_ACP == 0)
-    {        
+    {
         UINT ACP = GetACP();
 
 #ifndef DACCESS_COMPILE
@@ -72,10 +72,10 @@ static WCHAR MapChar(WCHAR wc, DWORD dwFlags)
     WCHAR                     wTmp;
 
 #ifndef FEATURE_PAL
-    
+
     int iRet = ::LCMapStringEx(LOCALE_NAME_INVARIANT, dwFlags, &wc, 1, &wTmp, 1, NULL, NULL, 0);
     if (!iRet) {
-        // This can fail in non-exceptional cases becauseof unknown unicode characters. 
+        // This can fail in non-exceptional cases becauseof unknown unicode characters.
         wTmp = wc;
     }
 
@@ -128,21 +128,21 @@ int SString::CaseCompareHelper(const WCHAR *buffer1, const WCHAR *buffer2, COUNT
         WCHAR ch1 = *buffer1++;
         WCHAR ch2 = *buffer2++;
         diff = ch1 - ch2;
-        if ((ch1 == 0) || (ch2 == 0)) 
+        if ((ch1 == 0) || (ch2 == 0))
         {
-            if  (diff != 0 || stopOnNull) 
+            if  (diff != 0 || stopOnNull)
             {
                 break;
             }
         }
-        else 
+        else
         {
             if (diff != 0)
             {
                 diff = ((CAN_SIMPLE_UPCASE(ch1) ? SIMPLE_UPCASE(ch1) : MapChar(ch1, LCMAP_UPPERCASE))
                         - (CAN_SIMPLE_UPCASE(ch2) ? SIMPLE_UPCASE(ch2) : MapChar(ch2, LCMAP_UPPERCASE)));
             }
-            if (diff != 0) 
+            if (diff != 0)
             {
                 break;
             }
@@ -159,24 +159,24 @@ int SString::CaseCompareHelper(const WCHAR *buffer1, const WCHAR *buffer2, COUNT
 int GetCaseInsensitiveValueA(const CHAR *buffer, int length) {
     LIMITED_METHOD_CONTRACT;
     _ASSERTE(buffer != NULL);
-    _ASSERTE(length == 1 || ((length == 2) && IsDBCSLeadByte(*buffer)));    
+    _ASSERTE(length == 1 || ((length == 2) && IsDBCSLeadByte(*buffer)));
 
     WCHAR wideCh;
     int sortValue;
-    int conversionReturn = MultiByteToWideChar(CP_ACP, MB_ERR_INVALID_CHARS, buffer, length, &wideCh, 1);            
-    if (conversionReturn == 0) 
+    int conversionReturn = MultiByteToWideChar(CP_ACP, MB_ERR_INVALID_CHARS, buffer, length, &wideCh, 1);
+    if (conversionReturn == 0)
     {
         // An invalid sequence should only compare equal to itself, so use a negative mapping.
-        if (length == 1) 
+        if (length == 1)
         {
             sortValue = -((int)((unsigned char)(*buffer)));
         }
-        else 
+        else
         {
-            sortValue = -(((((int)((unsigned char)(*buffer))) << 8) | ((int)((unsigned char)(*(buffer + 1))))));        
-        }        
+            sortValue = -(((((int)((unsigned char)(*buffer))) << 8) | ((int)((unsigned char)(*(buffer + 1))))));
+        }
     }
-    else 
+    else
     {
         _ASSERTE(conversionReturn == 1);
         sortValue = MapChar(wideCh, LCMAP_UPPERCASE);
@@ -188,7 +188,7 @@ int GetCaseInsensitiveValueA(const CHAR *buffer, int length) {
 int SString::CaseCompareHelperA(const CHAR *buffer1, const CHAR *buffer2, COUNT_T count, BOOL stopOnNull, BOOL stopOnCount)
 {
     LIMITED_METHOD_CONTRACT;
-    
+
     _ASSERTE(stopOnNull || stopOnCount);
 
     const CHAR *buffer1End = buffer1 + count;
@@ -198,20 +198,20 @@ int SString::CaseCompareHelperA(const CHAR *buffer1, const CHAR *buffer2, COUNT_
     {
         CHAR ch1 = *buffer1;
         CHAR ch2 = *buffer2;
-        if ((ch1 == 0) || (ch2 == 0)) 
+        if ((ch1 == 0) || (ch2 == 0))
         {
             diff = ch1 - ch2;
-            if  (diff != 0 || stopOnNull) 
+            if  (diff != 0 || stopOnNull)
             {
                 break;
             }
             buffer1++;
             buffer2++;
         }
-        else if (CAN_SIMPLE_UPCASE_ANSI(ch1) && CAN_SIMPLE_UPCASE_ANSI(ch2)) 
+        else if (CAN_SIMPLE_UPCASE_ANSI(ch1) && CAN_SIMPLE_UPCASE_ANSI(ch2))
         {
             diff = ch1 - ch2;
-            if (diff != 0) 
+            if (diff != 0)
             {
                 diff = (SIMPLE_UPCASE_ANSI(ch1) - SIMPLE_UPCASE_ANSI(ch2));
                 if (diff != 0)
@@ -222,19 +222,19 @@ int SString::CaseCompareHelperA(const CHAR *buffer1, const CHAR *buffer2, COUNT_
             buffer1++;
             buffer2++;
         }
-        else 
+        else
         {
             int length = 1;
-            if (IsDBCSLeadByte(ch1) 
+            if (IsDBCSLeadByte(ch1)
                 && IsDBCSLeadByte(ch2)
-                && (!stopOnCount || ((buffer1 + 1) < buffer1End))) 
+                && (!stopOnCount || ((buffer1 + 1) < buffer1End)))
             {
                 length = 2;
             }
             int sortValue1 = GetCaseInsensitiveValueA(buffer1, length);
             int sortValue2 = GetCaseInsensitiveValueA(buffer2, length);
             diff = sortValue1 - sortValue2;
-            if (diff != 0) 
+            if (diff != 0)
             {
                 break;
             }
@@ -338,7 +338,7 @@ void SString::Set(const WCHAR *string, COUNT_T count)
 
 //-----------------------------------------------------------------------------
 // Set this string to a point to the first count characters of the given
-// preallocated unicode string (shallow copy). 
+// preallocated unicode string (shallow copy).
 //-----------------------------------------------------------------------------
 void SString::SetPreallocated(const WCHAR *string, COUNT_T count)
 {
@@ -727,7 +727,7 @@ void SString::ConvertASCIIToUnicode(SString &dest) const
     CONSISTENCY_CHECK(CheckPointer(GetRawASCII()));
     CONSISTENCY_CHECK(GetRawCount() > 0);
 
-    // If dest is the same as this, then we need to preserve on resize. 
+    // If dest is the same as this, then we need to preserve on resize.
     dest.Resize(GetRawCount(), REPRESENTATION_UNICODE,
                 this == &dest ? PRESERVE : DONT_PRESERVE);
 
@@ -1750,7 +1750,7 @@ BOOL SString::MatchCaseInsensitive(const CIterator &i, WCHAR c) const
 
 //-----------------------------------------------------------------------------
 // Convert string to unicode lowercase using the invariant culture
-// Note: Please don't use it in PATH as multiple character can map to the same 
+// Note: Please don't use it in PATH as multiple character can map to the same
 // lower case symbol
 //-----------------------------------------------------------------------------
 void SString::LowerCase()
@@ -1764,7 +1764,7 @@ void SString::LowerCase()
         SUPPORTS_DAC;
     }
     SS_CONTRACT_END;
-    
+
     ConvertToUnicode();
 
     for (WCHAR *pwch = GetRawUnicode(); pwch < GetRawUnicode() + GetRawCount(); ++pwch)
@@ -1776,7 +1776,7 @@ void SString::LowerCase()
 //-----------------------------------------------------------------------------
 // Convert null-terminated string to lowercase using the invariant culture
 //-----------------------------------------------------------------------------
-//static 
+//static
 void SString::LowerCase(__inout_z LPWSTR wszString)
 {
     SS_CONTRACT_VOID
@@ -1786,12 +1786,12 @@ void SString::LowerCase(__inout_z LPWSTR wszString)
         SUPPORTS_DAC;
     }
     SS_CONTRACT_END;
-    
+
     if (wszString == NULL)
     {
         return;
     }
-    
+
     for (WCHAR * pwch = wszString; *pwch != '\0'; ++pwch)
     {
         *pwch = (CAN_SIMPLE_DOWNCASE(*pwch) ? SIMPLE_DOWNCASE(*pwch) : MapChar(*pwch, LCMAP_LOWERCASE));
@@ -1800,7 +1800,7 @@ void SString::LowerCase(__inout_z LPWSTR wszString)
 
 //-----------------------------------------------------------------------------
 // Convert string to unicode uppercase using the invariant culture
-// Note: Please don't use it in PATH as multiple character can map to the same 
+// Note: Please don't use it in PATH as multiple character can map to the same
 // upper case symbol
 //-----------------------------------------------------------------------------
 void SString::UpperCase()
@@ -1815,7 +1815,7 @@ void SString::UpperCase()
         SUPPORTS_DAC;
     }
     SS_CONTRACT_END;
-    
+
     ConvertToUnicode();
 
     for (WCHAR *pwch = GetRawUnicode(); pwch < GetRawUnicode() + GetRawCount(); ++pwch)
@@ -1837,9 +1837,6 @@ const CHAR *SString::GetANSI(AbstractScratchBuffer &scratch) const
     }
     SS_CONTRACT_END;
 
-    if (this == NULL)
-        SS_RETURN NULL;
-
     if (IsRepresentation(REPRESENTATION_ANSI))
         SS_RETURN GetRawANSI();
 
@@ -1860,9 +1857,6 @@ const UTF8 *SString::GetUTF8(AbstractScratchBuffer &scratch) const
     }
     CONTRACT_END;
 
-    if (this == NULL)
-        RETURN NULL;
-
     if (IsRepresentation(REPRESENTATION_UTF8))
         RETURN GetRawUTF8();
 
@@ -1879,9 +1873,6 @@ const UTF8 *SString::GetUTF8(AbstractScratchBuffer &scratch, COUNT_T *pcbUtf8) c
         GC_NOTRIGGER;
     }
     CONTRACT_END;
-
-    if (this == NULL)
-        RETURN NULL;
 
     if (IsRepresentation(REPRESENTATION_UTF8))
     {
@@ -1906,9 +1897,6 @@ const UTF8 *SString::GetUTF8NoConvert() const
         GC_NOTRIGGER;
     }
     CONTRACT_END;
-
-    if (this == NULL)
-        RETURN NULL;
 
     if (IsRepresentation(REPRESENTATION_UTF8))
         RETURN GetRawUTF8();
@@ -2031,7 +2019,7 @@ void SString::VPrintf(const CHAR *format, va_list args)
 
         if (result >=0)
         {
-            // Succeeded in writing. Now resize - 
+            // Succeeded in writing. Now resize -
             Resize(result, REPRESENTATION_ANSI, PRESERVE);
             SString sss(Ansi, format);
             INDEBUG(CheckForFormatStringGlobalizationIssues(sss, *this));
@@ -2107,7 +2095,7 @@ void SString::PPrintf(const WCHAR *format, ...)
     va_list argItr;
     va_start(argItr, format);
     PVPrintf(format, argItr);
-    va_end(argItr);    
+    va_end(argItr);
 
     RETURN;
 }

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -114,7 +114,7 @@ int                 BaseDomain::m_iNumberOfProcessors = 0;
 // System Domain Statics
 GlobalStringLiteralMap* SystemDomain::m_pGlobalStringLiteralMap = NULL;
 
-DECLSPEC_ALIGN(16) 
+DECLSPEC_ALIGN(16)
 static BYTE         g_pSystemDomainMemory[sizeof(SystemDomain)];
 
 CrstStatic          SystemDomain::m_SystemDomainCrst;
@@ -255,7 +255,7 @@ OBJECTREF *LargeHeapHandleBucket::TryAllocateEmbeddedFreeHandle()
 }
 
 
-// Maximum bucket size will be 64K on 32-bit and 128K on 64-bit. 
+// Maximum bucket size will be 64K on 32-bit and 128K on 64-bit.
 // We subtract out a small amount to leave room for the object
 // header and length of the array.
 
@@ -738,7 +738,7 @@ void BaseDomain::Init()
 #ifdef FEATURE_COMINTEROP
     // Allocate the managed standard interfaces information.
     m_pMngStdInterfacesInfo = new MngStdInterfacesInfo();
-    
+
     {
         CLRPrivBinderWinRT::NamespaceResolutionKind fNamespaceResolutionKind = CLRPrivBinderWinRT::NamespaceResolutionKind_WindowsAPI;
         if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_DesignerNamespaceResolutionEnabled) != FALSE)
@@ -829,7 +829,7 @@ void AppDomain::ShutdownFreeLoaderAllocators()
     CONTRACTL_END;
 
     CrstHolder ch(GetLoaderAllocatorReferencesLock());
-    
+
     // Shutdown the LoaderAllocators associated with collectible assemblies
     while (m_pDelayedLoaderAllocatorUnloadList != NULL)
     {
@@ -851,9 +851,9 @@ void AppDomain::ShutdownFreeLoaderAllocators()
 } // AppDomain::ShutdownFreeLoaderAllocators
 
 //---------------------------------------------------------------------------------------
-// 
+//
 // Register the loader allocator for deletion in code:AppDomain::ShutdownFreeLoaderAllocators.
-// 
+//
 void AppDomain::RegisterLoaderAllocatorForDeletion(LoaderAllocator * pLoaderAllocator)
 {
     CONTRACTL
@@ -864,9 +864,9 @@ void AppDomain::RegisterLoaderAllocatorForDeletion(LoaderAllocator * pLoaderAllo
         CAN_TAKE_LOCK;
     }
     CONTRACTL_END;
-    
+
     CrstHolder ch(GetLoaderAllocatorReferencesLock());
-    
+
     pLoaderAllocator->m_pLoaderAllocatorDestroyNext = m_pDelayedLoaderAllocatorUnloadList;
     m_pDelayedLoaderAllocatorUnloadList = pLoaderAllocator;
 }
@@ -1244,9 +1244,9 @@ void AppDomain::CacheWinRTTypeByGuid(TypeHandle typeHandle)
 #endif // DACCESS_COMPILE
 
 void AppDomain::GetCachedWinRTTypes(
-                        SArray<PTR_MethodTable> * pTypes, 
-                        SArray<GUID> * pGuids, 
-                        UINT minEpoch, 
+                        SArray<PTR_MethodTable> * pTypes,
+                        SArray<GUID> * pGuids,
+                        UINT minEpoch,
                         UINT * pCurEpoch)
 {
     CONTRACTL
@@ -1260,19 +1260,19 @@ void AppDomain::GetCachedWinRTTypes(
 
     LockHolder lh(this);
 
-    for (auto it = m_pNameToTypeMap->Begin(), end = m_pNameToTypeMap->End(); 
-            it != end; 
+    for (auto it = m_pNameToTypeMap->Begin(), end = m_pNameToTypeMap->End();
+            it != end;
             ++it)
     {
         NameToTypeMapEntry entry = (NameToTypeMapEntry)(*it);
         TypeHandle th = entry.m_typeHandle;
-        if (th.AsMethodTable() != NULL && 
+        if (th.AsMethodTable() != NULL &&
             entry.m_key.m_wzName[0] == W('{') &&
             entry.m_nEpoch >= minEpoch)
         {
             _ASSERTE(!th.IsTypeDesc());
             PTR_MethodTable pMT = th.AsMethodTable();
-            // we're parsing the GUID value from the cache, because projected types do not cache the 
+            // we're parsing the GUID value from the cache, because projected types do not cache the
             // COM GUID in their GetGuid() but rather the legacy GUID
             GUID iid;
             if (LPWSTRToGuid(&iid, entry.m_key.m_wzName, 38) && iid != GUID_NULL)
@@ -1369,7 +1369,7 @@ void AppDomain::CacheWinRTFactoryObject(MethodTable *pClassMT, OBJECTREF *refFac
         e.m_ohFactoryObject = ohNewHandle;
 
         m_pWinRTFactoryCache->Add(e);
-     
+
         // suppress release of the CtxEntry and handle after we successfully inserted the new entry
         pNewCtxEntry.SuppressRelease();
         ohNewHandle.SuppressRelease();
@@ -1404,7 +1404,7 @@ OBJECTREF AppDomain::LookupWinRTFactoryObject(MethodTable *pClassMT, LPVOID lpCt
 
     if (m_pWinRTFactoryCache == nullptr)
         return NULL;
-            
+
     //
     // Retrieve cached factory
     //
@@ -1413,17 +1413,17 @@ OBJECTREF AppDomain::LookupWinRTFactoryObject(MethodTable *pClassMT, LPVOID lpCt
     const WinRTFactoryCacheEntry *pEntry = m_pWinRTFactoryCache->LookupPtr(pClassMT);
     if (pEntry == NULL)
         return NULL;
-    
+
     //
-    // Ignore factories from a different context, unless lpCtxCookie == NULL, 
+    // Ignore factories from a different context, unless lpCtxCookie == NULL,
     // which means the factory is free-threaded
     // Note that we cannot touch the RCW to retrieve cookie at this point
     // because the RCW might belong to a STA thread and that STA thread might die
-    // and take the RCW with it. Therefore we have to save cookie in this cache    
+    // and take the RCW with it. Therefore we have to save cookie in this cache
     //
     if (pEntry->m_pCtxEntry == NULL || pEntry->m_pCtxEntry->GetCtxCookie() == lpCtxCookie)
         return ObjectFromHandle(pEntry->m_ohFactoryObject);
-    
+
     return NULL;
 }
 
@@ -2102,7 +2102,7 @@ void SystemDomain::LoadBaseSystemClasses()
 #ifdef FEATURE_COMINTEROP
     g_pBaseCOMObject = MscorlibBinder::GetClass(CLASS__COM_OBJECT);
     g_pBaseRuntimeClass = MscorlibBinder::GetClass(CLASS__RUNTIME_CLASS);
-    
+
     MscorlibBinder::GetClass(CLASS__IDICTIONARYGENERIC);
     MscorlibBinder::GetClass(CLASS__IREADONLYDICTIONARYGENERIC);
     MscorlibBinder::GetClass(CLASS__ATTRIBUTE);
@@ -2122,7 +2122,7 @@ void SystemDomain::LoadBaseSystemClasses()
     g_pICastableInterface = MscorlibBinder::GetClass(CLASS__ICASTABLE);
 #endif // FEATURE_ICASTABLE
 
-    // Make sure that FCall mapping for Monitor.Enter is initialized. We need it in case Monitor.Enter is used only as JIT helper. 
+    // Make sure that FCall mapping for Monitor.Enter is initialized. We need it in case Monitor.Enter is used only as JIT helper.
     // For more details, see comment in code:JITutil_MonEnterWorker around "__me = GetEEFuncEntryPointMacro(JIT_MonEnter)".
     ECall::GetFCallImpl(MscorlibBinder::GetMethod(METHOD__MONITOR__ENTER));
 
@@ -2559,10 +2559,10 @@ StackWalkAction SystemDomain::CallersMethodCallbackWithStackMark(CrawlFrame* pCf
     // If remoting is not available, we only set the caller if the crawlframe is from the same domain.
     // Why? Because if the callerdomain is different from current domain,
     // there have to be interop/native frames in between.
-    // For example, in the CORECLR, if we find the caller to be in a different domain, then the 
+    // For example, in the CORECLR, if we find the caller to be in a different domain, then the
     // call into reflection is due to an unmanaged call into mscorlib. For that
     // case, the caller really is an INTEROP method.
-    // In general, if the caller is INTEROP, we set the caller/callerdomain to be NULL 
+    // In general, if the caller is INTEROP, we set the caller/callerdomain to be NULL
     // (To be precise: they are already NULL and we don't change them).
     if (pCf->GetAppDomain() == GetAppDomain())
     // We must either be looking for the caller, or the caller's caller when
@@ -2690,7 +2690,7 @@ BOOL SystemDomain::RemoveDomain(AppDomain* pDomain)
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pDomain));
-        PRECONDITION(!pDomain->IsDefaultDomain());    
+        PRECONDITION(!pDomain->IsDefaultDomain());
     }
     CONTRACTL_END;
 
@@ -2883,7 +2883,7 @@ AppDomain::~AppDomain()
         m_pWinRTFactoryCache = nullptr;
     }
 #endif //FEATURE_COMINTEROP
-    
+
 #endif // CROSSGEN_COMPILE
 }
 
@@ -2907,17 +2907,17 @@ void AppDomain::Init()
     //  - To prevent deadlock with GC thread, we cannot trigger GC while holding the lock
     //  - To prevent deadlock with profiler thread, we cannot allow thread suspension
     m_crstHostAssemblyMap.Init(
-        CrstHostAssemblyMap, 
-        (CrstFlags)(CRST_GC_NOTRIGGER_WHEN_TAKEN 
-                    | CRST_DEBUGGER_THREAD 
+        CrstHostAssemblyMap,
+        (CrstFlags)(CRST_GC_NOTRIGGER_WHEN_TAKEN
+                    | CRST_DEBUGGER_THREAD
                     INDEBUG(| CRST_DEBUG_ONLY_CHECK_FORBID_SUSPEND_THREAD)));
     m_crstHostAssemblyMapAdd.Init(CrstHostAssemblyMapAdd);
 
 #ifndef CROSSGEN_COMPILE
     //Allocate the threadpool entry before the appdomain id list. Otherwise,
-    //the thread pool list will be out of sync if insertion of id in 
-    //the appdomain fails. 
-    m_tpIndex = PerAppDomainTPCountList::AddNewTPIndex();    
+    //the thread pool list will be out of sync if insertion of id in
+    //the appdomain fails.
+    m_tpIndex = PerAppDomainTPCountList::AddNewTPIndex();
 #endif // CROSSGEN_COMPILE
 
     BaseDomain::Init();
@@ -3115,10 +3115,10 @@ void AppDomain::AddAssembly(DomainAssembly * assem)
         INJECT_FAULT(COMPlusThrowOM(););
     }
     CONTRACTL_END;
-    
+
     {
         CrstHolder ch(GetAssemblyListLock());
-    
+
         // Attempt to find empty space in assemblies list
         DWORD asmCount = m_Assemblies.GetCount_Unlocked();
         for (DWORD i = 0; i < asmCount; ++i)
@@ -3143,7 +3143,7 @@ void AppDomain::RemoveAssembly(DomainAssembly * pAsm)
         GC_NOTRIGGER;
     }
     CONTRACTL_END;
-    
+
     CrstHolder ch(GetAssemblyListLock());
     DWORD asmCount = m_Assemblies.GetCount_Unlocked();
     for (DWORD i = 0; i < asmCount; ++i)
@@ -3154,7 +3154,7 @@ void AppDomain::RemoveAssembly(DomainAssembly * pAsm)
             return;
         }
     }
-    
+
     _ASSERTE(!"Unreachable");
 }
 
@@ -3326,7 +3326,7 @@ static const char *fileLoadLevelName[] =
     "ADD_DEPENDENCIES",                   // FILE_LOAD_ADD_DEPENDENCIES
     "PRE_LOADLIBRARY",                    // FILE_LOAD_PRE_LOADLIBRARY
     "LOADLIBRARY",                        // FILE_LOAD_LOADLIBRARY
-    "POST_LOADLIBRARY",                   // FILE_LOAD_POST_LOADLIBRARY                
+    "POST_LOADLIBRARY",                   // FILE_LOAD_POST_LOADLIBRARY
     "EAGER_FIXUPS",                       // FILE_LOAD_EAGER_FIXUPS
     "DELIVER_EVENTS",                     // FILE_LOAD_DELIVER_EVENTS
     "VTABLE FIXUPS",                      // FILE_LOAD_VTABLE_FIXUPS
@@ -3360,7 +3360,7 @@ BOOL FileLoadLock::CompleteLoadLevel(FileLoadLevel level, BOOL success)
 
 #if _DEBUG
                 BOOL fDbgOnly_SuccessfulUnlink =
-#endif                
+#endif
                     m_pList->Unlink(this);
                 _ASSERTE(fDbgOnly_SuccessfulUnlink);
 
@@ -3757,7 +3757,7 @@ public:
 extern BOOL AreSameBinderInstance(ICLRPrivBinder *pBinderA, ICLRPrivBinder *pBinderB);
 
 DomainAssembly* AppDomain::LoadDomainAssembly(AssemblySpec* pSpec,
-                                              PEAssembly *pFile, 
+                                              PEAssembly *pFile,
                                               FileLoadLevel targetLevel)
 {
     STATIC_CONTRACT_THROWS;
@@ -3781,7 +3781,7 @@ DomainAssembly* AppDomain::LoadDomainAssembly(AssemblySpec* pSpec,
             // Setup the binder reference in AssemblySpec from the PEAssembly if one is not already set.
             ICLRPrivBinder* pCurrentBindingContext = pSpec->GetBindingContext();
             ICLRPrivBinder* pBindingContextFromPEAssembly = pFile->GetBindingContext();
-            
+
             if (pCurrentBindingContext == NULL)
             {
                 // Set the binding context we got from the PEAssembly if AssemblySpec does not
@@ -3789,13 +3789,13 @@ DomainAssembly* AppDomain::LoadDomainAssembly(AssemblySpec* pSpec,
                 _ASSERTE(pBindingContextFromPEAssembly != NULL);
                 pSpec->SetBindingContext(pBindingContextFromPEAssembly);
             }
-#if defined(_DEBUG)            
+#if defined(_DEBUG)
             else
             {
                 // Binding context in the spec should be the same as the binding context in the PEAssembly
                 _ASSERTE(AreSameBinderInstance(pCurrentBindingContext, pBindingContextFromPEAssembly));
             }
-#endif // _DEBUG            
+#endif // _DEBUG
 
             if (!EEFileLoadException::CheckType(pEx))
             {
@@ -3846,7 +3846,7 @@ DomainAssembly *AppDomain::LoadDomainAssemblyInternal(AssemblySpec* pIdentity,
 
     // Check for existing fully loaded assembly, or for an assembly which has failed during the loading process.
     result = FindAssembly(pFile, FindAssemblyOptions_IncludeFailedToLoad);
-    
+
     if (result == NULL)
     {
         LoaderAllocator *pLoaderAllocator = NULL;
@@ -3938,7 +3938,7 @@ DomainAssembly *AppDomain::LoadDomainAssemblyInternal(AssemblySpec* pIdentity,
     {
         GetAppDomain()->AddAssemblyToCache(pIdentity, result);
     }
-    
+
     RETURN result;
 } // AppDomain::LoadDomainAssembly
 
@@ -4212,7 +4212,7 @@ static void NormalizeAssemblySpecForNativeDependencies(AssemblySpec * pSpec)
     }
 
     //
-    // CoreCLR binder unifies assembly versions. Ignore assembly version here to 
+    // CoreCLR binder unifies assembly versions. Ignore assembly version here to
     // detect more types of potential mismatches.
     //
     AssemblyMetaDataInternal * pContext = pSpec->GetContext();
@@ -4222,7 +4222,7 @@ static void NormalizeAssemblySpecForNativeDependencies(AssemblySpec * pSpec)
     pContext->usRevisionNumber = (USHORT)-1;
 
     // Ignore the WinRT type while considering if two assemblies have the same identity.
-    pSpec->SetWindowsRuntimeType(NULL, NULL);    
+    pSpec->SetWindowsRuntimeType(NULL, NULL);
 }
 
 void AppDomain::CheckForMismatchedNativeImages(AssemblySpec * pSpec, const GUID * pGuid)
@@ -4232,8 +4232,8 @@ void AppDomain::CheckForMismatchedNativeImages(AssemblySpec * pSpec, const GUID 
     //
     // The native images are ever used only for trusted images in CoreCLR.
     // We don't wish to open the IL file at runtime so we just forgo any
-    // eager consistency checking. But we still want to prevent mistmatched 
-    // NGen images from being used. We record all mappings between assembly 
+    // eager consistency checking. But we still want to prevent mistmatched
+    // NGen images from being used. We record all mappings between assembly
     // names and MVID, and fail once we detect mismatch.
     //
     NormalizeAssemblySpecForNativeDependencies(pSpec);
@@ -4354,7 +4354,7 @@ DomainAssembly * AppDomain::FindAssembly(PEAssembly * pFile, FindAssemblyOptions
     }
 
     AssemblyIterator i = IterateAssembliesEx((AssemblyIterationFlags)(
-        kIncludeLoaded | 
+        kIncludeLoaded |
         (includeFailedToLoad ? kIncludeFailedToLoad : 0) |
         kIncludeExecution));
     CollectibleAssemblyHolder<DomainAssembly *> pDomainAssembly;
@@ -4362,8 +4362,8 @@ DomainAssembly * AppDomain::FindAssembly(PEAssembly * pFile, FindAssemblyOptions
     while (i.Next(pDomainAssembly.This()))
     {
         PEFile * pManifestFile = pDomainAssembly->GetFile();
-        if (pManifestFile && 
-            !pManifestFile->IsResource() && 
+        if (pManifestFile &&
+            !pManifestFile->IsResource() &&
             pManifestFile->Equals(pFile))
         {
             // Caller already has PEAssembly, so we can give DomainAssembly away freely without AddRef
@@ -4373,7 +4373,7 @@ DomainAssembly * AppDomain::FindAssembly(PEAssembly * pFile, FindAssemblyOptions
     return NULL;
 }
 
-static const AssemblyIterationFlags STANDARD_IJW_ITERATOR_FLAGS = 
+static const AssemblyIterationFlags STANDARD_IJW_ITERATOR_FLAGS =
     (AssemblyIterationFlags)(kIncludeLoaded | kIncludeLoading | kIncludeExecution | kExcludeCollectible);
 
 
@@ -4419,7 +4419,7 @@ void AppDomain::SetFriendlyName(LPCWSTR pwzFriendlyName, BOOL fDebuggerCares/*=T
     m_friendlyName = tmpFriendlyName;
     m_friendlyName.Normalize();
 
-    if(g_pDebugInterface) 
+    if(g_pDebugInterface)
     {
         // update the name in the IPC publishing block
         if (SUCCEEDED(g_pDebugInterface->UpdateAppDomainEntryInIPC(this)))
@@ -4443,13 +4443,6 @@ LPCWSTR AppDomain::GetFriendlyName(BOOL fDebuggerCares/*=TRUE*/)
     }
     CONTRACT_END;
 
-#if _DEBUG
-    // Handle NULL this pointer - this happens sometimes when printing log messages
-    // but in general shouldn't occur in real code
-    if (this == NULL)
-        RETURN NULL;
-#endif // _DEBUG
-
     if (m_friendlyName.IsEmpty())
         SetFriendlyName(NULL, fDebuggerCares);
 
@@ -4466,12 +4459,6 @@ LPCWSTR AppDomain::GetFriendlyNameForLogging()
         POSTCONDITION(CheckPointer(RETVAL,NULL_OK));
     }
     CONTRACT_END;
-#if _DEBUG
-    // Handle NULL this pointer - this happens sometimes when printing log messages
-    // but in general shouldn't occur in real code
-    if (this == NULL)
-        RETURN NULL;
-#endif // _DEBUG
     RETURN (m_friendlyName.IsEmpty() ?W(""):(LPCWSTR)m_friendlyName);
 }
 
@@ -4569,7 +4556,7 @@ BOOL AppDomain::AddFileToCache(AssemblySpec* pSpec, PEAssembly *pFile, BOOL fAll
         // TODO: Disabling the below assertion as currently we experience
         // inconsistency on resolving the Microsoft.Office.Interop.MSProject.dll
         // This causes below assertion to fire and crashes the VS. This issue
-        // is being tracked with Dev10 Bug 658555. Brought back it when this bug 
+        // is being tracked with Dev10 Bug 658555. Brought back it when this bug
         // is fixed.
         // _ASSERTE(FALSE);
 
@@ -4593,7 +4580,7 @@ BOOL AppDomain::AddAssemblyToCache(AssemblySpec* pSpec, DomainAssembly *pAssembl
         INJECT_FAULT(COMPlusThrowOM(););
     }
     CONTRACTL_END;
-    
+
     CrstHolder holder(&m_DomainCacheCrst);
     // !!! suppress exceptions
     BOOL bRetVal = m_AssemblyCache.StoreAssembly(pSpec, pAssembly);
@@ -4612,7 +4599,7 @@ BOOL AppDomain::AddExceptionToCache(AssemblySpec* pSpec, Exception *ex)
         INJECT_FAULT(COMPlusThrowOM(););
     }
     CONTRACTL_END;
-    
+
     if (ex->IsTransient())
         return TRUE;
 
@@ -4694,7 +4681,7 @@ BOOL AppDomain::RemoveAssemblyFromCache(DomainAssembly* pAssembly)
         INJECT_FAULT(COMPlusThrowOM(););
     }
     CONTRACTL_END;
-    
+
     CrstHolder holder(&m_DomainCacheCrst);
 
     return m_AssemblyCache.RemoveAssembly(pAssembly);
@@ -4795,13 +4782,13 @@ BOOL AppDomain::PostBindResolveAssembly(AssemblySpec  *pPrePolicySpec,
 
 //-----------------------------------------------------------------------------------------------------------------
 HRESULT AppDomain::BindAssemblySpecForHostedBinder(
-    AssemblySpec *   pSpec, 
-    IAssemblyName *  pAssemblyName, 
-    ICLRPrivBinder * pBinder, 
+    AssemblySpec *   pSpec,
+    IAssemblyName *  pAssemblyName,
+    ICLRPrivBinder * pBinder,
     PEAssembly **    ppAssembly)
 {
     STANDARD_VM_CONTRACT;
-    
+
     PRECONDITION(CheckPointer(pSpec));
     PRECONDITION(pSpec->GetAppDomain() == this);
     PRECONDITION(CheckPointer(ppAssembly));
@@ -4827,22 +4814,22 @@ HRESULT AppDomain::BindAssemblySpecForHostedBinder(
 }
 
 //-----------------------------------------------------------------------------------------------------------------
-HRESULT 
+HRESULT
 AppDomain::BindHostedPrivAssembly(
     PEAssembly *       pParentAssembly,
-    ICLRPrivAssembly * pPrivAssembly, 
-    IAssemblyName *    pAssemblyName, 
+    ICLRPrivAssembly * pPrivAssembly,
+    IAssemblyName *    pAssemblyName,
     PEAssembly **      ppAssembly)
 {
     STANDARD_VM_CONTRACT;
 
     PRECONDITION(CheckPointer(pPrivAssembly));
     PRECONDITION(CheckPointer(ppAssembly));
-    
+
     HRESULT hr = S_OK;
-    
+
     *ppAssembly = nullptr;
-    
+
     // See if result has been previously loaded.
     {
         DomainAssembly* pDomainAssembly = FindAssembly(pPrivAssembly);
@@ -4890,11 +4877,11 @@ AppDomain::BindHostedPrivAssembly(
     }
 #endif // FEATURE_PREJIT
     _ASSERTE(pPEImageIL != nullptr);
-    
+
     // Create a PEAssembly using the IL and NI images.
     PEAssemblyHolder pPEAssembly = PEAssembly::Open(pParentAssembly, pPEImageIL, pPEImageNI, pPrivAssembly);
 
-    // The result.    
+    // The result.
     *ppAssembly = pPEAssembly.Extract();
 
     return S_OK;
@@ -4902,7 +4889,7 @@ AppDomain::BindHostedPrivAssembly(
 
 //---------------------------------------------------------------------------------------------------------------------
 PEAssembly * AppDomain::BindAssemblySpec(
-    AssemblySpec *         pSpec, 
+    AssemblySpec *         pSpec,
     BOOL                   fThrowOnFileNotFound)
 {
     STATIC_CONTRACT_THROWS;
@@ -4943,7 +4930,7 @@ PEAssembly * AppDomain::BindAssemblySpec(
             assem->SetFallbackBinder(pSpec->GetFallbackLoadContextBinderForRequestingAssembly());
 EndTry2:;
         }
-        // The combination of this conditional catch/ the following if statement which will throw reduces the count of exceptions 
+        // The combination of this conditional catch/ the following if statement which will throw reduces the count of exceptions
         // thrown in scenarios where the exception does not escape the method. We cannot get rid of the try/catch block, as
         // there are cases within some of the clrpriv binder's which throw.
         // Note: In theory, FileNotFound should always come here as HRESULT, never as exception.
@@ -4996,7 +4983,7 @@ EndTry2:;
     {
         HRESULT hrBindResult = S_OK;
         PEAssemblyHolder result;
-        
+
         EX_TRY
         {
             if (!IsCached(pSpec))
@@ -5009,7 +4996,7 @@ EndTry2:;
                     pSpec->Bind(this, FALSE /* fThrowOnFileNotFound */, &bindResult, FALSE /* fNgenExplicitBind */, FALSE /* fExplicitBindToNativeImage */);
                     hrBindResult = bindResult.GetHRBindResult();
 
-                    if (bindResult.Found()) 
+                    if (bindResult.Found())
                     {
                         if (SystemDomain::SystemFile() && bindResult.IsMscorlib())
                         {
@@ -5023,7 +5010,7 @@ EndTry2:;
                             result = PEAssembly::Open(&bindResult,
                                                       FALSE);
                         }
-                        
+
                         // Setup the reference to the binder, which performed the bind, into the AssemblySpec
                         ICLRPrivBinder* pBinder = result->GetBindingContext();
                         _ASSERTE(pBinder != NULL);
@@ -5081,7 +5068,7 @@ EndTry2:;
                 {
                     BOOL bFileNotFoundException =
                         (EEFileLoadException::GetFileLoadKind(ex->GetHR()) == kFileNotFoundException);
-                
+
                     if (!bFileNotFoundException)
                     {
                         fFailure = AddExceptionToCache(pFailedSpec, ex);
@@ -5108,12 +5095,12 @@ EndTry2:;
                             //
                             // In Whidbey, we now set the more appropriate INET_E_RESOURCE_NOT_FOUND hr. But
                             // the online/offline switch code in VSTO for Everett hardcoded a check for
-                            // COR_E_FILENOTFOUND. 
+                            // COR_E_FILENOTFOUND.
                             //
                             // So now, to keep that code from breaking, we have to remap INET_E_RESOURCE_NOT_FOUND
                             // back to COR_E_FILENOTFOUND. We're doing it here rather down in Fusion so as to affect
                             // the least number of callers.
-                            
+
                             if (ex->GetHR() == INET_E_RESOURCE_NOT_FOUND)
                             {
                                 EEFileLoadException::Throw(pFailedSpec, COR_E_FILENOTFOUND, ex);
@@ -5138,7 +5125,7 @@ EndTry2:;
                                     }
                                 }
                             }
-                            
+
                             EEFileLoadException::Throw(pFailedSpec, ex->GetHR(), ex);
                         }
 
@@ -5284,7 +5271,7 @@ void AppDomain::RaiseLoadingAssemblyEvent(DomainAssembly *pAssembly)
     EX_END_CATCH(SwallowAllExceptions);
 }
 
-BOOL AppDomain::OnUnhandledException(OBJECTREF *pThrowable, BOOL isTerminating/*=TRUE*/) 
+BOOL AppDomain::OnUnhandledException(OBJECTREF *pThrowable, BOOL isTerminating/*=TRUE*/)
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_TRIGGERS;
@@ -5384,7 +5371,7 @@ IUnknown *AppDomain::CreateFusionContext()
         // Initialize the assembly binder for the default context loads for CoreCLR.
         IfFailThrow(CCoreCLRBinderHelper::DefaultBinderSetupContext(DefaultADID, &pTPABinder));
         m_pFusionContext = reinterpret_cast<IUnknown *>(pTPABinder);
-        
+
         // By default, initial binding context setup for CoreCLR is also the TPABinding context
         (m_pTPABinderContext = pTPABinder)->AddRef();
 
@@ -5444,7 +5431,7 @@ BOOL AppDomain::NotifyDebuggerLoad(int flags, BOOL attaching)
     CollectibleAssemblyHolder<DomainAssembly *> pDomainAssembly;
     while (i.Next(pDomainAssembly.This()))
     {
-        result = (pDomainAssembly->NotifyDebuggerLoad(flags, attaching) || 
+        result = (pDomainAssembly->NotifyDebuggerLoad(flags, attaching) ||
                   result);
     }
 
@@ -5453,7 +5440,7 @@ BOOL AppDomain::NotifyDebuggerLoad(int flags, BOOL attaching)
 
 void AppDomain::NotifyDebuggerUnload()
 {
-    WRAPPER_NO_CONTRACT;    
+    WRAPPER_NO_CONTRACT;
     if (!IsDebuggerAttached())
         return;
 
@@ -5507,8 +5494,8 @@ RCWRefCache *AppDomain::GetRCWRefCache()
         NewHolder<RCWRefCache> pRCWRefCache = new RCWRefCache(this);
         if (FastInterlockCompareExchangePointer(&m_pRCWRefCache, (RCWRefCache *)pRCWRefCache, NULL) == NULL)
         {
-            pRCWRefCache.SuppressRelease();    
-        }        
+            pRCWRefCache.SuppressRelease();
+        }
     }
     RETURN m_pRCWRefCache;
 }
@@ -5970,7 +5957,7 @@ Assembly* AppDomain::RaiseResourceResolveEvent(DomainAssembly* pAssembly, LPCSTR
 }
 
 
-Assembly * 
+Assembly *
 AppDomain::RaiseAssemblyResolveEvent(
     AssemblySpec * pSpec)
 {
@@ -6018,9 +6005,9 @@ AppDomain::RaiseAssemblyResolveEvent(
             ObjToArgSlot(gc.AssemblyRef),
             ObjToArgSlot(gc.str)
         };
-            
+
         ASSEMBLYREF ResultingAssemblyRef = (ASSEMBLYREF) onAssemblyResolve.Call_RetOBJECTREF(args);
-            
+
         if (ResultingAssemblyRef != NULL)
         {
             pAssembly = ResultingAssemblyRef->GetAssembly();
@@ -6059,7 +6046,7 @@ void SystemDomain::ProcessDelayedUnloadLoaderAllocators()
         GC_TRIGGERS;
         MODE_COOPERATIVE;
     }
-    CONTRACTL_END;    
+    CONTRACTL_END;
 
     int iGCRefPoint=GCHeapUtilities::GetGCHeap()->CollectionCount(GCHeapUtilities::GetGCHeap()->GetMaxGeneration());
     if (GCHeapUtilities::GetGCHeap()->IsConcurrentGCInProgress())
@@ -6068,7 +6055,7 @@ void SystemDomain::ProcessDelayedUnloadLoaderAllocators()
     LoaderAllocator * pAllocatorsToDelete = NULL;
 
     {
-        CrstHolder lh(&m_DelayedUnloadCrst); 
+        CrstHolder lh(&m_DelayedUnloadCrst);
 
         LoaderAllocator ** ppAllocator=&m_pDelayedUnloadListOfLoaderAllocators;
         while (*ppAllocator!= NULL)
@@ -6088,7 +6075,7 @@ void SystemDomain::ProcessDelayedUnloadLoaderAllocators()
         }
     }
 
-    // Delete collected loader allocators on the finalizer thread. We cannot offload it to appdomain unload thread because of 
+    // Delete collected loader allocators on the finalizer thread. We cannot offload it to appdomain unload thread because of
     // there is not guaranteed to be one, and it is not that expensive operation anyway.
     while (pAllocatorsToDelete != NULL)
     {
@@ -6187,8 +6174,8 @@ void BaseDomain::RemoveTypesFromTypeIDMap(LoaderAllocator* pLoaderAllocator)
 #endif // DACCESS_COMPILE
 
 //---------------------------------------------------------------------------------------
-// 
-BOOL 
+//
+BOOL
 AppDomain::AssemblyIterator::Next(
     CollectibleAssemblyHolder<DomainAssembly *> * pDomainAssemblyHolder)
 {
@@ -6197,16 +6184,16 @@ AppDomain::AssemblyIterator::Next(
         WRAPPER(GC_TRIGGERS); // Triggers only in MODE_COOPERATIVE (by taking the lock)
         MODE_ANY;
     } CONTRACTL_END;
-    
+
     CrstHolder ch(m_pAppDomain->GetAssemblyListLock());
     return Next_Unlocked(pDomainAssemblyHolder);
 }
 
 //---------------------------------------------------------------------------------------
-// 
+//
 // Note: Does not lock the assembly list, but locks collectible assemblies for adding references.
-// 
-BOOL 
+//
+BOOL
 AppDomain::AssemblyIterator::Next_Unlocked(
     CollectibleAssemblyHolder<DomainAssembly *> * pDomainAssemblyHolder)
 {
@@ -6215,11 +6202,11 @@ AppDomain::AssemblyIterator::Next_Unlocked(
         GC_NOTRIGGER;
         MODE_ANY;
     } CONTRACTL_END;
-    
+
 #ifndef DACCESS_COMPILE
     _ASSERTE(m_pAppDomain->GetAssemblyListLock()->OwnedByCurrentThread());
 #endif
-    
+
     while (m_Iterator.Next())
     {
         // Get element from the list/iterator (without adding reference to the assembly)
@@ -6241,8 +6228,8 @@ AppDomain::AssemblyIterator::Next_Unlocked(
 
         // First, reject DomainAssemblies whose load status is not to be included in
         // the enumeration
-        
-        if (pDomainAssembly->IsAvailableToProfilers() && 
+
+        if (pDomainAssembly->IsAvailableToProfilers() &&
             (m_assemblyIterationFlags & kIncludeAvailableToProfilers))
         {
             // The assembly has reached the state at which we would notify profilers,
@@ -6271,7 +6258,7 @@ AppDomain::AssemblyIterator::Next_Unlocked(
 
         // Next, reject DomainAssemblies whose execution status is
         // not to be included in the enumeration
-        
+
         // execution assembly
         if (!(m_assemblyIterationFlags & kIncludeExecution))
         {
@@ -6286,7 +6273,7 @@ AppDomain::AssemblyIterator::Next_Unlocked(
                 _ASSERTE(!(m_assemblyIterationFlags & kIncludeCollected));
                 continue; // reject
             }
-            
+
             // Un-tenured collectible assemblies should not be returned. (This can only happen in a brief
             // window during collectible assembly creation. No thread should need to have a pointer
             // to the just allocated DomainAssembly at this stage.)
@@ -6297,22 +6284,22 @@ AppDomain::AssemblyIterator::Next_Unlocked(
 
             if (pDomainAssembly->GetLoaderAllocator()->AddReferenceIfAlive())
             {   // The assembly is alive
-                
+
                 // Set the holder value (incl. increasing ref-count)
                 *pDomainAssemblyHolder = pDomainAssembly;
-                
+
                 // Now release the reference we took in the if-condition
                 pDomainAssembly->GetLoaderAllocator()->Release();
                 return TRUE;
             }
-            // The assembly is not alive anymore (and we didn't increase its ref-count in the 
+            // The assembly is not alive anymore (and we didn't increase its ref-count in the
             // if-condition)
-            
+
             if (!(m_assemblyIterationFlags & kIncludeCollected))
             {
                 continue; // reject
             }
-            // Set the holder value to assembly with 0 ref-count without increasing the ref-count (won't 
+            // Set the holder value to assembly with 0 ref-count without increasing the ref-count (won't
             // call Release either)
             pDomainAssemblyHolder->Assign(pDomainAssembly, FALSE);
             return TRUE;
@@ -6339,24 +6326,24 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
         PRECONDITION(ppLoadedAssembly != NULL);
     }
     CONTRACTL_END;
-    
+
     HRESULT hr = E_FAIL;
 
     // Switch to COOP mode since we are going to work with managed references
     GCX_COOP();
-        
-    struct 
+
+    struct
     {
         ASSEMBLYNAMEREF oRefAssemblyName;
         ASSEMBLYREF oRefLoadedAssembly;
     } _gcRefs;
-        
+
     ZeroMemory(&_gcRefs, sizeof(_gcRefs));
-        
+
     GCPROTECT_BEGIN(_gcRefs);
-        
+
     ICLRPrivAssembly *pResolvedAssembly = NULL;
-        
+
     // Prepare to invoke System.Runtime.Loader.AssemblyLoadContext.Resolve method.
     //
     // First, initialize an assembly spec for the requested assembly
@@ -6369,10 +6356,10 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
 
         // Allocate an AssemblyName managed object
         _gcRefs.oRefAssemblyName = (ASSEMBLYNAMEREF) AllocateObject(MscorlibBinder::GetClass(CLASS__ASSEMBLY_NAME));
-            
+
         // Initialize the AssemblyName object from the AssemblySpec
         spec.AssemblyNameInit(&_gcRefs.oRefAssemblyName, NULL);
-                
+
         bool isSatelliteAssemblyRequest = !spec.IsNeutralCulture();
 
         if (pTPABinder != NULL)
@@ -6382,7 +6369,7 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
 
             // Finally, setup arguments for invocation
             MethodDescCallSite methLoadAssembly(METHOD__ASSEMBLYLOADCONTEXT__RESOLVE);
-                
+
             // Setup the arguments for the call
             ARG_SLOT args[2] =
             {
@@ -6448,7 +6435,7 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
             // attempt to resolve it using the Resolving event.
             // Finally, setup arguments for invocation
             MethodDescCallSite methResolveUsingEvent(METHOD__ASSEMBLYLOADCONTEXT__RESOLVEUSINGEVENT);
-                
+
             // Setup the arguments for the call
             ARG_SLOT args[2] =
             {
@@ -6464,12 +6451,12 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
                 fResolvedAssembly = true;
             }
         }
-            
+
         if (fResolvedAssembly && pResolvedAssembly == NULL)
         {
             // If we are here, assembly was successfully resolved via Load or Resolving events.
             _ASSERTE(_gcRefs.oRefLoadedAssembly != NULL);
-                    
+
             // We were able to get the assembly loaded. Now, get its name since the host could have
             // performed the resolution using an assembly with different name.
             DomainAssembly *pDomainAssembly = _gcRefs.oRefLoadedAssembly->GetDomainAssembly();
@@ -6489,7 +6476,7 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
                     fFailLoad = true;
                 }
             }
-                
+
             // The loaded assembly's ICLRPrivAssembly* is saved as HostAssembly in PEAssembly
             if (fFailLoad)
             {
@@ -6497,10 +6484,10 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
                 spec.GetFileOrDisplayName(0, name);
                 COMPlusThrowHR(COR_E_INVALIDOPERATION, IDS_HOST_ASSEMBLY_RESOLVER_DYNAMICALLY_EMITTED_ASSEMBLIES_UNSUPPORTED, name);
             }
-                
+
             pResolvedAssembly = pLoadedPEAssembly->GetHostAssembly();
         }
-            
+
         if (fResolvedAssembly)
         {
             _ASSERTE(pResolvedAssembly != NULL);
@@ -6527,9 +6514,9 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
             hr = COR_E_FILENOTFOUND;
         }
     }
-        
+
     GCPROTECT_END();
-    
+
     return hr;
 }
 #endif // !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
@@ -6547,7 +6534,7 @@ size_t AppDomain::EstimateSize()
         MODE_ANY;
     }
     CONTRACTL_END;
-    
+
     size_t retval = sizeof(AppDomain);
     retval += GetLoaderAllocator()->EstimateSize();
     //very rough estimate
@@ -6631,7 +6618,7 @@ AppDomain::EnumMemoryRegions(CLRDataEnumMemoryFlags flags,
     m_Assemblies.EnumMemoryRegions(flags);
     AssemblyIterator assem = IterateAssembliesEx((AssemblyIterationFlags)(kIncludeLoaded | kIncludeExecution));
     CollectibleAssemblyHolder<DomainAssembly *> pDomainAssembly;
-    
+
     while (assem.Next(pDomainAssembly.This()))
     {
         pDomainAssembly->EnumMemoryRegions(flags);
@@ -6726,10 +6713,10 @@ void AppDomain::PublishHostedAssembly(
         // We have to serialize all Add operations
         CrstHolder lockAdd(&m_crstHostAssemblyMapAdd);
         _ASSERTE(m_hostAssemblyMap.Lookup(pDomainAssembly->GetFile()->GetHostAssembly()) == nullptr);
-        
+
         // Wrapper for m_hostAssemblyMap.Add that avoids call out into host
         HostAssemblyMap::AddPhases addCall;
-        
+
         // 1. Preallocate one element
         addCall.PreallocateForAdd(&m_hostAssemblyMap);
         {
@@ -6752,7 +6739,7 @@ void AppDomain::PublishHostedAssembly(
 
 //---------------------------------------------------------------------------------------------------------------------
 void AppDomain::UpdatePublishHostedAssembly(
-    DomainAssembly * pAssembly, 
+    DomainAssembly * pAssembly,
     PTR_PEFile       pFile)
 {
     CONTRACTL
@@ -6772,8 +6759,8 @@ void AppDomain::UpdatePublishHostedAssembly(
             // Wrapper for m_hostAssemblyMap.Add that avoids call out into host
             OriginalFileHostAssemblyMap::AddPhases addCall;
             bool fAddOrigFile = false;
-        
-            // For cases where the pefile is being updated 
+
+            // For cases where the pefile is being updated
             // 1. Preallocate one element
             if (pFile != pAssembly->GetFile())
             {
@@ -6786,14 +6773,14 @@ void AppDomain::UpdatePublishHostedAssembly(
                 ForbidSuspendThreadHolder suspend;
                 {
                     CrstHolder lock(&m_crstHostAssemblyMap);
-                
+
                     // Remove from hash table.
                     _ASSERTE(m_hostAssemblyMap.Lookup(pAssembly->GetFile()->GetHostAssembly()) != nullptr);
                     m_hostAssemblyMap.Remove(pAssembly->GetFile()->GetHostAssembly());
-                
+
                     // Update PEFile on DomainAssembly. (This may cause the key for the hash to change, which is why we need this function)
                     pAssembly->UpdatePEFileWorker(pFile);
-                
+
                     _ASSERTE(fAddOrigFile == (pAssembly->GetOriginalFile() != pAssembly->GetFile()));
                     if (fAddOrigFile)
                     {
@@ -6858,14 +6845,14 @@ void AppDomain::UnPublishHostedAssembly(
 HRESULT AppDomain::SetWinrtApplicationContext(LPCWSTR pwzAppLocalWinMD)
 {
     STANDARD_VM_CONTRACT;
-    
+
     _ASSERTE(WinRTSupported());
     _ASSERTE(m_pWinRtBinder != nullptr);
 
     _ASSERTE(GetTPABinderContext() != NULL);
     BINDER_SPACE::ApplicationContext *pApplicationContext = GetTPABinderContext()->GetAppContext();
     _ASSERTE(pApplicationContext != NULL);
-    
+
     return m_pWinRtBinder->SetApplicationContext(pApplicationContext, pwzAppLocalWinMD);
 }
 
@@ -6884,10 +6871,10 @@ PTR_DomainAssembly AppDomain::FindAssembly(PTR_ICLRPrivAssembly pHostAssembly)
         SUPPORTS_DAC;
     }
     CONTRACTL_END
-    
+
     if (pHostAssembly == nullptr)
         return NULL;
-    
+
     {
         ForbidSuspendThreadHolder suspend;
         {
@@ -6896,7 +6883,7 @@ PTR_DomainAssembly AppDomain::FindAssembly(PTR_ICLRPrivAssembly pHostAssembly)
             if (returnValue == NULL)
             {
                 // If not found in the m_hostAssemblyMap, look in the m_hostAssemblyMapForOrigFile
-                // This is necessary as it may happen during in a second AppDomain that the PEFile 
+                // This is necessary as it may happen during in a second AppDomain that the PEFile
                 // first discovered in the AppDomain may not be used by the DomainFile, but the CLRPrivBinderFusion
                 // will in some cases find the pHostAssembly associated with this no longer used PEFile
                 // instead of the PEFile that was finally decided upon.

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -33,7 +33,7 @@
 #include "../binder/inc/clrprivbindercoreclr.h"
 
 FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAFE,
-        StringObject* codeBaseUNSAFE, 
+        StringObject* codeBaseUNSAFE,
         AssemblyBaseObject* requestingAssemblyUNSAFE,
         StackCrawlMark* stackMark,
         CLR_BOOL fThrowOnFileNotFound,
@@ -84,7 +84,7 @@ FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
         {
             pRefAssembly = SystemDomain::GetCallersAssembly(stackMark);
         }
-        
+
         if (pRefAssembly)
         {
             pParentAssembly = pRefAssembly->GetDomainAssembly();
@@ -93,15 +93,15 @@ FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
 
     // Initialize spec
     AssemblySpec spec;
-    spec.InitializeSpec(pStackingAllocator, 
+    spec.InitializeSpec(pStackingAllocator,
                         &gc.assemblyName,
                         FALSE);
-    
+
     if (!spec.HasUniqueIdentity())
     {   // Insuficient assembly name for binding (e.g. ContentType=WindowsRuntime cannot bind by assembly name)
         EEFileLoadException::Throw(&spec, COR_E_NOTSUPPORTED);
     }
-    
+
     if (gc.codeBase != NULL)
         spec.SetCodeBase(pStackingAllocator, &gc.codeBase);
 
@@ -124,7 +124,7 @@ FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
     }
 
     Assembly *pAssembly;
-    
+
     {
         GCX_PREEMP();
         pAssembly = spec.LoadAssembly(FILE_LOADED, fThrowOnFileNotFound);
@@ -132,7 +132,7 @@ FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
 
     if (pAssembly != NULL)
         gc.rv = (ASSEMBLYREF) pAssembly->GetExposedObject();
-    
+
     HELPER_METHOD_FRAME_END();
 
     return OBJECTREFToObject(gc.rv);
@@ -149,11 +149,11 @@ Assembly* AssemblyNative::LoadFromPEImage(ICLRPrivBinder* pBinderContext, PEImag
         POSTCONDITION(CheckPointer(RETVAL));
     }
     CONTRACT_END;
-    
+
     Assembly *pLoadedAssembly = NULL;
-    
+
     ReleaseHolder<ICLRPrivAssembly> pAssembly;
-    
+
     // Get the correct PEImage to work with.
     BOOL fIsNativeImage = TRUE;
     PEImage *pImage = pNIImage;
@@ -164,7 +164,7 @@ Assembly* AssemblyNative::LoadFromPEImage(ICLRPrivBinder* pBinderContext, PEImag
         fIsNativeImage = FALSE;
     }
     _ASSERTE(pImage != NULL);
-    
+
     BOOL fHadLoadFailure = FALSE;
 
     // Force the image to be loaded and mapped so that subsequent loads do not
@@ -177,18 +177,18 @@ Assembly* AssemblyNative::LoadFromPEImage(ICLRPrivBinder* pBinderContext, PEImag
     {
         pImage->LoadNoFile();
     }
-    
+
     DWORD dwMessageID = IDS_EE_FILELOAD_ERROR_GENERIC;
-    
+
     // Set the caller's assembly to be mscorlib
     DomainAssembly *pCallersAssembly = SystemDomain::System()->SystemAssembly()->GetDomainAssembly();
     PEAssembly *pParentAssembly = pCallersAssembly->GetFile();
-    
+
     // Initialize the AssemblySpec
     AssemblySpec spec;
     spec.InitializeSpec(TokenFromRid(1, mdtAssembly), pImage->GetMDImport(), pCallersAssembly);
     spec.SetBindingContext(pBinderContext);
-    
+
     BinderTracing::AssemblyBindOperation bindOperation(&spec);
 
     HRESULT hr = S_OK;
@@ -213,7 +213,7 @@ Assembly* AssemblyNative::LoadFromPEImage(ICLRPrivBinder* pBinderContext, PEImag
         {
             dwMessageID = IDS_HOST_ASSEMBLY_RESOLVER_ASSEMBLY_ALREADY_LOADED_IN_CONTEXT;
         }
-        
+
         StackSString name;
         spec.GetFileOrDisplayName(0, name);
         COMPlusThrowHR(COR_E_FILELOAD, dwMessageID, name);
@@ -221,7 +221,7 @@ Assembly* AssemblyNative::LoadFromPEImage(ICLRPrivBinder* pBinderContext, PEImag
 
     BINDER_SPACE::Assembly* assem;
     assem = BINDER_SPACE::GetAssemblyFromPrivAssemblyFast(pAssembly);
-    
+
     PEAssemblyHolder pPEAssembly(PEAssembly::Open(pParentAssembly, assem->GetPEImage(), assem->GetNativePEImage(), pAssembly));
     bindOperation.SetResult(pPEAssembly.GetValue());
 
@@ -235,22 +235,22 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
     QCALL_CONTRACT;
 
     BEGIN_QCALL;
-    
+
     PTR_AppDomain pCurDomain = GetAppDomain();
 
     // Get the binder context in which the assembly will be loaded.
     ICLRPrivBinder *pBinderContext = reinterpret_cast<ICLRPrivBinder*>(ptrNativeAssemblyLoadContext);
     _ASSERTE(pBinderContext != NULL);
-        
+
     // Form the PEImage for the ILAssembly. Incase of an exception, the holders will ensure
     // the release of the image.
     PEImageHolder pILImage, pNIImage;
-    
+
     if (pwzILPath != NULL)
     {
         pILImage = PEImage::OpenImage(pwzILPath);
-        
-        // Need to verify that this is a valid CLR assembly. 
+
+        // Need to verify that this is a valid CLR assembly.
         if (!pILImage->CheckILFormat())
             THROW_BAD_FORMAT(BFA_BAD_IL, pILImage.GetValue());
 
@@ -261,7 +261,7 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
             THROW_BAD_FORMAT(BFA_IJW_IN_COLLECTIBLE_ALC, pILImage.GetValue());
         }
     }
-    
+
 #ifdef FEATURE_PREJIT
     // Form the PEImage for the NI assembly, if specified
     if (pwzNIPath != NULL)
@@ -284,45 +284,45 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         }
     }
 #endif // FEATURE_PREJIT
-    
+
     Assembly *pLoadedAssembly = AssemblyNative::LoadFromPEImage(pBinderContext, pILImage, pNIImage);
-    
+
     {
         GCX_COOP();
         retLoadedAssembly.Set(pLoadedAssembly->GetExposedObject());
     }
 
-    LOG((LF_CLASSLOADER, 
-            LL_INFO100, 
+    LOG((LF_CLASSLOADER,
+            LL_INFO100,
             "\tLoaded assembly from a file\n"));
-    
+
     END_QCALL;
 }
 
 /*static */
-void QCALLTYPE AssemblyNative::LoadFromStream(INT_PTR ptrNativeAssemblyLoadContext, INT_PTR ptrAssemblyArray, 
-                                              INT32 cbAssemblyArrayLength, INT_PTR ptrSymbolArray, INT32 cbSymbolArrayLength, 
+void QCALLTYPE AssemblyNative::LoadFromStream(INT_PTR ptrNativeAssemblyLoadContext, INT_PTR ptrAssemblyArray,
+                                              INT32 cbAssemblyArrayLength, INT_PTR ptrSymbolArray, INT32 cbSymbolArrayLength,
                                               QCall::ObjectHandleOnStack retLoadedAssembly)
 {
     QCALL_CONTRACT;
-    
+
     BEGIN_QCALL;
-    
+
     // Ensure that the invariants are in place
     _ASSERTE(ptrNativeAssemblyLoadContext != NULL);
     _ASSERTE((ptrAssemblyArray != NULL) && (cbAssemblyArrayLength > 0));
     _ASSERTE((ptrSymbolArray == NULL) || (cbSymbolArrayLength > 0));
 
-    // We must have a flat image stashed away since we need a private 
+    // We must have a flat image stashed away since we need a private
     // copy of the data which we can verify before doing the mapping.
     PVOID pAssemblyArray = reinterpret_cast<PVOID>(ptrAssemblyArray);
 
     PEImageHolder pILImage(PEImage::LoadFlat(pAssemblyArray, (COUNT_T)cbAssemblyArrayLength));
-    
-    // Need to verify that this is a valid CLR assembly. 
+
+    // Need to verify that this is a valid CLR assembly.
     if (!pILImage->CheckILFormat())
         ThrowHR(COR_E_BADIMAGEFORMAT, BFA_BAD_IL);
-    
+
     // Get the binder context in which the assembly will be loaded
     ICLRPrivBinder *pBinderContext = reinterpret_cast<ICLRPrivBinder*>(ptrNativeAssemblyLoadContext);
 
@@ -334,22 +334,22 @@ void QCALLTYPE AssemblyNative::LoadFromStream(INT_PTR ptrNativeAssemblyLoadConte
     }
 
     // Pass the stream based assembly as IL and NI in an attempt to bind and load it
-    Assembly* pLoadedAssembly = AssemblyNative::LoadFromPEImage(pBinderContext, pILImage, NULL); 
+    Assembly* pLoadedAssembly = AssemblyNative::LoadFromPEImage(pBinderContext, pILImage, NULL);
     {
         GCX_COOP();
         retLoadedAssembly.Set(pLoadedAssembly->GetExposedObject());
     }
 
-    LOG((LF_CLASSLOADER, 
-            LL_INFO100, 
+    LOG((LF_CLASSLOADER,
+            LL_INFO100,
             "\tLoaded assembly from a file\n"));
-            
+
     // In order to assign the PDB image (if present),
     // the resulting assembly's image needs to be exactly the one
     // we created above. We need pointer comparison instead of pe image equivalence
     // to avoid mixed binaries/PDB pairs of other images.
     // This applies to both Desktop CLR and CoreCLR, with or without fusion.
-    BOOL fIsSameAssembly = (pLoadedAssembly->GetManifestFile()->GetILimage() == pILImage); 
+    BOOL fIsSameAssembly = (pLoadedAssembly->GetManifestFile()->GetILimage() == pILImage);
 
     // Setting the PDB info is only applicable for our original assembly.
     // This applies to both Desktop CLR and CoreCLR, with or without fusion.
@@ -373,31 +373,31 @@ void QCALLTYPE AssemblyNative::LoadFromStream(INT_PTR ptrNativeAssemblyLoadConte
 void QCALLTYPE AssemblyNative::LoadFromInMemoryModule(INT_PTR ptrNativeAssemblyLoadContext, INT_PTR hModule, QCall::ObjectHandleOnStack retLoadedAssembly)
 {
     QCALL_CONTRACT;
-    
+
     BEGIN_QCALL;
-    
+
     // Ensure that the invariants are in place
     _ASSERTE(ptrNativeAssemblyLoadContext != NULL);
     _ASSERTE(hModule != NULL);
 
     PEImageHolder pILImage(PEImage::LoadImage((HMODULE)hModule));
-    
-    // Need to verify that this is a valid CLR assembly. 
+
+    // Need to verify that this is a valid CLR assembly.
     if (!pILImage->HasCorHeader())
         ThrowHR(COR_E_BADIMAGEFORMAT, BFA_BAD_IL);
-    
+
     // Get the binder context in which the assembly will be loaded
     ICLRPrivBinder *pBinderContext = reinterpret_cast<ICLRPrivBinder*>(ptrNativeAssemblyLoadContext);
-    
+
     // Pass the in memory module as IL in an attempt to bind and load it
-    Assembly* pLoadedAssembly = AssemblyNative::LoadFromPEImage(pBinderContext, pILImage, NULL); 
+    Assembly* pLoadedAssembly = AssemblyNative::LoadFromPEImage(pBinderContext, pILImage, NULL);
     {
         GCX_COOP();
         retLoadedAssembly.Set(pLoadedAssembly->GetExposedObject());
     }
 
-    LOG((LF_CLASSLOADER, 
-            LL_INFO100, 
+    LOG((LF_CLASSLOADER,
+            LL_INFO100,
             "\tLoaded assembly from pre-loaded native module\n"));
 
     END_QCALL;
@@ -413,7 +413,7 @@ void QCALLTYPE AssemblyNative::GetLocation(QCall::AssemblyHandle pAssembly, QCal
     {
         retString.Set(pAssembly->GetFile()->GetPath());
     }
-    
+
     END_QCALL;
 }
 
@@ -525,7 +525,7 @@ FCIMPL1(FC_BOOL_RET, AssemblyNative::IsDynamic, AssemblyBaseObject* pAssemblyUNS
     FCALL_CONTRACT;
 
     ASSEMBLYREF refAssembly = (ASSEMBLYREF)ObjectToOBJECTREF(pAssemblyUNSAFE);
-    
+
     if (refAssembly == NULL)
         FCThrowRes(kArgumentNullException, W("Arg_InvalidHandle"));
 
@@ -546,7 +546,7 @@ void QCALLTYPE AssemblyNative::GetVersion(QCall::AssemblyHandle pAssembly, INT32
     *pMajorVersion = major;
     *pMinorVersion = minor;
     *pBuildNumber = build;
-    *pRevisionNumber = revision; 
+    *pRevisionNumber = revision;
 
     END_QCALL;
 }
@@ -570,7 +570,7 @@ void QCALLTYPE AssemblyNative::GetSimpleName(QCall::AssemblyHandle pAssembly, QC
 
     BEGIN_QCALL;
     retSimpleName.Set(pAssembly->GetSimpleName());
-    END_QCALL;    
+    END_QCALL;
 }
 
 void QCALLTYPE AssemblyNative::GetLocale(QCall::AssemblyHandle pAssembly, QCall::StringHandleOnStack retString)
@@ -584,7 +584,7 @@ void QCALLTYPE AssemblyNative::GetLocale(QCall::AssemblyHandle pAssembly, QCall:
     {
         retString.Set(pLocale);
     }
-    
+
     END_QCALL;
 }
 
@@ -722,12 +722,12 @@ void QCALLTYPE AssemblyNative::GetModules(QCall::AssemblyHandle pAssembly, BOOL 
             modules.Append(pModule);
         }
     }
-    
+
     {
         GCX_COOP();
 
         PTRARRAYREF orModules = NULL;
-        
+
         GCPROTECT_BEGIN(orModules);
 
         // Return the modules
@@ -781,7 +781,7 @@ void QCALLTYPE AssemblyNative::GetModule(QCall::AssemblyHandle pAssembly, LPCWST
     BEGIN_QCALL;
 
     Module * pModule = NULL;
-    
+
     CQuickBytes qbLC;
 
     if (wszFileName == NULL)
@@ -822,7 +822,7 @@ void QCALLTYPE AssemblyNative::GetExportedTypes(QCall::AssemblyHandle pAssembly,
     InlineSArray<TypeHandle, 20> types;
 
     Assembly * pAsm = pAssembly->GetAssembly();
-    
+
     IMDInternalImport *pImport = pAsm->GetManifestImport();
 
     {
@@ -832,27 +832,27 @@ void QCALLTYPE AssemblyNative::GetExportedTypes(QCall::AssemblyHandle pAssembly,
         mdTypeDef mdTD;
         while(pImport->EnumNext(&phTDEnum, &mdTD))
         {
-            DWORD dwFlags;            
+            DWORD dwFlags;
             IfFailThrow(pImport->GetTypeDefProps(
                 mdTD,
                 &dwFlags,
                 NULL));
-            
+
             // nested type
             mdTypeDef mdEncloser = mdTD;
             while (SUCCEEDED(pImport->GetNestedClassProps(mdEncloser, &mdEncloser)) &&
                    IsTdNestedPublic(dwFlags))
             {
                 IfFailThrow(pImport->GetTypeDefProps(
-                    mdEncloser, 
-                    &dwFlags, 
+                    mdEncloser,
+                    &dwFlags,
                     NULL));
             }
-            
+
             if (IsTdPublic(dwFlags))
             {
-                TypeHandle typeHnd = ClassLoader::LoadTypeDefThrowing(pAsm->GetManifestModule(), mdTD, 
-                                                                      ClassLoader::ThrowIfNotFound, 
+                TypeHandle typeHnd = ClassLoader::LoadTypeDefThrowing(pAsm->GetManifestModule(), mdTD,
+                                                                      ClassLoader::ThrowIfNotFound,
                                                                       ClassLoader::PermitUninstDefOrRef);
                 types.Append(typeHnd);
             }
@@ -873,31 +873,31 @@ void QCALLTYPE AssemblyNative::GetExportedTypes(QCall::AssemblyHandle pAssembly,
             DWORD dwFlags;
 
             IfFailThrow(pImport->GetExportedTypeProps(
-                mdCT, 
-                &pszNameSpace, 
-                &pszClassName, 
-                &mdImpl, 
+                mdCT,
+                &pszNameSpace,
+                &pszClassName,
+                &mdImpl,
                 NULL,           //binding
                 &dwFlags));
-            
+
             // nested type
             while ((TypeFromToken(mdImpl) == mdtExportedType) &&
                    (mdImpl != mdExportedTypeNil) &&
                    IsTdNestedPublic(dwFlags))
             {
                 IfFailThrow(pImport->GetExportedTypeProps(
-                    mdImpl, 
+                    mdImpl,
                     NULL,       //namespace
                     NULL,       //name
-                    &mdImpl, 
+                    &mdImpl,
                     NULL,       //binding
                     &dwFlags));
             }
-            
+
             if ((TypeFromToken(mdImpl) == mdtFile) &&
                 (mdImpl != mdFileNil) &&
                 IsTdPublic(dwFlags))
-            {                
+            {
                 NameHandle typeName(pszNameSpace, pszClassName);
                 typeName.SetTypeToken(pAsm->GetManifestModule(), mdCT);
                 TypeHandle typeHnd = pAsm->GetLoader()->LoadTypeHandleThrowIfFailed(&typeName);
@@ -942,7 +942,7 @@ void QCALLTYPE AssemblyNative::GetForwardedTypes(QCall::AssemblyHandle pAssembly
     InlineSArray<TypeHandle, 8> types;
 
     Assembly * pAsm = pAssembly->GetAssembly();
-    
+
     IMDInternalImport *pImport = pAsm->GetManifestImport();
 
     // enumerate the ExportedTypes table
@@ -967,7 +967,7 @@ void QCALLTYPE AssemblyNative::GetForwardedTypes(QCall::AssemblyHandle pAssembly
                 &dwFlags));
 
             if ((TypeFromToken(mdImpl) == mdtAssemblyRef) && (mdImpl != mdAssemblyRefNil))
-            {                
+            {
                 NameHandle typeName(pszNameSpace, pszClassName);
                 typeName.SetTypeToken(pAsm->GetManifestModule(), mdCT);
                 TypeHandle typeHnd = pAsm->GetLoader()->LoadTypeHandleThrowIfFailed(&typeName);
@@ -1009,7 +1009,7 @@ FCIMPL1(Object*, AssemblyNative::GetManifestResourceNames, AssemblyBaseObject * 
     FCALL_CONTRACT;
 
     ASSEMBLYREF refAssembly = (ASSEMBLYREF)ObjectToOBJECTREF(pAssemblyUNSAFE);
-    
+
     if (refAssembly == NULL)
         FCThrowRes(kArgumentNullException, W("Arg_InvalidHandle"));
 
@@ -1034,23 +1034,23 @@ FCIMPL1(Object*, AssemblyNative::GetManifestResourceNames, AssemblyBaseObject * 
     for(DWORD i = 0;  i < dwCount; i++) {
         pImport->EnumNext(&phEnum, &mdResource);
         LPCSTR pszName = NULL;
-        
+
         IfFailThrow(pImport->GetManifestResourceProps(
-            mdResource, 
+            mdResource,
             &pszName,   // name
             NULL,       // linkref
             NULL,       // offset
             NULL));     //flags
-        
+
         OBJECTREF o = (OBJECTREF) StringObject::NewString(pszName);
         ItemArray->SetAt(i, o);
     }
-    
+
     rv = ItemArray;
     GCPROTECT_END();
-    
+
     HELPER_METHOD_FRAME_END();
-    
+
     return OBJECTREFToObject(rv);
 }
 FCIMPLEND
@@ -1089,13 +1089,13 @@ FCIMPL1(Object*, AssemblyNative::GetReferencedAssemblies, AssemblyBaseObject * p
     mdAssemblyRef mdAssemblyRef;
 
     gc.ItemArray = (PTRARRAYREF) AllocateObjectArray(dwCount, pAsmNameClass);
-    
-    for(DWORD i = 0; i < dwCount; i++) 
+
+    for(DWORD i = 0; i < dwCount; i++)
     {
         pImport->EnumNext(&phEnum, &mdAssemblyRef);
-    
+
         AssemblySpec spec;
-        spec.InitializeSpec(mdAssemblyRef, pImport);                                             
+        spec.InitializeSpec(mdAssemblyRef, pImport);
 
         gc.pObj = (ASSEMBLYNAMEREF) AllocateObject(pAsmNameClass);
         spec.AssemblyNameInit(&gc.pObj,NULL);
@@ -1153,7 +1153,7 @@ void QCALLTYPE AssemblyNative::GetExecutingAssembly(QCall::StackCrawlMarkHandle 
     QCALL_CONTRACT;
 
     DomainAssembly * pExecutingAssembly = NULL;
-    
+
     BEGIN_QCALL;
 
     Assembly* pAssembly = SystemDomain::GetCallersAssembly(stackMark);
@@ -1176,7 +1176,7 @@ void QCALLTYPE AssemblyNative::GetEntryAssembly(QCall::ObjectHandleOnStack retAs
 
     DomainAssembly * pRootAssembly = NULL;
     Assembly * pAssembly = GetAppDomain()->m_pRootAssembly;
-    
+
     if (pAssembly)
     {
         pRootAssembly = pAssembly->GetDomainAssembly();
@@ -1196,7 +1196,7 @@ FCIMPL1(ReflectModuleBaseObject *, AssemblyNative::GetInMemoryAssemblyModule, As
 
 
     ASSEMBLYREF refAssembly = (ASSEMBLYREF)ObjectToOBJECTREF(pAssemblyUNSAFE);
-    
+
     if (refAssembly == NULL)
         FCThrowRes(kArgumentNullException, W("Arg_InvalidHandle"));
 
@@ -1234,13 +1234,13 @@ INT_PTR QCALLTYPE AssemblyNative::InitializeAssemblyLoadContext(INT_PTR ptrManag
     QCALL_CONTRACT;
 
     INT_PTR ptrNativeAssemblyLoadContext = NULL;
-    
+
     BEGIN_QCALL;
-    
+
     // We do not need to take a lock since this method is invoked from the ctor of AssemblyLoadContext managed type and
     // only one thread is ever executing a ctor for a given instance.
     //
-    
+
     // Initialize the assembly binder instance in the VM
     PTR_AppDomain pCurDomain = AppDomain::GetCurrentDomain();
     CLRPrivBinderCoreCLR *pTPABinderContext = pCurDomain->GetTPABinderContext();
@@ -1299,9 +1299,9 @@ INT_PTR QCALLTYPE AssemblyNative::InitializeAssemblyLoadContext(INT_PTR ptrManag
         pTPABinderContext->SetManagedAssemblyLoadContext(ptrManagedAssemblyLoadContext);
         ptrNativeAssemblyLoadContext = reinterpret_cast<INT_PTR>(pTPABinderContext);
     }
-   
+
     END_QCALL;
-    
+
     return ptrNativeAssemblyLoadContext;
 }
 
@@ -1329,15 +1329,16 @@ INT_PTR QCALLTYPE AssemblyNative::GetLoadContextForAssembly(QCall::AssemblyHandl
     QCALL_CONTRACT;
 
     INT_PTR ptrManagedAssemblyLoadContext = NULL;
-    
+
     BEGIN_QCALL;
-    
+
+    _ASSERTE(pAssembly != NULL);
+
     // Get the PEAssembly for the RuntimeAssembly
     PEFile *pPEFile = pAssembly->GetFile();
-    PTR_PEAssembly pPEAssembly = pPEFile->AsAssembly();
-    _ASSERTE(pAssembly != NULL);
-   
-    // Platform assemblies are semantically bound against the "Default" binder. 
+    PTR_PEAssembly pPEAssembly = pPEFile ? pPEFile->AsAssembly() : NULL;
+
+    // Platform assemblies are semantically bound against the "Default" binder.
     // The reference to the same will be returned when this QCall returns.
 
     // Get the binding context for the assembly.
@@ -1387,9 +1388,9 @@ INT_PTR QCALLTYPE AssemblyNative::GetLoadContextForAssembly(QCall::AssemblyHandl
         ptrManagedAssemblyLoadContext = pBinder->GetManagedAssemblyLoadContext();
         _ASSERTE(ptrManagedAssemblyLoadContext != NULL);
     }
-    
+
     END_QCALL;
-    
+
     return ptrManagedAssemblyLoadContext;
 }
 

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 // ===========================================================================
 // File: CEELOAD.CPP
-// 
+//
 
 //
 
@@ -50,10 +50,10 @@
 #include "zapsig.h"
 #endif //FEATURE_PREJIT
 
-#ifdef FEATURE_COMINTEROP 
+#ifdef FEATURE_COMINTEROP
 #include "runtimecallablewrapper.h"
 #include "comcallablewrapper.h"
-#endif //FEATURE_COMINTEROP 
+#endif //FEATURE_COMINTEROP
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -176,7 +176,7 @@ void Module::DoInit(AllocMemTracker *pamTracker, LPCWSTR szName)
         Initialize(pamTracker, szName);
     }
 #ifdef PROFILING_SUPPORTED
-    
+
 
     EX_HOOK
     {
@@ -206,7 +206,7 @@ BOOL Module::SetTransientFlagInterlocked(DWORD dwFlag)
     }
 }
 
-#if PROFILING_SUPPORTED 
+#if PROFILING_SUPPORTED
 void Module::UpdateNewlyAddedTypes()
 {
     CONTRACTL
@@ -368,8 +368,8 @@ void Module::NotifyEtwLoadFinished(HRESULT hr)
 
     // we report only successful loads
     if (SUCCEEDED(hr) &&
-        ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, 
-                                     TRACE_LEVEL_INFORMATION, 
+        ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context,
+                                     TRACE_LEVEL_INFORMATION,
                                      KEYWORDZERO))
     {
         BOOL fSharedModule = !SetTransientFlagInterlocked(IS_ETW_NOTIFIED);
@@ -405,7 +405,7 @@ Module::Module(Assembly *pAssembly, mdFile moduleRef, PEFile *file)
         _ASSERTE(m_pBinder == NULL);
         _ASSERTE(m_symbolFormat == eSymbolFormatNone);
     }
-    
+
     file->AddRef();
 }
 
@@ -455,7 +455,7 @@ void Module::InitializeForProfiling()
     }
 }
 
-#ifdef FEATURE_PREJIT 
+#ifdef FEATURE_PREJIT
 
 void Module::InitializeNativeImage(AllocMemTracker* pamTracker)
 {
@@ -490,13 +490,13 @@ void Module::InitializeNativeImage(AllocMemTracker* pamTracker)
     }
 #endif // defined(HAVE_GCCOVER)
 }
-#else // FEATURE_PREJIT 
+#else // FEATURE_PREJIT
 BOOL Module::IsPersistedObject(void *address)
 {
     LIMITED_METHOD_CONTRACT;
     return FALSE;
 }
-#endif // FEATURE_PREJIT 
+#endif // FEATURE_PREJIT
 
 void Module::SetNativeMetadataAssemblyRefInCache(DWORD rid, PTR_Assembly pAssembly)
 {
@@ -535,9 +535,9 @@ void Module::SetNativeMetadataAssemblyRefInCache(DWORD rid, PTR_Assembly pAssemb
 // The Initialize() phase completes the initialization after the constructor has run.
 // It can throw exceptions but whether it throws or succeeds, it must leave the Module
 // in a state where Destruct() can be safely called.
-// 
+//
 // szName is only used by dynamic modules, see ReflectionModule::Initialize
-// 
+//
 //
 void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
 {
@@ -642,7 +642,7 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
     m_ModuleID = NULL;
     m_ModuleIndex.m_dwIndex = (SIZE_T)-1;
 
-    // These will be initialized in NotifyProfilerLoadFinished, set them to 
+    // These will be initialized in NotifyProfilerLoadFinished, set them to
     // a safe initial value now.
     m_dwTypeCount = 0;
     m_dwExportedTypeCount = 0;
@@ -651,7 +651,7 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
     // Prepare statics that are known at module load time
     AllocateStatics(pamTracker);
 
-#ifdef FEATURE_PREJIT 
+#ifdef FEATURE_PREJIT
     // Set up native image
     if (HasNativeImage())
     {
@@ -673,7 +673,7 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
     {
         Module::CreateAssemblyRefByNameTable(pamTracker);
     }
-    
+
     // If the program has the "ForceEnc" env variable set we ensure every eligible
     // module has EnC turned on.
     if (g_pConfig->ForceEnc() && IsEditAndContinueCapable())
@@ -699,7 +699,7 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
 #ifndef DACCESS_COMPILE
 
 // static
-GuidToMethodTableHashTable* GuidToMethodTableHashTable::Create(Module* pModule, DWORD cInitialBuckets, 
+GuidToMethodTableHashTable* GuidToMethodTableHashTable::Create(Module* pModule, DWORD cInitialBuckets,
                         AllocMemTracker *pamTracker)
 {
     CONTRACTL
@@ -722,7 +722,7 @@ GuidToMethodTableHashTable* GuidToMethodTableHashTable::Create(Module* pModule, 
     return pThis;
 }
 
-GuidToMethodTableEntry *GuidToMethodTableHashTable::InsertValue(PTR_GUID pGuid, PTR_MethodTable pMT, 
+GuidToMethodTableEntry *GuidToMethodTableHashTable::InsertValue(PTR_GUID pGuid, PTR_MethodTable pMT,
                         BOOL bReplaceIfFound, AllocMemTracker *pamTracker)
 {
     CONTRACTL
@@ -795,18 +795,18 @@ GuidToMethodTableEntry *GuidToMethodTableHashTable::FindItem(const GUID * pGuid,
     CONTRACTL_END;
 
     // It's legal for the caller not to pass us a LookupContext, but we might need to iterate
-    // internally (since we lookup via hash and hashes may collide). So substitute our own 
+    // internally (since we lookup via hash and hashes may collide). So substitute our own
     // private context if one was not provided.
     LookupContext sAltContext;
     if (pContext == NULL)
         pContext = &sAltContext;
 
-    // The base class provides the ability to enumerate all entries with the same hash code. 
+    // The base class provides the ability to enumerate all entries with the same hash code.
     // We further check which of these entries actually match the full key.
     PTR_GuidToMethodTableEntry pSearch = BaseFindFirstEntryByHash(Hash(pGuid), pContext);
     while (pSearch)
     {
-        if (CompareKeys(pSearch, pGuid)) 
+        if (CompareKeys(pSearch, pGuid))
         {
             return pSearch;
         }
@@ -867,10 +867,10 @@ void GuidToMethodTableHashTable::Fixup(DataImage *pImage)
     Base_t::BaseFixup(pImage);
 }
 
-bool GuidToMethodTableHashTable::SaveEntry(DataImage *pImage, CorProfileData *pProfileData, 
-                    GuidToMethodTableEntry *pOldEntry, GuidToMethodTableEntry *pNewEntry, 
+bool GuidToMethodTableHashTable::SaveEntry(DataImage *pImage, CorProfileData *pProfileData,
+                    GuidToMethodTableEntry *pOldEntry, GuidToMethodTableEntry *pNewEntry,
                     EntryMappingTable *pMap)
-{ 
+{
     LIMITED_METHOD_CONTRACT;
     return false;
 }
@@ -881,7 +881,7 @@ void GuidToMethodTableHashTable::FixupEntry(DataImage *pImage, GuidToMethodTable
     pImage->FixupField(pFixupBase, cbFixupOffset + offsetof(GuidToMethodTableEntry, m_pMT), pEntry->m_pMT);
     pImage->FixupField(pFixupBase, cbFixupOffset + offsetof(GuidToMethodTableEntry, m_Guid), pEntry->m_Guid);
 }
-    
+
 #endif // FEATURE_NATIVE_IMAGE_GENERATION && !DACCESS_COMPILE
 
 
@@ -1006,7 +1006,7 @@ MemberRefToDescHashTable* MemberRefToDescHashTable::Create(Module *pModule, DWOR
     return pThis;
 }
 
-//Inserts FieldRef 
+//Inserts FieldRef
 MemberRefToDescHashEntry* MemberRefToDescHashTable::Insert(mdMemberRef token , FieldDesc *value)
 {
     CONTRACTL
@@ -1091,7 +1091,7 @@ void MemberRefToDescHashTable::Save(DataImage *pImage, CorProfileData *pProfileD
     if (pProfileData)
     {
         DWORD numInTokenList = pProfileData->GetHotTokens(mdtMemberRef>>24, 1<<RidMap, 1<<RidMap, NULL, 0);
-        
+
         if (numInTokenList > 0)
         {
             LookupContext sAltContext;
@@ -1163,7 +1163,7 @@ void Module::SetDebuggerInfoBits(DebuggerAssemblyControlFlags newBits)
     m_dwTransientFlags &= ~DEBUGGER_INFO_MASK_PRIV;
     m_dwTransientFlags |= (newBits << DEBUGGER_INFO_SHIFT_PRIV);
 
-#ifdef DEBUGGING_SUPPORTED 
+#ifdef DEBUGGING_SUPPORTED
     BOOL setEnC = ((newBits & DACF_ENC_ENABLED) != 0) && IsEditAndContinueCapable();
 
     // The only way can change Enc is through debugger override.
@@ -1210,7 +1210,7 @@ Module *Module::Create(Assembly *pAssembly, mdFile moduleRef, PEFile *file, Allo
 
     // Create the module
 
-#ifdef FEATURE_PREJIT 
+#ifdef FEATURE_PREJIT
 
     if (file->HasNativeImage())
     {
@@ -1265,7 +1265,7 @@ void Module::ApplyMetaData()
     HRESULT hr = S_OK;
     ULONG ulCount;
 
-#if PROFILING_SUPPORTED 
+#if PROFILING_SUPPORTED
     if (!IsResource())
     {
         UpdateNewlyAddedTypes();
@@ -1327,10 +1327,10 @@ void Module::Destruct()
 
     // Free classes in the class table
     FreeClassTables();
-    
 
 
-#ifdef DEBUGGING_SUPPORTED 
+
+#ifdef DEBUGGING_SUPPORTED
     if (g_pDebugInterface)
     {
         GCX_PREEMP();
@@ -1359,7 +1359,7 @@ void Module::Destruct()
 
 
 
-#ifdef PROFILING_SUPPORTED 
+#ifdef PROFILING_SUPPORTED
     {
         BEGIN_PIN_PROFILER(CORProfilerTrackModuleLoads());
         // Profiler is causing some peripheral class loads. Probably this just needs
@@ -1422,7 +1422,7 @@ void Module::Destruct()
         delete m_debuggerSpecificData.m_pILOffsetMappingTable;
     }
 
-#ifdef FEATURE_PREJIT 
+#ifdef FEATURE_PREJIT
 
     if (HasNativeImage())
     {
@@ -1434,7 +1434,7 @@ void Module::Destruct()
         m_file->Release();
     }
 
-    // If this module was loaded as domain-specific, then 
+    // If this module was loaded as domain-specific, then
     // we must free its ModuleIndex so that it can be reused
     FreeModuleIndex();
 }
@@ -1531,7 +1531,7 @@ MethodTable *Module::GetGlobalMethodTable()
 
 #endif // !DACCESS_COMPILE
 
-#ifdef FEATURE_PREJIT 
+#ifdef FEATURE_PREJIT
 
 /*static*/
 BOOL Module::IsAlwaysSavedInPreferredZapModule(Instantiation classInst,     // the type arguments to the type (if any)
@@ -1581,7 +1581,7 @@ static bool IsLikelyDependencyOf(Module * pModule, Module * pOtherModule)
         PRECONDITION(CheckPointer(pOtherModule));
     }
     CONTRACTL_END
-    
+
     // Every module has a dependency with itself
     if (pModule == pOtherModule)
         return true;
@@ -1590,12 +1590,12 @@ static bool IsLikelyDependencyOf(Module * pModule, Module * pOtherModule)
     // Explicit check for low level system assemblies is working around Win8P facades introducing extra layer between low level system assemblies
     // (System.dll or System.Core.dll) and the app assemblies. Because of this extra layer, the check below won't see the direct
     // reference between these low level system assemblies and the app assemblies. The prefererred zap module for instantiations of generic
-    // collections from these low level system assemblies (like LinkedList<AppType>) should be module of AppType. It would be module of the generic 
+    // collections from these low level system assemblies (like LinkedList<AppType>) should be module of AppType. It would be module of the generic
     // collection without this check.
     //
     // Similar problem exists for Windows.Foundation.winmd. There is a cycle between Windows.Foundation.winmd and Windows.Storage.winmd. This cycle
     // would cause prefererred zap module for instantiations of foundation types (like IAsyncOperation<StorageFolder>) to be Windows.Foundation.winmd.
-    // It is a bad choice. It should be Windows.Storage.winmd instead. We explicitly push Windows.Foundation to lower level by treating it as 
+    // It is a bad choice. It should be Windows.Storage.winmd instead. We explicitly push Windows.Foundation to lower level by treating it as
     // low level system assembly to avoid this problem.
     //
     if (pModule->IsLowLevelSystemAssemblyByName())
@@ -1619,7 +1619,7 @@ static bool IsLikelyDependencyOf(Module * pModule, Module * pOtherModule)
 
     // At this point neither pModule or pOtherModule is mscorlib
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
     //
     // We will check to see if the pOtherModule has a reference to pModule
     //
@@ -1682,7 +1682,7 @@ PTR_Module Module::ComputePreferredZapModuleHelper(
             RETURN dac_cast<PTR_Module>(pOpenModule);
     }
 
-    // The initial value of pCurrentPZM is the pDefinitionModule or mscorlib 
+    // The initial value of pCurrentPZM is the pDefinitionModule or mscorlib
     Module* pCurrentPZM = (pDefinitionModule != NULL) ? pDefinitionModule : MscorlibBinder::GetModule();
     bool preferredZapModuleBasedOnValueType = false;
 
@@ -1691,17 +1691,17 @@ PTR_Module Module::ComputePreferredZapModuleHelper(
         TypeHandle pTypeParam = (i < classInst.GetNumArgs()) ? classInst[i] : methodInst[i - classInst.GetNumArgs()];
 
         _ASSERTE(pTypeParam != NULL);
-        _ASSERTE(!pTypeParam.IsEncodedFixup()); 
+        _ASSERTE(!pTypeParam.IsEncodedFixup());
 
         Module * pParamPZM = GetPreferredZapModuleForTypeHandle(pTypeParam);
 
         //
         // If pCurrentPZM is not a dependency of pParamPZM
         // then we aren't going to update pCurrentPZM
-        // 
+        //
         if (IsLikelyDependencyOf(pCurrentPZM, pParamPZM))
         {
-            // If we have a type parameter that is a value type 
+            // If we have a type parameter that is a value type
             // and we don't yet have a value type based pCurrentPZM
             // then we will select it's module as the new pCurrentPZM.
             //
@@ -1712,11 +1712,11 @@ PTR_Module Module::ComputePreferredZapModuleHelper(
             }
             else
             {
-                // The normal rule is to replace the pCurrentPZM only when 
+                // The normal rule is to replace the pCurrentPZM only when
                 // both of the following are true:
-                //     pCurrentPZM is a dependency of pParamPZM 
+                //     pCurrentPZM is a dependency of pParamPZM
                 // and pParamPZM is not a dependency of pCurrentPZM
-                // 
+                //
                 // note that the second condition is alway true when pCurrentPZM is mscorlib
                 //
                 if (!IsLikelyDependencyOf(pParamPZM, pCurrentPZM))
@@ -1850,7 +1850,7 @@ PTR_Module Module::GetPreferredZapModuleForMethodDesc(const MethodDesc *pMD)
     else
     {
         return ComputePreferredZapModule(pMD->GetModule(),
-                                         pMD->GetClassInstantiation(), 
+                                         pMD->GetClassInstantiation(),
                                          pMD->GetMethodInstantiation());
     }
 }
@@ -1886,7 +1886,7 @@ BOOL Module::IsEditAndContinueCapable(Assembly *pAssembly, PEFile *file)
     CONTRACTL_END;
 
     _ASSERTE(pAssembly != NULL && file != NULL);
-    
+
     // Some modules are never EnC-capable
     return ! (pAssembly->GetDebuggerInfoBits() & DACF_ALLOW_JIT_OPTS ||
               file->IsSystem() ||
@@ -1916,7 +1916,7 @@ DomainFile *Module::GetDomainFile()
     return dac_cast<PTR_DomainFile>(m_ModuleID->GetDomainFile());
 }
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
 #include "staticallocationhelpers.inl"
 
 // Parses metadata and initializes offsets of per-class static blocks.
@@ -1953,7 +1953,7 @@ void Module::BuildStaticsOffsets(AllocMemTracker *pamTracker)
     _ASSERTE(OFFSETOF__ThreadLocalModule__m_pDataBlob  == ThreadLocalModule::OffsetOfDataBlob());
 #endif
 
-    DWORD      dwNonGCBytes[2] = { 
+    DWORD      dwNonGCBytes[2] = {
         DomainLocalModule::OffsetOfDataBlob() + (DWORD)(sizeof(BYTE)*dwNumTypes),
         ThreadLocalModule::OffsetOfDataBlob() + (DWORD)(sizeof(BYTE)*dwNumTypes)
     };
@@ -1991,12 +1991,12 @@ void Module::BuildStaticsOffsets(AllocMemTracker *pamTracker)
                 CorElementType ElementType = ELEMENT_TYPE_END;
                 mdToken tkValueTypeToken = 0;
                 int kk; // Use one set of variables for regular statics, and the other set for thread statics
-                
+
                 fSkip = GetStaticFieldElementTypeForFieldDef(this, pImport, field, &ElementType, &tkValueTypeToken, &kk);
                 if (fSkip)
                     continue;
 
-                // We account for "regular statics" and "thread statics" separately. 
+                // We account for "regular statics" and "thread statics" separately.
                 // Currently we are lumping RVA into "regular statics",
                 // but we probably shouldn't.
                 switch (ElementType)
@@ -2068,27 +2068,27 @@ void Module::BuildStaticsOffsets(AllocMemTracker *pamTracker)
 
             if (pRegularStaticOffsets == NULL && (dwClassGCHandles[0] != 0 || dwClassNonGCBytes[0] != 0))
             {
-                // Lazily allocate table for offsets. We need offsets for GC and non GC areas. We add +1 to use as a sentinel. 
+                // Lazily allocate table for offsets. We need offsets for GC and non GC areas. We add +1 to use as a sentinel.
                 pRegularStaticOffsets = (PTR_DWORD)pamTracker->Track(
                     GetLoaderAllocator()->GetHighFrequencyHeap()->AllocMem(
                         (S_SIZE_T(2 * sizeof(DWORD))*(S_SIZE_T(dwNumTypes)+S_SIZE_T(1)))));
 
                 for (DWORD i = 0; i < dwIndex; i++) {
                     pRegularStaticOffsets[i * 2    ] = dwGCHandles[0]*TARGET_POINTER_SIZE;
-                    pRegularStaticOffsets[i * 2 + 1] = dwNonGCBytes[0];                    
+                    pRegularStaticOffsets[i * 2 + 1] = dwNonGCBytes[0];
                 }
             }
 
             if (pThreadStaticOffsets == NULL && (dwClassGCHandles[1] != 0 || dwClassNonGCBytes[1] != 0))
             {
-                // Lazily allocate table for offsets. We need offsets for GC and non GC areas. We add +1 to use as a sentinel. 
+                // Lazily allocate table for offsets. We need offsets for GC and non GC areas. We add +1 to use as a sentinel.
                 pThreadStaticOffsets = (PTR_DWORD)pamTracker->Track(
                     GetLoaderAllocator()->GetHighFrequencyHeap()->AllocMem(
                         (S_SIZE_T(2 * sizeof(DWORD))*(S_SIZE_T(dwNumTypes)+S_SIZE_T(1)))));
 
                 for (DWORD i = 0; i < dwIndex; i++) {
                     pThreadStaticOffsets[i * 2    ] = dwGCHandles[1]*TARGET_POINTER_SIZE;
-                    pThreadStaticOffsets[i * 2 + 1] = dwNonGCBytes[1];                    
+                    pThreadStaticOffsets[i * 2 + 1] = dwNonGCBytes[1];
                 }
             }
         }
@@ -2101,7 +2101,7 @@ void Module::BuildStaticsOffsets(AllocMemTracker *pamTracker)
             // Save current offsets
             pRegularStaticOffsets[dwIndex*2]     = dwGCHandles[0]*TARGET_POINTER_SIZE;
             pRegularStaticOffsets[dwIndex*2 + 1] = dwNonGCBytes[0];
-        
+
             // Increment for next class
             dwGCHandles[0]  += dwClassGCHandles[0];
             dwNonGCBytes[0] += dwClassNonGCBytes[0];
@@ -2115,7 +2115,7 @@ void Module::BuildStaticsOffsets(AllocMemTracker *pamTracker)
             // Save current offsets
             pThreadStaticOffsets[dwIndex*2]     = dwGCHandles[1]*TARGET_POINTER_SIZE;
             pThreadStaticOffsets[dwIndex*2 + 1] = dwNonGCBytes[1];
-        
+
             // Increment for next class
             dwGCHandles[1]  += dwClassGCHandles[1];
             dwNonGCBytes[1] += dwClassNonGCBytes[1];
@@ -2295,7 +2295,7 @@ void Module::InitializeDynamicILCrst()
 //                      is this a permanent override that should go in the
 //                      DynamicILBlobTable, or a temporary one?
 //     Output: not explicit, but if the pair was not already in the table it will be added.
-//             Does not add duplicate tokens to the table. 
+//             Does not add duplicate tokens to the table.
 
 void Module::SetDynamicIL(mdToken token, TADDR blobAddress, BOOL fTemporaryOverride)
 {
@@ -2309,9 +2309,9 @@ void Module::SetDynamicIL(mdToken token, TADDR blobAddress, BOOL fTemporaryOverr
     }
 
     CrstHolder ch(m_debuggerSpecificData.m_pDynamicILCrst);
-   
+
     // Figure out which table to fill in
-    PTR_DynamicILBlobTable &table(fTemporaryOverride ? m_debuggerSpecificData.m_pTemporaryILBlobTable 
+    PTR_DynamicILBlobTable &table(fTemporaryOverride ? m_debuggerSpecificData.m_pTemporaryILBlobTable
                                                      : m_debuggerSpecificData.m_pDynamicILBlobTable);
 
     // Lazily allocate the hash table.
@@ -2345,7 +2345,7 @@ TADDR Module::GetDynamicIL(mdToken token, BOOL fAllowTemporary)
 
     CrstHolder ch(m_debuggerSpecificData.m_pDynamicILCrst);
 #endif
- 
+
     // Both hash tables are lazily allocated, so if they're NULL
     // then we have no IL blobs
 
@@ -2359,7 +2359,7 @@ TADDR Module::GetDynamicIL(mdToken token, BOOL fAllowTemporary)
             return entry.m_il;
         }
     }
- 
+
     if (m_debuggerSpecificData.m_pDynamicILBlobTable == NULL)
     {
         return TADDR(NULL);
@@ -2397,7 +2397,7 @@ void Module::SetInstrumentedILOffsetMapping(mdMethodDef token, InstrumentedILOff
     }
 
     CrstHolder ch(m_debuggerSpecificData.m_pDynamicILCrst);
-   
+
     // Lazily allocate the hash table.
     if (m_debuggerSpecificData.m_pILOffsetMappingTable == NULL)
     {
@@ -2448,8 +2448,8 @@ InstrumentedILOffsetMapping Module::GetInstrumentedILOffsetMapping(mdMethodDef t
     }
 
     CrstHolder ch(m_debuggerSpecificData.m_pDynamicILCrst);
- 
-    // If the hash table hasn't been created, then we couldn't possibly have added any mapping yet, 
+
+    // If the hash table hasn't been created, then we couldn't possibly have added any mapping yet,
     // so just return NULL.
     if (m_debuggerSpecificData.m_pILOffsetMappingTable == NULL)
     {
@@ -2467,7 +2467,7 @@ InstrumentedILOffsetMapping Module::GetInstrumentedILOffsetMapping(mdMethodDef t
 
 
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
 
 
 BOOL Module::IsNoStringInterning()
@@ -2488,22 +2488,22 @@ BOOL Module::IsNoStringInterning()
         BOOL fNoStringInterning = FALSE;
 
         HRESULT hr;
-        
+
         // This flag applies to assembly, but it is stored on module so it can be cached in ngen image
         // Thus, we should ever need it for manifest module only.
         IMDInternalImport *mdImport = GetAssembly()->GetManifestImport();
         _ASSERTE(mdImport);
-        
+
         mdToken token;
         IfFailThrow(mdImport->GetAssemblyFromScope(&token));
-        
+
         const BYTE *pVal;
         ULONG       cbVal;
-        
+
         hr = mdImport->GetCustomAttributeByName(token,
                         COMPILATIONRELAXATIONS_TYPE,
                         (const void**)&pVal, &cbVal);
-        
+
         // Parse the attribute
         if (hr == S_OK)
         {
@@ -2595,20 +2595,20 @@ BOOL Module::IsRuntimeWrapExceptions()
     {
         // The flags should be precomputed in native images
         _ASSERTE(!HasNativeImage());
-        
+
         HRESULT hr;
         BOOL fRuntimeWrapExceptions = FALSE;
-        
+
         // This flag applies to assembly, but it is stored on module so it can be cached in ngen image
         // Thus, we should ever need it for manifest module only.
         IMDInternalImport *mdImport = GetAssembly()->GetManifestImport();
-        
+
         mdToken token;
         IfFailGo(mdImport->GetAssemblyFromScope(&token));
-        
+
         const BYTE *pVal;
         ULONG       cbVal;
-        
+
         hr = mdImport->GetCustomAttributeByName(token,
                         RUNTIMECOMPATIBILITY_TYPE,
                         (const void**)&pVal, &cbVal);
@@ -2618,15 +2618,15 @@ BOOL Module::IsRuntimeWrapExceptions()
         {
             CustomAttributeParser ca(pVal, cbVal);
             CaNamedArg namedArgs[1] = {{0}};
-            
+
             // First, the void constructor:
             IfFailGo(ParseKnownCaArgs(ca, NULL, 0));
-            
+
             // Then, find the named argument
             namedArgs[0].InitBoolField("WrapNonExceptionThrows");
-            
+
             IfFailGo(ParseKnownCaNamedArgs(ca, namedArgs, lengthof(namedArgs)));
-            
+
             if (namedArgs[0].val.boolean)
                 fRuntimeWrapExceptions = TRUE;
         }
@@ -2634,7 +2634,7 @@ ErrExit:
         FastInterlockOr(&m_dwPersistedFlags, COMPUTED_WRAP_EXCEPTIONS |
             (fRuntimeWrapExceptions ? WRAP_EXCEPTIONS : 0));
     }
-    
+
     return !!(m_dwPersistedFlags & WRAP_EXCEPTIONS);
 }
 
@@ -2651,10 +2651,10 @@ BOOL Module::IsPreV4Assembly()
     {
         // The flags should be precomputed in native images
         _ASSERTE(!HasNativeImage());
-        
+
         IMDInternalImport *pImport = GetAssembly()->GetManifestImport();
         _ASSERTE(pImport);
-        
+
         BOOL fIsPreV4Assembly = FALSE;
         LPCSTR szVersion = NULL;
         if (SUCCEEDED(pImport->GetVersionString(&szVersion)))
@@ -2840,7 +2840,7 @@ BOOL Module::IsStaticStoragePrepared(mdTypeDef tkType)
     // and a 2nd pass for it at module init time for modules that weren't NGENed or the NGEN
     // pass was unsucessful. If we are loading types after that then we must use dynamic
     // static storage. These dynamic statics require an additional indirection so they
-    // don't perform quite as well. 
+    // don't perform quite as well.
     //
     // This check was created for the scenario where a profiler adds additional types
     // however it seems likely this check would also accurately handle other dynamic
@@ -2883,7 +2883,7 @@ void Module::AllocateStatics(AllocMemTracker *pamTracker)
     BuildStaticsOffsets(pamTracker);
 }
 
-// This method will report GC static refs of the module. It doesn't have to be complete (ie, it's 
+// This method will report GC static refs of the module. It doesn't have to be complete (ie, it's
 // currently used to opportunistically get more concurrency in the marking of statics), so it currently
 // ignores any statics that are not preallocated (ie: won't report statics from IsDynamicStatics() MT)
 // The reason this function is in Module and not in DomainFile (together with DomainLocalModule is because
@@ -2891,7 +2891,7 @@ void Module::AllocateStatics(AllocMemTracker *pamTracker)
 // a table in DomainLocalBlock that's indexed with a module ID
 //
 // This method is a secondary way for the GC to find statics, and it is only used when we are on
-// a multiproc machine and we are using the ServerHeap. The primary way used by the GC to find 
+// a multiproc machine and we are using the ServerHeap. The primary way used by the GC to find
 // statics is through the handle table. Module::AllocateRegularStaticHandles() allocates a GC handle
 // from the handle table, and the GC will trace this handle and find the statics.
 
@@ -2904,8 +2904,8 @@ void Module::EnumRegularStaticGCRefs(promote_func* fn, ScanContext* sc)
     }
     CONTRACT_END;
 
-    _ASSERTE(GCHeapUtilities::IsGCInProgress() && 
-         GCHeapUtilities::IsServerHeap() && 
+    _ASSERTE(GCHeapUtilities::IsGCInProgress() &&
+         GCHeapUtilities::IsServerHeap() &&
          IsGCSpecialThread());
 
 
@@ -3195,8 +3195,8 @@ void Module::FreeClassTables()
 
     // disable ibc here because it can cause errors during the destruction of classes
     IBCLoggingDisabler disableLogging;
-            
-#if _DEBUG 
+
+#if _DEBUG
     DebugLogRidMapOccupancy();
 #endif
 
@@ -3239,7 +3239,7 @@ void Module::FreeClassTables()
                     if (pMT->HasCCWTemplate() && (!pMT->IsZapped() || pMT->GetZapModule() == this))
                     {
                         // code:MethodTable::GetComCallWrapperTemplate() may go through canonical methodtable indirection cell.
-                        // The module load could be aborted before completing code:FILE_LOAD_EAGER_FIXUPS phase that's responsible 
+                        // The module load could be aborted before completing code:FILE_LOAD_EAGER_FIXUPS phase that's responsible
                         // for resolving pre-restored indirection cells, so we have to check for it here explicitly.
                         if (CORCOMPILE_IS_POINTER_TAGGED(pMT->GetCanonicalMethodTableFixup()))
                             continue;
@@ -3292,13 +3292,13 @@ PTR_BaseDomain Module::GetDomain()
     return m_pAssembly->GetDomain();
 }
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
 
 #ifndef CROSSGEN_COMPILE
 void Module::StartUnload()
 {
     WRAPPER_NO_CONTRACT;
-#ifdef PROFILING_SUPPORTED 
+#ifdef PROFILING_SUPPORTED
     {
         BEGIN_PIN_PROFILER(CORProfilerTrackModuleLoads());
         if (!IsBeingUnloaded())
@@ -3359,13 +3359,13 @@ void Module::ReleaseILData(void)
 //
 BOOL Module::IsWindowsRuntimeModule()
 {
-    CONTRACTL 
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         CAN_TAKE_LOCK;     // Accesses metadata directly, which takes locks
         MODE_ANY;
-    } 
+    }
     CONTRACTL_END;
 
     BOOL fRet = FALSE;
@@ -3476,13 +3476,13 @@ BOOL Module::IsInSameVersionBubble(Module *target)
 //
 HRESULT Module::GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, LPVOID * ppvInterface)
 {
-    CONTRACTL 
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         CAN_TAKE_LOCK;     // IsWindowsRuntimeModule accesses metadata directly, which takes locks
         MODE_ANY;
-    } 
+    }
     CONTRACTL_END;
 
     _ASSERTE((dwOpenFlags & ofWrite) == 0);
@@ -3495,7 +3495,7 @@ HRESULT Module::GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID rii
     // to do a Release() (either the interface was internal and not AddRef'd, or was
     // public and will be released by the above holder).
     IUnknown * pIUnk = NULL;
-    
+
     HRESULT hr = S_OK;
 
     // Normally, we just get an RWImporter to do the QI on, and we're on our way.
@@ -3534,13 +3534,13 @@ HRESULT Module::GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID rii
         // Now that the pieces are ready, we can use the riid specified by the
         // profiler in this call to the dispenser to get the requested interface. If
         // this fails, then this is the interesting HRESULT for the caller to see.
-        // 
+        //
         // We'll get an AddRef'd public interface, so use a holder to release it
         hr = pDispenser->OpenScopeOnMemory(
-            pvMetadata, 
-            cbMetadata, 
+            pvMetadata,
+            cbMetadata,
             (dwOpenFlags | ofReadOnly),         // Force ofReadOnly on behalf of the profiler
-            riid, 
+            riid,
             &pIUnkPublic);
         if (FAILED(hr))
             return hr;
@@ -3586,9 +3586,9 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReaderNoThrow(void)
     {
         // We swallow any exception and say that we simply couldn't get a reader by returning NULL.
         // The only type of error that should be possible here is OOM.
-        /* DISABLED due to Dev10 bug 619495 
+        /* DISABLED due to Dev10 bug 619495
         CONSISTENCY_CHECK_MSG(
-            GET_EXCEPTION()->GetHR() == E_OUTOFMEMORY, 
+            GET_EXCEPTION()->GetHR() == E_OUTOFMEMORY,
             "Exception from GetISymUnmanagedReader");
          */
     }
@@ -3626,7 +3626,7 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
     // work is done by the security system which caches the result.
     if( m_pISymUnmanagedReader == NULL && !IsSymbolReadingEnabled() )
         RETURN NULL;
-    
+
     // Take the lock for the m_pISymUnmanagedReader
     // This ensures that we'll only ever attempt to create one reader at a time, and we won't
     // create a reader if we're in the middle of destroying one that has become stale.
@@ -3654,7 +3654,7 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
         bool fInMemorySymbols = ( m_file->IsIStream() || GetInMemorySymbolStream() );
         if( !fInMemorySymbols && m_file->GetPath().IsEmpty() )
         {
-            // Case 4.  We don't have a module path, an IStream or an in memory symbol stream, 
+            // Case 4.  We don't have a module path, an IStream or an in memory symbol stream,
             // so there is no-where to try and get symbols from.
             RETURN (NULL);
         }
@@ -3685,7 +3685,7 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
         else
         {
             // We're going to be working with Windows PDB format symbols. Attempt to CoCreate the symbol binder.
-            // CoreCLR supports not having a symbol reader installed, so CoCreate searches the PATH env var 
+            // CoreCLR supports not having a symbol reader installed, so CoCreate searches the PATH env var
             // and then tries coreclr dll location.
             // On desktop, the framework installer is supposed to install diasymreader.dll as well
             // and so this shouldn't happen.
@@ -3715,7 +3715,7 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
 
         SafeComHolder<ISymUnmanagedReader> pReader;
 
-        if (fInMemorySymbols) 
+        if (fInMemorySymbols)
         {
             SafeComHolder<IStream> pIStream( NULL );
 
@@ -3723,10 +3723,10 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
             // This is the common case for case 2 (hosted modules) and case 3 (Ref.Emit).
             if (GetInMemorySymbolStream() )
             {
-                
+
                 if( IsReflection() )
                 {
-                    // If this is Reflection.Emit, we must clone the stream because another thread may 
+                    // If this is Reflection.Emit, we must clone the stream because another thread may
                     // update it when someone is using the reader we create here leading to AVs.
                     // Note that the symbol stream should be up to date since we flush the writer
                     // after every addition in Module::AddClass.
@@ -3753,7 +3753,7 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
             // trying to get a symbol reader. This has to be done once per
             // Assembly.
             // for this to work with winmds we cannot simply call GetRWImporter() as winmds are RO
-            // and thus don't implement the RW interface. so we call this wrapper function which knows 
+            // and thus don't implement the RW interface. so we call this wrapper function which knows
             // how to get a IMetaDataImport interface regardless of the underlying module type.
             ReleaseHolder<IUnknown> pUnk = NULL;
             hr = GetReadablePublicMetaDataInterface(ofReadOnly, IID_IMetaDataImport, &pUnk);
@@ -3808,7 +3808,7 @@ BOOL Module::IsSymbolReadingEnabled()
         return TRUE;
     }
 
-#ifdef DEBUGGING_SUPPORTED 
+#ifdef DEBUGGING_SUPPORTED
     if (!g_pDebugInterface)
     {
         // if debugging is disabled (no debug pack installed), do not load symbols
@@ -3843,12 +3843,12 @@ void Module::SetSymbolBytes(LPCBYTE pbSyms, DWORD cbSyms)
 
     // This can only be called when the module is being created.  No-one should have
     // tried to use the symbols yet, and so there should not be a reader.
-    // If instead, we wanted to call this when a reader could have been created, we need to 
-    // serialize access by taking the reader lock, and flush the old reader by calling 
+    // If instead, we wanted to call this when a reader could have been created, we need to
+    // serialize access by taking the reader lock, and flush the old reader by calling
     // code:Module.ReleaseISymUnmanagedReader
     _ASSERTE( m_pISymUnmanagedReader == NULL );
-    
-#ifdef LOGGING 
+
+#ifdef LOGGING
     LPCWSTR pName = NULL;
     pName = GetDebugName();
 #endif // LOGGING
@@ -3968,7 +3968,7 @@ void Module::AddClass(mdTypeDef classdef)
         BuildClassForModule();
     }
 
-    // Since the module is being modified, the in-memory symbol stream 
+    // Since the module is being modified, the in-memory symbol stream
     // (if any) has probably also been modified. If we support reading the symbols
     // then we need to commit the changes to the writer and flush any old readers
     // However if we don't support reading then we can skip this which will give
@@ -3991,7 +3991,7 @@ void Module::AddClass(mdTypeDef classdef)
             CrstHolder holder(&m_ISymUnmanagedReaderCrst);
 
             // Flush writes to the symbol store to the symbol stream
-            // Note that we do this when finishing the addition of the class, instead of 
+            // Note that we do this when finishing the addition of the class, instead of
             // on-demand in GetISymUnmanagedReader because the writer is not thread-safe.
             // Here, we're inside the lock of TypeBuilder.CreateType, and so it's safe to
             // manipulate the writer.
@@ -4063,16 +4063,16 @@ void Module::BuildClassForModule()
 #endif // !DACCESS_COMPILE
 
 // Returns true iff the debugger should be notified about this module
-// 
+//
 // Notes:
 //   Debugger doesn't need to be notified about modules that can't be executed,
 //   like inspection and resource only. These are just pure data.
-//   
+//
 //   This should be immutable for an instance of a module. That ensures that the debugger gets consistent
 //   notifications about it. It this value mutates, than the debugger may miss relevant notifications.
 BOOL Module::IsVisibleToDebugger()
 {
-    WRAPPER_NO_CONTRACT; 
+    WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
 
     if (IsResource())
@@ -4172,7 +4172,7 @@ PTR_VOID Module::GetRvaField(DWORD rva, BOOL fZapped)
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
 
-#ifdef FEATURE_PREJIT 
+#ifdef FEATURE_PREJIT
     if (fZapped && m_file->IsILOnly())
     {
         return dac_cast<PTR_VOID>(m_file->GetLoadedNative()->GetRvaData(rva,NULL_OK));
@@ -4182,7 +4182,7 @@ PTR_VOID Module::GetRvaField(DWORD rva, BOOL fZapped)
     return m_file->GetRvaField(rva);
 }
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
 
 CHECK Module::CheckRvaField(RVA field)
 {
@@ -4302,13 +4302,13 @@ void Module::InitializeStringData(DWORD token, EEStringData *pstrData, CQuickByt
     BOOL fIs80Plus;
     DWORD dwCharCount;
     LPCWSTR pString;
-    if (FAILED(GetMDImport()->GetUserString(token, &dwCharCount, &fIs80Plus, &pString)) || 
+    if (FAILED(GetMDImport()->GetUserString(token, &dwCharCount, &fIs80Plus, &pString)) ||
         (pString == NULL))
     {
         THROW_BAD_FORMAT(BFA_BAD_STRING_TOKEN_RANGE, this);
     }
-    
-#if !BIGENDIAN 
+
+#if !BIGENDIAN
     pstrData->SetStringBuffer(pString);
 #else // !!BIGENDIAN
     _ASSERTE(pqb != NULL);
@@ -4332,9 +4332,9 @@ void Module::InitializeStringData(DWORD token, EEStringData *pstrData, CQuickByt
 
 #ifndef CROSSGEN_COMPILE
 
-#ifdef FEATURE_PREJIT 
+#ifdef FEATURE_PREJIT
 OBJECTHANDLE Module::ResolveStringRefHelper(DWORD token, BaseDomain *pDomain, PTR_CORCOMPILE_IMPORT_SECTION pSection, EEStringData *pStrData)
-{        
+{
     PEImageLayout *pNativeImage = GetNativeImage();
 
     // Get the table
@@ -4354,7 +4354,7 @@ OBJECTHANDLE Module::ResolveStringRefHelper(DWORD token, BaseDomain *pDomain, PT
             BYTE * pBlob = (BYTE *) pNativeImage->GetRvaData(CORCOMPILE_UNTAG_TOKEN(entry));
 
             // Note that we only care about strings from current module, and so we do not check ENCODE_MODULE_OVERRIDE
-            if (*pBlob++ == ENCODE_STRING_HANDLE && 
+            if (*pBlob++ == ENCODE_STRING_HANDLE &&
                     TokenFromRid(CorSigUncompressData((PCCOR_SIGNATURE&) pBlob), mdtString) ==  token)
             {
                 // This string hasn't been fixed up. Synchronize the update with the normal
@@ -4413,7 +4413,7 @@ OBJECTHANDLE Module::ResolveStringRef(DWORD token, BaseDomain *pDomain, bool bNe
     EEStringData strData;
     OBJECTHANDLE string = NULL;
 
-#if !BIGENDIAN 
+#if !BIGENDIAN
     InitializeStringData(token, &strData, NULL);
 #else // !!BIGENDIAN
     CQuickBytes qb;
@@ -4425,7 +4425,7 @@ OBJECTHANDLE Module::ResolveStringRef(DWORD token, BaseDomain *pDomain, bool bNe
     // We can only do this for native images as they guarantee that resolvestringref will be
     // called only once per string from this module. @TODO: We really dont have any way of asserting
     // this, which would be nice... (and is needed to guarantee correctness)
-#ifdef FEATURE_PREJIT 
+#ifdef FEATURE_PREJIT
     if (HasNativeImage() && IsNoStringInterning())
     {
         if (bNeedToSyncWithFixups)
@@ -4475,12 +4475,12 @@ OBJECTHANDLE Module::ResolveStringRef(DWORD token, BaseDomain *pDomain, bool bNe
 
         */
         /*
-        Dev10 804385 bugfix - 
+        Dev10 804385 bugfix -
            We should be using appdomain that the string token lives in (GetAssembly->GetDomain())
            to allocate the System.String object instead of the appdomain that first uses the ldstr <token> (pDomain).
 
-           Otherwise, it is possible to get into the situation that pDomain is unloaded but GetAssembly->GetDomain() is 
-           still kicking around. Anything else that is still using that string will now be pointing to an object 
+           Otherwise, it is possible to get into the situation that pDomain is unloaded but GetAssembly->GetDomain() is
+           still kicking around. Anything else that is still using that string will now be pointing to an object
            that will be freed when the next GC happens.
         */
         pDomain = GetAssembly()->GetDomain();
@@ -4496,7 +4496,7 @@ OBJECTHANDLE Module::ResolveStringRef(DWORD token, BaseDomain *pDomain, bool bNe
         STRINGREF str = AllocateStringObject(&strData);
         SetObjectReference(pRef, str);
 
-        #ifdef LOGGING 
+        #ifdef LOGGING
         int length = strData.GetCharCount();
         length = min(length, 100);
         WCHAR *szString = (WCHAR *)_alloca((length + 1) * sizeof(WCHAR));
@@ -4518,7 +4518,7 @@ INTERN_OLD_STYLE:
         pLoaderAllocator = this->GetLoaderAllocator();
     else
         pLoaderAllocator = pDomain->GetLoaderAllocator();
-        
+
     string = (OBJECTHANDLE)pLoaderAllocator->GetStringObjRefPtrFromUnicodeString(&strData);
 
     return string;
@@ -4652,7 +4652,7 @@ Assembly * Module::GetAssemblyIfLoadedFromNativeAssemblyRefWithRefDefMismatch(md
         {
             // Find out if THIS reference is satisfied
             // Specify fDoNotUtilizeExtraChecks to prevent recursion
-            Assembly *pAssemblyCandidate = this->GetAssemblyIfLoaded(foundAssemblyDef, NULL, NULL, pImportFoundNativeImage, TRUE /*fDoNotUtilizeExtraChecks*/); 
+            Assembly *pAssemblyCandidate = this->GetAssemblyIfLoaded(foundAssemblyDef, NULL, NULL, pImportFoundNativeImage, TRUE /*fDoNotUtilizeExtraChecks*/);
 
             // This extended check is designed only to find assemblies loaded via an AssemblySpecBindingCache based binder. Verify that's what we found.
             if(pAssemblyCandidate != NULL)
@@ -4678,15 +4678,15 @@ Assembly * Module::GetAssemblyIfLoadedFromNativeAssemblyRefWithRefDefMismatch(md
 #endif // !defined(DACCESS_COMPILE) && defined(FEATURE_PREJIT)
 
 // Fills ppContainingWinRtAppDomain only if WinRT type name is passed and if the assembly is found (return value != NULL).
-Assembly * 
+Assembly *
 Module::GetAssemblyIfLoaded(
-    mdAssemblyRef       kAssemblyRef, 
+    mdAssemblyRef       kAssemblyRef,
     LPCSTR              szWinRtNamespace,   // = NULL
     LPCSTR              szWinRtClassName,   // = NULL
     IMDInternalImport * pMDImportOverride,  // = NULL
     BOOL                fDoNotUtilizeExtraChecks, // = FALSE
     ICLRPrivBinder      *pBindingContextForLoadedAssembly // = NULL
-)    
+)
 {
     CONTRACT(Assembly *)
     {
@@ -4720,7 +4720,7 @@ Module::GetAssemblyIfLoaded(
     {
         pAssembly = LookupAssemblyRef(kAssemblyRef);
     }
-    
+
 #ifndef DACCESS_COMPILE
     // Check if actually loaded, unless a GC is in progress or the current thread is
     // walking the stack (either its own stack, or another thread's stack) as that works
@@ -4736,15 +4736,15 @@ Module::GetAssemblyIfLoaded(
         DomainAssembly * pDomainAssembly = pAssembly->GetDomainAssembly();
         if ((pDomainAssembly == NULL) || !pDomainAssembly->IsLoaded())
             pAssembly = NULL;
-    }   
+    }
 #endif //!DACCESS_COMPILE
-    
+
     if (pAssembly == NULL)
     {
         do
         {
             AppDomain * pAppDomainExamine = AppDomain::GetCurrentDomain();
-            
+
             DomainAssembly * pCurAssemblyInExamineDomain = GetAssembly()->GetDomainAssembly();
             if (pCurAssemblyInExamineDomain == NULL)
             {
@@ -4755,23 +4755,23 @@ Module::GetAssemblyIfLoaded(
             if (szWinRtNamespace != NULL)
             {
                 _ASSERTE(szWinRtClassName != NULL);
-                
+
                 CLRPrivBinderWinRT * pWinRtBinder = pAppDomainExamine->GetWinRtBinder();
                 if (pWinRtBinder != nullptr)
                 {
                     ENABLE_FORBID_GC_LOADER_USE_IN_THIS_SCOPE();
                     pAssembly = pWinRtBinder->FindAssemblyForTypeIfLoaded(
-                        dac_cast<PTR_AppDomain>(pAppDomainExamine), 
-                        szWinRtNamespace, 
+                        dac_cast<PTR_AppDomain>(pAppDomainExamine),
+                        szWinRtNamespace,
                         szWinRtClassName);
                 }
-                
+
                 // Never store WinMD AssemblyRefs into the rid map.
                 if (pAssembly != NULL)
                 {
                     break;
                 }
-                
+
                 // Never attemt to search the assembly spec binding cache for this form of WinRT assembly reference.
                 continue;
             }
@@ -4780,20 +4780,20 @@ Module::GetAssemblyIfLoaded(
 #ifndef DACCESS_COMPILE
             {
                 IMDInternalImport * pMDImport = (pMDImportOverride == NULL) ? (GetMDImport()) : (pMDImportOverride);
-                
+
                 //we have to be very careful here.
-                //we are using InitializeSpecInternal so we need to make sure that under no condition 
+                //we are using InitializeSpecInternal so we need to make sure that under no condition
                 //the data we pass to it can outlive the assembly spec.
                 AssemblySpec spec;
-                if (FAILED(spec.InitializeSpecInternal(kAssemblyRef, 
-                                                       pMDImport, 
+                if (FAILED(spec.InitializeSpecInternal(kAssemblyRef,
+                                                       pMDImport,
                                                        pCurAssemblyInExamineDomain,
                                                        FALSE /*fAllowAllocation*/)))
                 {
                     continue;
                 }
 
-                // If we have been passed the binding context for the loaded assembly that is being looked up in the 
+                // If we have been passed the binding context for the loaded assembly that is being looked up in the
                 // cache, then set it up in the AssemblySpec for the cache lookup to use it below.
                 if (pBindingContextForLoadedAssembly != NULL)
                 {
@@ -4846,13 +4846,13 @@ Module::GetAssemblyIfLoaded(
         {
             IMDInternalImport * pMDImport = (pMDImportOverride == NULL) ? (GetMDImport()) : (pMDImportOverride);
 
-            if (FAILED(specSearchAssemblyRef.InitializeSpecInternal(kAssemblyRef, 
-                                                    pMDImport, 
+            if (FAILED(specSearchAssemblyRef.InitializeSpecInternal(kAssemblyRef,
+                                                    pMDImport,
                                                     NULL,
                                                     FALSE /*fAllowAllocation*/)))
             {
                 eligibleForAdditionalChecks = FALSE; // If an assemblySpec can't be constructed then we're not going to succeed
-                                                     // This should not ever happen, due to the above checks, but this logic 
+                                                     // This should not ever happen, due to the above checks, but this logic
                                                      // is intended to be defensive against unexpected behavior.
             }
             else if (specSearchAssemblyRef.IsContentType_WindowsRuntime())
@@ -4869,7 +4869,7 @@ Module::GetAssemblyIfLoaded(
             bool onlyScanCurrentModule = HasNativeImage() && GetFile()->IsAssembly();
             mdAssemblyRef foundAssemblyRef = mdAssemblyRefNil;
 
-            // In each AppDomain that might be interesting, scan for an ngen image that is loaded that has a dependency on the same 
+            // In each AppDomain that might be interesting, scan for an ngen image that is loaded that has a dependency on the same
             // assembly that is now being looked up. If that ngen image has the same dependency, then we can use the CORCOMPILE_DEPENDENCIES
             // table to find the exact AssemblyDef that defines the assembly, and attempt a load based on that information.
             // As this logic is expected to be used only in exceedingly rare situations, this code has not been tuned for performance
@@ -4877,7 +4877,7 @@ Module::GetAssemblyIfLoaded(
             do
             {
                 AppDomain * pAppDomainExamine = ::GetAppDomain(); // There is only 1 AppDomain on CoreCLR
-            
+
                 DomainAssembly * pCurAssemblyInExamineDomain = GetAssembly()->GetDomainAssembly();
                 if (pCurAssemblyInExamineDomain == NULL)
                 {
@@ -4885,7 +4885,7 @@ Module::GetAssemblyIfLoaded(
                 }
 
                 DomainFile *pDomainFileNativeImage;
-                
+
                 if (onlyScanCurrentModule)
                 {
                     pDomainFileNativeImage = pCurAssemblyInExamineDomain;
@@ -4920,8 +4920,8 @@ Module::GetAssemblyIfLoaded(
                             while (pImportFoundNativeImage->EnumNext(&hAssemblyRefEnum, &assemblyRef) && (pAssembly == NULL))
                             {
                                 AssemblySpec specFoundAssemblyRef;
-                                if (FAILED(specFoundAssemblyRef.InitializeSpecInternal(assemblyRef, 
-                                                                        pImportFoundNativeImage, 
+                                if (FAILED(specFoundAssemblyRef.InitializeSpecInternal(assemblyRef,
+                                                                        pImportFoundNativeImage,
                                                                         NULL,
                                                                         FALSE /*fAllowAllocation*/)))
                                 {
@@ -4958,17 +4958,17 @@ Module::GetAssemblyIfLoaded(
     _ASSERTE((pAssembly != NULL) || !(IsStackWalkerThread() || IsGCThread()));
 
 #ifdef DACCESS_COMPILE
-    
+
     // Note: In rare cases when debugger walks the stack, we could actually have pAssembly=NULL here.
     // To fix that we should DACize the AppDomain-iteration code above (especially AssemblySpec).
     _ASSERTE(pAssembly != NULL);
-    
+
 #endif //DACCESS_COMPILE
-    
+
     RETURN pAssembly;
 } // Module::GetAssemblyIfLoaded
 
-DWORD 
+DWORD
 Module::GetAssemblyRefFlags(
     mdAssemblyRef tkAssemblyRef)
 {
@@ -4979,35 +4979,35 @@ Module::GetAssemblyRefFlags(
         MODE_ANY;
     }
     CONTRACTL_END;
-    
+
     _ASSERTE(TypeFromToken(tkAssemblyRef) == mdtAssemblyRef);
-    
+
     LPCSTR      pszAssemblyName;
     const void *pbPublicKeyOrToken;
     DWORD cbPublicKeyOrToken;
 
     DWORD dwAssemblyRefFlags;
     IfFailThrow(GetMDImport()->GetAssemblyRefProps(
-            tkAssemblyRef, 
-            &pbPublicKeyOrToken, 
-            &cbPublicKeyOrToken, 
-            &pszAssemblyName, 
-            NULL, 
-            NULL, 
-            NULL, 
+            tkAssemblyRef,
+            &pbPublicKeyOrToken,
+            &cbPublicKeyOrToken,
+            &pszAssemblyName,
+            NULL,
+            NULL,
+            NULL,
             &dwAssemblyRefFlags));
-    
+
     return dwAssemblyRefFlags;
 } // Module::GetAssemblyRefFlags
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
 
 // Arguments:
 //   szWinRtTypeNamespace ... Namespace of WinRT type.
 //   szWinRtTypeClassName ... Name of WinRT type, NULL for non-WinRT (classic) types.
 DomainAssembly * Module::LoadAssembly(
-    mdAssemblyRef kAssemblyRef, 
-    LPCUTF8       szWinRtTypeNamespace, 
+    mdAssemblyRef kAssemblyRef,
+    LPCUTF8       szWinRtTypeNamespace,
     LPCUTF8       szWinRtTypeClassName)
 {
     CONTRACT(DomainAssembly *)
@@ -5041,12 +5041,12 @@ DomainAssembly * Module::LoadAssembly(
     }
 
     bool fHasBindableIdentity = HasBindableIdentity(kAssemblyRef);
-    
+
     {
         PEAssemblyHolder pFile = GetDomainAssembly()->GetFile()->LoadAssembly(
-                kAssemblyRef, 
-                NULL, 
-                szWinRtTypeNamespace, 
+                kAssemblyRef,
+                NULL,
+                szWinRtTypeNamespace,
                 szWinRtTypeClassName);
         AssemblySpec spec;
         spec.InitializeSpec(kAssemblyRef, GetMDImport(), GetDomainAssembly());
@@ -5114,15 +5114,15 @@ Module *Module::GetModuleIfLoaded(mdFile kFile, BOOL onlyLoadedInAppDomain, BOOL
         {
             RETURN NULL;
         }
-        
+
         // This is required only because of some lower casing on the name
         kFile = GetAssembly()->GetManifestFileToken(moduleName);
         if (kFile == mdTokenNil)
             RETURN NULL;
-        
+
         RETURN GetAssembly()->GetManifestModule()->GetModuleIfLoaded(kFile, onlyLoadedInAppDomain, permitResources);
     }
-    
+
     Module *pModule = LookupFile(kFile);
     if (pModule == NULL)
     {
@@ -5136,7 +5136,7 @@ Module *Module::GetModuleIfLoaded(mdFile kFile, BOOL onlyLoadedInAppDomain, BOOL
             // If we didn't find it there, look at the "master rid map" in the manifest file
             Assembly *pAssembly = GetAssembly();
             mdFile kMatch;
-            
+
             // This is required only because of some lower casing on the name
             kMatch = pAssembly->GetManifestFileToken(GetMDImport(), kFile);
             if (IsNilToken(kMatch))
@@ -5153,13 +5153,13 @@ Module *Module::GetModuleIfLoaded(mdFile kFile, BOOL onlyLoadedInAppDomain, BOOL
             else
             pModule = pAssembly->GetManifestModule()->LookupFile(kMatch);
         }
-        
+
 #ifndef DACCESS_COMPILE
         if (pModule != NULL)
             StoreFileNoThrow(kFile, pModule);
 #endif
     }
-    
+
     // We may not want to return a resource module
     if (!permitResources && pModule && pModule->IsResource())
         pModule = NULL;
@@ -5220,7 +5220,7 @@ PTR_Module Module::LookupModule(mdToken kFile,BOOL permitResources/*=TRUE*/)
         INSTANCE_CHECK;
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
-        if (FORBIDGC_LOADER_USE_ENABLED()) FORBID_FAULT; 
+        if (FORBIDGC_LOADER_USE_ENABLED()) FORBID_FAULT;
         else { INJECT_FAULT(COMPlusThrowOM()); }
         MODE_ANY;
         PRECONDITION(TypeFromToken(kFile) == mdtFile
@@ -5229,7 +5229,7 @@ PTR_Module Module::LookupModule(mdToken kFile,BOOL permitResources/*=TRUE*/)
         SUPPORTS_DAC;
     }
     CONTRACT_END;
-    
+
     if (TypeFromToken(kFile) == mdtModuleRef)
     {
         LPCSTR moduleName;
@@ -5285,11 +5285,11 @@ TypeHandle Module::LookupTypeRef(mdTypeRef token)
     // @PERF: Enable this so that we do not need to touch metadata
     // to resolve typerefs
 
-#ifdef FIXUPS_ALL_TYPEREFS 
+#ifdef FIXUPS_ALL_TYPEREFS
 
     if (CORCOMPILE_IS_POINTER_TAGGED((SIZE_T) entry.AsPtr()))
     {
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
         Module::RestoreTypeHandlePointer(&entry, TRUE);
         m_TypeRefToMethodTableMap.SetElement(RidFromToken(token), dac_cast<PTR_TypeRef>(value.AsTAddr()));
 #else // DACCESS_COMPILE
@@ -5378,7 +5378,7 @@ mdMemberRef Module::LookupMemberRefByMethodDesc(MethodDesc *pMD)
 }
 #endif // FEATURE_NATIVE_IMAGE_GENERATION
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
 
 //
 // Increase the size of one of the maps, such that it can handle a RID of at least "rid".
@@ -5463,10 +5463,10 @@ PTR_TADDR LookupMapBase::GetElementPtr(DWORD rid)
 
     LookupMapBase * pMap = this;
 
-#ifdef FEATURE_PREJIT 
+#ifdef FEATURE_PREJIT
     if (pMap->dwNumHotItems > 0)
     {
-#ifdef _DEBUG_IMPL 
+#ifdef _DEBUG_IMPL
         static  DWORD counter = 0;
         counter++;
         if (counter >= pMap->dwNumHotItems)
@@ -5500,7 +5500,7 @@ PTR_TADDR LookupMapBase::GetElementPtr(DWORD rid)
 }
 
 
-#ifdef FEATURE_PREJIT 
+#ifdef FEATURE_PREJIT
 
 // This method can only be called on a compressed map (MapIsCompressed() == true). Compressed rid maps store
 // the array of values as packed deltas (each value is based on the accumulated of all the previous entries).
@@ -5649,7 +5649,7 @@ PTR_TADDR LookupMapBase::FindHotItemValuePtr(DWORD rid)
     return NULL;
 }
 
-#ifdef _DEBUG 
+#ifdef _DEBUG
 void LookupMapBase::CheckConsistentHotItemList()
 {
     LIMITED_METHOD_DAC_CONTRACT;
@@ -5706,7 +5706,7 @@ DWORD LookupMapBase::GetSize()
 
 #ifndef DACCESS_COMPILE
 
-#ifdef _DEBUG 
+#ifdef _DEBUG
 void LookupMapBase::DebugGetRidMapOccupancy(DWORD *pdwOccupied, DWORD *pdwSize)
 {
     LIMITED_METHOD_CONTRACT;
@@ -5832,7 +5832,7 @@ MethodDesc *Module::FindMethod(mdToken pMethod)
     }
     EX_CATCH
     {
-#ifdef _DEBUG 
+#ifdef _DEBUG
         CONTRACT_VIOLATION(ThrowsViolation);
         char szMethodName [MAX_CLASSNAME_LENGTH];
         CEEInfo::findNameOfToken(this, pMethod, szMethodName, COUNTOF (szMethodName));
@@ -5902,9 +5902,9 @@ HRESULT Module::GetPropertyInfoForMethodDef(mdMethodDef md, mdProperty *ppd, LPC
         MODE_ANY;
     }
     CONTRACTL_END;
-    
+
     HRESULT hr;
-    
+
     if ((m_dwPersistedFlags & COMPUTED_METHODDEF_TO_PROPERTYINFO_MAP) != 0)
     {
         SIZE_T value = m_MethodDefToPropertyInfoMap.GetElement(RidFromToken(md));
@@ -5931,28 +5931,28 @@ HRESULT Module::GetPropertyInfoForMethodDef(mdMethodDef md, mdProperty *ppd, LPC
                 *ppd = prop;
                 _ASSERTE(*ppd == dbgPd);
             }
-            
+
             if (pSemantic != NULL)
             {
                 *pSemantic = semantic;
                 _ASSERTE(*pSemantic == dbgSemantic);
             }
-            
+
             if (pName != NULL)
             {
                 IfFailRet(GetMDImport()->GetPropertyProps(prop, pName, NULL, NULL, NULL));
-                
+
 #ifdef _DEBUG
                 HRESULT hr = GetMDImport()->GetPropertyProps(prop, pName, NULL, NULL, NULL);
                 _ASSERTE(hr == S_OK);
                 _ASSERTE(strcmp(*pName, dbgName) == 0);
 #endif
             }
-            
+
             return S_OK;
         }
     }
-    
+
     return GetMDImport()->GetPropertyInfoForMethodDef(md, ppd, pName, pSemantic);
 }
 
@@ -5976,7 +5976,7 @@ void Module::PrecomputeMatchingProperties(DataImage *image)
     {
         return;
     }
-    
+
     m_propertyNameSet = new (image->GetHeap()) BYTE[m_nPropertyNameSet];
 
     DWORD nEnumeratedProperties = 0;
@@ -6171,20 +6171,20 @@ void Module::UpdateDynamicMetadataIfNeeded()
     }
 
     // Since serializing metadata to an auxillary buffer is only needed by the debugger,
-    // we should only be doing this for modules that the debugger can see. 
+    // we should only be doing this for modules that the debugger can see.
     if (!IsVisibleToDebugger())
     {
         return;
     }
 
-    
+
     HRESULT hr = S_OK;
     EX_TRY
     {
         GetReflectionModule()->CaptureModuleMetaDataToMemory();
     }
     EX_CATCH_HRESULT(hr);
-    
+
     // This Metadata buffer is only used for the debugger, so it's a non-fatal exception for regular CLR execution.
     // Just swallow it and keep going. However, with the exception of out-of-memory, we do expect it to
     // succeed, so assert on failures.
@@ -6195,7 +6195,7 @@ void Module::UpdateDynamicMetadataIfNeeded()
 
 }
 
-#ifdef DEBUGGING_SUPPORTED 
+#ifdef DEBUGGING_SUPPORTED
 
 
 #endif // DEBUGGING_SUPPORTED
@@ -6218,10 +6218,10 @@ BOOL Module::NotifyDebuggerLoad(AppDomain *pDomain, DomainFile * pDomainFile, in
 
     //
     // Remaining work is only needed if a debugger is attached
-    // 
+    //
     if (!attaching && !pDomain->IsDebuggerAttached())
         return FALSE;
-        
+
 
     BOOL result = FALSE;
 
@@ -6230,9 +6230,9 @@ BOOL Module::NotifyDebuggerLoad(AppDomain *pDomain, DomainFile * pDomainFile, in
         g_pDebugInterface->LoadModule(this,
                                       m_file->GetPath(),
                                       m_file->GetPath().GetCount(),
-                                      GetAssembly(), 
-                                      pDomain, 
-                                      pDomainFile, 
+                                      GetAssembly(),
+                                      pDomain,
+                                      pDomainFile,
                                       attaching);
 
         result = TRUE;
@@ -6607,7 +6607,7 @@ void Module::FixupVTables()
                     MethodDesc *pMD = rgMethodsToLoad[iCurMethod].pMD;
                     iCurMethod++;
 
-#ifdef _DEBUG 
+#ifdef _DEBUG
                     if (pMD->IsNDirect())
                     {
                         LOG((LF_INTEROP, LL_INFO10, "[0x%lx] <-- PINV thunk for \"%s\" (target = 0x%lx)\n",
@@ -6627,7 +6627,7 @@ void Module::FixupVTables()
                 }
 
             }
-            else if (pFixupTable[iFixup].Type == (COR_VTABLE_PTRSIZED | COR_VTABLE_FROM_UNMANAGED) || 
+            else if (pFixupTable[iFixup].Type == (COR_VTABLE_PTRSIZED | COR_VTABLE_FROM_UNMANAGED) ||
                     (pFixupTable[iFixup].Type == (COR_VTABLE_PTRSIZED | COR_VTABLE_FROM_UNMANAGED_RETAIN_APPDOMAIN)))
             {
                 for (int iMethod = 0; iMethod < pFixupTable[iFixup].Count; iMethod++)
@@ -6745,7 +6745,7 @@ static TypeHandle LoadTypeDefOrRefHelper(DataImage * image, Module * pModule, md
     return th;
 }
 
-static TypeHandle LoadTypeSpecHelper(DataImage * image, Module * pModule, mdToken tk, 
+static TypeHandle LoadTypeSpecHelper(DataImage * image, Module * pModule, mdToken tk,
                                      PCCOR_SIGNATURE pSig, ULONG cSig)
 {
     STANDARD_VM_CONTRACT;
@@ -6849,7 +6849,7 @@ mdTypeDef Module::LookupIbcTypeToken(Module *  pExternalModule, mdToken ibcToken
     ibcName.tkIbcNestedClass = blobTypeDefEntry->nestedClassToken;
     ibcName.szNamespace      = NULL;
     ibcName.tkEnclosingClass = mdTypeDefNil;
-    
+
     if (!IsNilToken(blobTypeDefEntry->nameSpaceToken))
     {
         _ASSERTE(IsNilToken(blobTypeDefEntry->nestedClassToken));
@@ -6904,14 +6904,14 @@ mdTypeDef Module::LookupIbcTypeToken(Module *  pExternalModule, mdToken ibcToken
     //     LPCSTR      szName,                 // [IN] Name of the TypeDef.
     //     mdToken     tkEnclosingClass,       // [IN] TypeRef/TypeDef Token for the enclosing class.
     //     mdTypeDef   *ptypedef) PURE;        // [IN] return typedef
-    
+
     IMDInternalImport *pInternalImport = pExternalModule->GetMDImport();
 
     mdTypeDef mdResult = mdTypeDefNil;
 
     HRESULT hr = pInternalImport->FindTypeDef(ibcName.szNamespace, ibcName.szName, ibcName.tkEnclosingClass, &mdResult);
 
-    if(FAILED(hr)) 
+    if(FAILED(hr))
         mdResult = mdTypeDefNil;
 
     return mdResult;
@@ -6924,19 +6924,19 @@ struct IbcCompareContext
     DWORD            cMatch;      // count of methods that had a matching method name
     bool             useBestSig;  // if true we should use the BestSig when we don't find an exact match
     PCCOR_SIGNATURE  pvBestSig;   // Current Best matching signature
-    DWORD            cbBestSig;   // 
+    DWORD            cbBestSig;   //
 };
 
 //---------------------------------------------------------------------------------------
-// 
-// Compare two signatures from the same scope. 
-// 
-BOOL 
+//
+// Compare two signatures from the same scope.
+//
+BOOL
 CompareIbcMethodSigs(
     PCCOR_SIGNATURE pvCandidateSig, // Candidate signature
-    DWORD           cbCandidateSig, // 
+    DWORD           cbCandidateSig, //
     PCCOR_SIGNATURE pvIbcSignature, // The Ibc signature that we want to match
-    DWORD           cbIbcSignature, // 
+    DWORD           cbIbcSignature, //
     void *          pvContext)      // void pointer to IbcCompareContext
 {
     CONTRACTL
@@ -6946,19 +6946,19 @@ CompareIbcMethodSigs(
         MODE_ANY;
     }
     CONTRACTL_END
-    
+
     //
     // Same pointer return TRUE
-    // 
+    //
     if (pvCandidateSig == pvIbcSignature)
     {
         _ASSERTE(cbCandidateSig == cbIbcSignature);
         return TRUE;
     }
-       
+
     //
     // Check for exact match
-    // 
+    //
     if (cbCandidateSig == cbIbcSignature)
     {
         if (memcmp(pvCandidateSig, pvIbcSignature, cbIbcSignature) == 0)
@@ -6971,10 +6971,10 @@ CompareIbcMethodSigs(
 
     //
     // No exact match, we will return FALSE and keep looking at other matching method names
-    // 
+    //
     // However since the method name was an exact match we will remember this signature,
     // so that if it is the best match we can look it up again and return it's methodDef token
-    // 
+    //
     if (context->cMatch == 0)
     {
         context->pvBestSig = pvCandidateSig;
@@ -6984,7 +6984,7 @@ CompareIbcMethodSigs(
     }
     else
     {
-        context->cMatch++; 
+        context->cMatch++;
 
         SigTypeContext emptyTypeContext;
         SigTypeContext ibcTypeContext =  SigTypeContext(context->enclosingType);
@@ -6994,9 +6994,9 @@ CompareIbcMethodSigs(
         MetaSig bestSignature(context->pvBestSig, context->cbBestSig, context->pModule, &emptyTypeContext);
         //
         // Is candidateSig a better match than bestSignature?
-        // 
+        //
         // First check the calling convention
-        // 
+        //
         if (candidateSig.GetCallingConventionInfo() != bestSignature.GetCallingConventionInfo())
         {
             if (bestSignature.GetCallingConventionInfo() == ibcSignature.GetCallingConventionInfo())
@@ -7005,13 +7005,13 @@ CompareIbcMethodSigs(
                 goto SELECT_CANDIDATE;
             //
             // Neither one is a match
-            // 
+            //
             goto USE_NEITHER;
         }
 
         //
         // Next check the number of arguments
-        // 
+        //
         if (candidateSig.NumFixedArgs() != bestSignature.NumFixedArgs())
         {
             //
@@ -7023,23 +7023,23 @@ CompareIbcMethodSigs(
                 goto SELECT_CANDIDATE;
             //
             // Neither one is a match
-            // 
+            //
             goto USE_NEITHER;
         }
         else if (candidateSig.NumFixedArgs() != ibcSignature.NumFixedArgs())
         {
             //
             // Neither one is a match
-            // 
+            //
             goto USE_NEITHER;
         }
 
-        CorElementType  etIbc; 
-        CorElementType  etCandidate; 
-        CorElementType  etBest; 
+        CorElementType  etIbc;
+        CorElementType  etCandidate;
+        CorElementType  etBest;
         //
         // Next get the return element type
-        // 
+        //
         // etIbc = ibcSignature.GetReturnProps().PeekElemTypeClosed(ibcSignature.GetSigTypeContext());
         IfFailThrow(ibcSignature.GetReturnProps().PeekElemType(&etIbc));
         IfFailThrow(candidateSig.GetReturnProps().PeekElemType(&etCandidate));
@@ -7059,8 +7059,8 @@ CompareIbcMethodSigs(
         //
         // Now iterate over the method argument types to see which signature
         // is the better match
-        // 
-        for (DWORD i = 0; (i < ibcSignature.NumFixedArgs()); i++) 
+        //
+        for (DWORD i = 0; (i < ibcSignature.NumFixedArgs()); i++)
         {
             ibcSignature.SkipArg();
             IfFailThrow(ibcSignature.GetArgProps().PeekElemType(&etIbc));
@@ -7082,10 +7082,10 @@ CompareIbcMethodSigs(
                 if (etCandidate == etIbc)
                     goto SELECT_CANDIDATE;
             }
-        } 
+        }
         // When we fall though to here we did not find any differences
         // that we could base a choice on
-        // 
+        //
          context->useBestSig = true;
 
 SELECT_CANDIDATE:
@@ -7148,7 +7148,7 @@ mdMethodDef Module::LookupIbcMethodToken(TypeHandle enclosingType, mdToken ibcTo
     _ASSERTE(TypeFromToken(ibcName.tkIbcNestedClass) == ibcExternalType);
 
     ibcName.tkEnclosingClass = LookupIbcTypeToken(pExternalModule, ibcName.tkIbcNestedClass, optionalFullNameOut);
-       
+
     if (IsNilToken(ibcName.tkEnclosingClass))
     {
         COMPlusThrow(kTypeLoadException, IDS_IBC_MISSING_EXTERNAL_TYPE);
@@ -7176,7 +7176,7 @@ mdMethodDef Module::LookupIbcMethodToken(TypeHandle enclosingType, mdToken ibcTo
     //     void*       pSignatureArgs,         // [IN] Additional info to supply the compare function
     //     mdMethodDef *pmd) PURE;             // [OUT] matching memberdef
     //
-         
+
     IMDInternalImport *  pInternalImport = pExternalModule->GetMDImport();
 
     IbcCompareContext context;
@@ -7187,17 +7187,17 @@ mdMethodDef Module::LookupIbcMethodToken(TypeHandle enclosingType, mdToken ibcTo
     context.useBestSig = false;
 
     mdMethodDef mdResult = mdMethodDefNil;
-    HRESULT hr = pInternalImport->FindMethodDefUsingCompare(ibcName.tkEnclosingClass, ibcName.szName, 
-                                                            pvSig, cbSig, 
+    HRESULT hr = pInternalImport->FindMethodDefUsingCompare(ibcName.tkEnclosingClass, ibcName.szName,
+                                                            pvSig, cbSig,
                                                             CompareIbcMethodSigs, (void *) &context,
                                                             &mdResult);
-    if (SUCCEEDED(hr)) 
+    if (SUCCEEDED(hr))
     {
         _ASSERTE(mdResult != mdMethodDefNil);
     }
     else if (context.useBestSig)
     {
-        hr = pInternalImport->FindMethodDefUsingCompare(ibcName.tkEnclosingClass, ibcName.szName, 
+        hr = pInternalImport->FindMethodDefUsingCompare(ibcName.tkEnclosingClass, ibcName.szName,
                                                         context.pvBestSig, context.cbBestSig,
                                                         CompareIbcMethodSigs, (void *) &context,
                                                         &mdResult);
@@ -7237,7 +7237,7 @@ TypeHandle Module::LoadIBCTypeHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_SIG
     EX_TRY
     {
         // This is what ZapSig::FindTypeHandleFromSignature does...
-        // 
+        //
         SigTypeContext typeContext;  // empty type context
 
         loadedType = p.GetTypeHandleThrowing( this,
@@ -7264,7 +7264,7 @@ TypeHandle Module::LoadIBCTypeHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_SIG
 }
 
 //---------------------------------------------------------------------------------------
-// 
+//
 MethodDesc* Module::LoadIBCMethodHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_SIG_ENTRY * pBlobSigEntry)
 {
     CONTRACT(MethodDesc*)
@@ -7291,7 +7291,7 @@ MethodDesc* Module::LoadIBCMethodHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_
 
     //
     //  First Decode and Load the enclosing type for this method
-    //  
+    //
     EX_TRY
     {
         // This is what ZapSig::FindTypeHandleFromSignature does...
@@ -7324,7 +7324,7 @@ MethodDesc* Module::LoadIBCMethodHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_
 
     //
     //  Now Decode and Load the method
-    //  
+    //
     EX_TRY
     {
         MethodTable *pOwnerMT = enclosingType.GetMethodTable();
@@ -7359,23 +7359,23 @@ MethodDesc* Module::LoadIBCMethodHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_
             RID methodRid;
             IfFailThrow(p.GetData(&methodRid));
 
-            mdMethodDef methodToken; 
+            mdMethodDef methodToken;
 
             //
             //  Is our enclosingType from another module?
-            //  
+            //
             if (this == enclosingType.GetModule())
             {
                 //
-                // The enclosing type is from our module 
+                // The enclosing type is from our module
                 // The method token is a normal MethodDef token
-                // 
+                //
                 methodToken = TokenFromRid(methodRid, mdtMethodDef);
             }
             else
             {
                 //
-                // The enclosing type is from an external module 
+                // The enclosing type is from an external module
                 // The method token is a ibcExternalMethod token
                 //
                 idExternalType ibcToken = RidToToken(methodRid, ibcExternalMethod);
@@ -7403,10 +7403,10 @@ MethodDesc* Module::LoadIBCMethodHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_
         {
             DWORD nargs = pMethod->GetNumGenericMethodArgs();
             SIZE_T cbMem;
-            
+
             if (!ClrSafeInt<SIZE_T>::multiply(nargs, sizeof(TypeHandle), cbMem/* passed by ref */))
                 ThrowHR(COR_E_OVERFLOW);
-            
+
             TypeHandle * pInst = (TypeHandle*) _alloca(cbMem);
             SigTypeContext typeContext;   // empty type context
 
@@ -7447,7 +7447,7 @@ MethodDesc* Module::LoadIBCMethodHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_
         const bool allowInstParam = !(isInstantiatingStub || isUnboxingStub);
 
         pMethod = MethodDesc::FindOrCreateAssociatedMethodDesc(pMethod, pOwnerMT,
-                                                               isUnboxingStub, 
+                                                               isUnboxingStub,
                                                                inst, allowInstParam);
 
 #if defined(_DEBUG) && !defined(DACCESS_COMPILE)
@@ -7468,7 +7468,7 @@ MethodDesc* Module::LoadIBCMethodHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_
 
 #ifdef FEATURE_COMINTEROP
 //---------------------------------------------------------------------------------------
-// 
+//
 // This function is a workaround for missing IBC data in WinRT assemblies and
 // not-yet-implemented sharing of IL_STUB(__Canon arg) IL stubs for all interfaces.
 //
@@ -7546,7 +7546,7 @@ static void ExpandWindowsRuntimeType(TypeHandle t, DataImage *image)
 #endif // FEATURE_COMINTEROP
 
 //---------------------------------------------------------------------------------------
-// 
+//
 void Module::ExpandAll(DataImage *image)
 {
     CONTRACTL
@@ -7555,7 +7555,7 @@ void Module::ExpandAll(DataImage *image)
         PRECONDITION(!IsResource());
     }
     CONTRACTL_END
-    
+
     mdToken tk;
     DWORD assemblyFlags = GetAssembly()->GetFlags();
 
@@ -7570,15 +7570,15 @@ void Module::ExpandAll(DataImage *image)
     // RID maps for the typedefs, method defs,
     // and field defs.
     //
-    
+
     IMDInternalImport *pInternalImport = GetMDImport();
     {
         HENUMInternalHolder hEnum(pInternalImport);
         hEnum.EnumTypeDefInit();
-        
+
         while (pInternalImport->EnumNext(&hEnum, &tk))
         {
-#ifdef FEATURE_COMINTEROP            
+#ifdef FEATURE_COMINTEROP
             // Skip the non-managed WinRT types since they're only used by Javascript and C++
             //
             // With WinRT files, we want to exclude certain types that cause us problems:
@@ -7590,13 +7590,13 @@ void Module::ExpandAll(DataImage *image)
             {
                 mdToken tkExtends;
                 pInternalImport->GetTypeDefProps(tk, NULL, &tkExtends);
-                
+
                 if (TypeFromToken(tkExtends) == mdtTypeRef)
                 {
                     LPCSTR szNameSpace = NULL;
                     LPCSTR szName = NULL;
                     pInternalImport->GetNameOfTypeRef(tkExtends, &szNameSpace, &szName);
-                    
+
                     if (!strcmp(szNameSpace, "System") && !_stricmp((szName), "Attribute"))
                     {
                         continue;
@@ -7606,9 +7606,9 @@ void Module::ExpandAll(DataImage *image)
 #endif // FEATURE_COMINTEROP
 
             TypeHandle t = LoadTypeDefOrRefHelper(image, this, tk);
-            
+
             if (t.IsNull()) // Skip this type
-                continue; 
+                continue;
 
             if (!t.HasInstantiation())
             {
@@ -7621,15 +7621,15 @@ void Module::ExpandAll(DataImage *image)
                 _ASSERTE(pTable != NULL);
 
                 t.GetName(ssFullyQualifiedName);
-                
+
                 // Convert to UTF8
                 StackScratchBuffer scratch;
                 LPCUTF8 szFullyQualifiedName = ssFullyQualifiedName.GetUTF8(scratch);
-                
+
                 BOOL isNested = ClassLoader::IsNested(this, tk, &mdEncloser);
                 EEClassHashTable::LookupContext sContext;
                 pBucket = pTable->GetValue(szFullyQualifiedName, &data, isNested, &sContext);
-                
+
                 if (isNested)
                 {
                     while (pBucket != NULL)
@@ -7641,17 +7641,17 @@ void Module::ExpandAll(DataImage *image)
                                                                                       pBucket->GetEncloser());
                         if (match)
                             break;
-                        
+
                         pBucket = pTable->FindNextNestedClass(szFullyQualifiedName, &data, &sContext);
                     }
                 }
-                
+
                 // Save the typehandle instead of the token in the hash entry so that ngen'ed images
                 // don't have to lookup based on token and update this entry
                 if ((pBucket != NULL) && !t.IsNull() && t.IsRestored())
                     pBucket->SetData(t.AsPtr());
             }
-            
+
             DWORD nGenericClassParams = t.GetNumGenericArgs();
             if (nGenericClassParams != 0)
             {
@@ -7667,7 +7667,7 @@ void Module::ExpandAll(DataImage *image)
                 {
                     genericClassArgs[i] = TypeHandle(g_pCanonMethodTableClass);
                 }
-                
+
                 TypeHandle thCanonInst = LoadGenericInstantiationHelper(image, this, tk, Instantiation(genericClassArgs, nGenericClassParams));
 
                 // If successful, add the instantiation to the Module's map of generic types instantiated at Object
@@ -7686,38 +7686,38 @@ void Module::ExpandAll(DataImage *image)
 #endif // FEATURE_COMINTEROP
         }
     }
-    
+
     //
     // Fill out TypeRef RID map
     //
-    
+
     {
         HENUMInternalHolder hEnum(pInternalImport);
         hEnum.EnumAllInit(mdtTypeRef);
-        
+
         while (pInternalImport->EnumNext(&hEnum, &tk))
         {
             mdToken tkResolutionScope = mdTokenNil;
             pInternalImport->GetResolutionScopeOfTypeRef(tk, &tkResolutionScope);
 
-#ifdef FEATURE_COMINTEROP            
+#ifdef FEATURE_COMINTEROP
             // WinRT first party files are authored with TypeRefs pointing to TypeDefs in the same module.
             // This causes us to load types we do not want to NGen such as custom attributes. We will not
             // expand any module local TypeRefs for WinMDs to prevent this.
             if(TypeFromToken(tkResolutionScope)==mdtModule && IsAfContentType_WindowsRuntime(assemblyFlags))
                 continue;
-#endif // FEATURE_COMINTEROP            
+#endif // FEATURE_COMINTEROP
             TypeHandle t = LoadTypeDefOrRefHelper(image, this, tk);
 
             if (t.IsNull()) // Skip this type
                 continue;
-            
-#ifdef FEATURE_COMINTEROP                
+
+#ifdef FEATURE_COMINTEROP
             if (!g_fNGenWinMDResilient && TypeFromToken(tkResolutionScope) == mdtAssemblyRef)
             {
                 DWORD dwAssemblyRefFlags;
                 IfFailThrow(pInternalImport->GetAssemblyRefProps(tkResolutionScope, NULL, NULL, NULL, NULL, NULL, NULL, &dwAssemblyRefFlags));
-                
+
                 if (IsAfContentType_WindowsRuntime(dwAssemblyRefFlags))
                 {
                     Assembly *pAssembly = t.GetAssembly();
@@ -7731,25 +7731,25 @@ void Module::ExpandAll(DataImage *image)
                     GetAppDomain()->ToCompilationDomain()->AddDependency(&refSpec,pPEAssembly);
                 }
             }
-#endif // FEATURE_COMINTEROP                
+#endif // FEATURE_COMINTEROP
         }
     }
-    
+
     //
     // Load all type specs
     //
-    
+
     {
         HENUMInternalHolder hEnum(pInternalImport);
         hEnum.EnumAllInit(mdtTypeSpec);
-        
+
         while (pInternalImport->EnumNext(&hEnum, &tk))
         {
             ULONG cSig;
             PCCOR_SIGNATURE pSig;
-            
+
             IfFailThrow(pInternalImport->GetTypeSpecFromToken(tk, &pSig, &cSig));
-            
+
             // Load all types specs that do not contain variables
             if (SigPointer(pSig, cSig).IsPolyType(NULL) == hasNoVars)
             {
@@ -7757,13 +7757,13 @@ void Module::ExpandAll(DataImage *image)
             }
         }
     }
-    
+
     //
     // Load all the reported parameterized types and methods
     //
     CorProfileData *  profileData = this->GetProfileData();
-    CORBBTPROF_BLOB_ENTRY *pBlobEntry = profileData->GetBlobStream();
-    
+    CORBBTPROF_BLOB_ENTRY *pBlobEntry = profileData ? profileData->GetBlobStream() : NULL;
+
     if (pBlobEntry != NULL)
     {
         while (pBlobEntry->TypeIsValid())
@@ -7784,7 +7784,7 @@ void Module::ExpandAll(DataImage *image)
             {
                 _ASSERTE(pBlobEntry->type == ParamMethodSpec);
                 CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry = (CORBBTPROF_BLOB_PARAM_SIG_ENTRY *) pBlobEntry;
-                
+
                 MethodDesc *pMD = LoadIBCMethodHelper(image, pBlobSigEntry);
             }
             pBlobEntry = pBlobEntry->GetNextEntry();
@@ -7792,64 +7792,68 @@ void Module::ExpandAll(DataImage *image)
         _ASSERTE(pBlobEntry->type == EndOfBlobStream);
     }
 
-    //
-    // Record references to all of the hot methods specifiled by MethodProfilingData array
-    // We call MethodReferencedByCompiledCode to indicate that we plan on compiling this method
-    //
-    CORBBTPROF_TOKEN_INFO * pMethodProfilingData = profileData->GetTokenFlagsData(MethodProfilingData);
-    DWORD                   cMethodProfilingData = profileData->GetTokenFlagsCount(MethodProfilingData);
-    for (unsigned int i = 0; (i < cMethodProfilingData); i++)
+    if (profileData)
     {
-        mdToken token = pMethodProfilingData[i].token;
-        DWORD   profilingFlags = pMethodProfilingData[i].flags;
-
-        // We call MethodReferencedByCompiledCode only when the profile data indicates that 
-        // we executed (i.e read) the code for the method
         //
-        if (profilingFlags & (1 << ReadMethodCode))
+        // Record references to all of the hot methods specifiled by MethodProfilingData array
+        // We call MethodReferencedByCompiledCode to indicate that we plan on compiling this method
+        //
+        CORBBTPROF_TOKEN_INFO * pMethodProfilingData = profileData->GetTokenFlagsData(MethodProfilingData);
+        DWORD                   cMethodProfilingData = profileData->GetTokenFlagsCount(MethodProfilingData);
+
+        for (unsigned int i = 0; (i < cMethodProfilingData); i++)
         {
-            if (TypeFromToken(token) == mdtMethodDef)
-            {
-                MethodDesc *  pMD = LookupMethodDef(token);
-                //
-                // Record a reference to a hot non-generic method 
-                //
-                image->GetPreloader()->MethodReferencedByCompiledCode((CORINFO_METHOD_HANDLE)pMD);
-            }
-            else if (TypeFromToken(token) == ibcMethodSpec)
-            {
-                CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry = profileData->GetBlobSigEntry(token);
+            mdToken token = pMethodProfilingData[i].token;
+            DWORD   profilingFlags = pMethodProfilingData[i].flags;
 
-                if (pBlobSigEntry != NULL)
+            // We call MethodReferencedByCompiledCode only when the profile data indicates that
+            // we executed (i.e read) the code for the method
+            //
+            if (profilingFlags & (1 << ReadMethodCode))
+            {
+                if (TypeFromToken(token) == mdtMethodDef)
                 {
-                    _ASSERTE(pBlobSigEntry->blob.token == token);
-                    MethodDesc * pMD = LoadIBCMethodHelper(image, pBlobSigEntry);
+                    MethodDesc *  pMD = LookupMethodDef(token);
+                    //
+                    // Record a reference to a hot non-generic method
+                    //
+                    image->GetPreloader()->MethodReferencedByCompiledCode((CORINFO_METHOD_HANDLE)pMD);
+                }
+                else if (TypeFromToken(token) == ibcMethodSpec)
+                {
+                    CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry = profileData->GetBlobSigEntry(token);
 
-                    if (pMD != NULL)
+                    if (pBlobSigEntry != NULL)
                     {
-                        // Occasionally a non-instantiated generic method shows up in the IBC data, we should NOT compile it.
-                        if (!pMD->IsTypicalMethodDefinition())
+                        _ASSERTE(pBlobSigEntry->blob.token == token);
+                        MethodDesc * pMD = LoadIBCMethodHelper(image, pBlobSigEntry);
+
+                        if (pMD != NULL)
                         {
-                            //
-                            // Record a reference to a hot instantiated generic method 
-                            //
-                            image->GetPreloader()->MethodReferencedByCompiledCode((CORINFO_METHOD_HANDLE)pMD);
+                            // Occasionally a non-instantiated generic method shows up in the IBC data, we should NOT compile it.
+                            if (!pMD->IsTypicalMethodDefinition())
+                            {
+                                //
+                                // Record a reference to a hot instantiated generic method
+                                //
+                                image->GetPreloader()->MethodReferencedByCompiledCode((CORINFO_METHOD_HANDLE)pMD);
+                            }
                         }
                     }
                 }
             }
         }
     }
-    
+
     {
         //
         // Fill out MemberRef RID map and va sig cookies for
         // varargs member refs.
         //
-        
+
         HENUMInternalHolder hEnum(pInternalImport);
         hEnum.EnumAllInit(mdtMemberRef);
-        
+
         while (pInternalImport->EnumNext(&hEnum, &tk))
         {
             mdTypeRef parent;
@@ -7865,11 +7869,11 @@ void Module::ExpandAll(DataImage *image)
                 // expand any module local TypeRefs for WinMDs to prevent this.
                 if(TypeFromToken(tkResolutionScope)==mdtModule)
                     continue;
-                
+
                 LPCSTR szNameSpace = NULL;
                 LPCSTR szName = NULL;
                 if (SUCCEEDED(pInternalImport->GetNameOfTypeRef(parent, &szNameSpace, &szName)))
-                {                    
+                {
                     if (WinMDAdapter::ConvertWellKnownTypeNameFromClrToWinRT(&szNameSpace, &szName))
                     {
                         //
@@ -7885,7 +7889,7 @@ void Module::ExpandAll(DataImage *image)
                         continue;
                     }
                 }
-                
+
             }
 #endif // FEATURE_COMINTEROP
 
@@ -7899,11 +7903,11 @@ void Module::ExpandAll(DataImage *image)
             }
         }
     }
-    
+
     //
     // Fill out binder
     //
-    
+
     if (m_pBinder != NULL)
     {
         m_pBinder->BindAll();
@@ -7926,8 +7930,8 @@ void Module::SaveMethodTable(DataImage *    image,
 
 
 /* static */
-void Module::SaveTypeHandle(DataImage *  image, 
-                            TypeHandle   t, 
+void Module::SaveTypeHandle(DataImage *  image,
+                            TypeHandle   t,
                             DWORD        profilingFlags)
 {
     STANDARD_VM_CONTRACT;
@@ -7950,7 +7954,7 @@ void Module::SaveTypeHandle(DataImage *  image,
             _ASSERTE(image->IsStored(pMT));
         }
     }
-#ifdef _DEBUG 
+#ifdef _DEBUG
     if (LoggingOn(LF_JIT, LL_INFO100))
     {
         Module *pPrefModule = Module::GetPreferredZapModuleForTypeHandle(t);
@@ -7994,7 +7998,7 @@ void ModuleCtorInfo::Save(DataImage *image, CorProfileData *profileData)
         totalBoxedStatics += ppMTTemp->GetNumBoxedRegularStatics();
 
         bool hot = true; // if there's no profiling data, assume the entries are all hot.
-        if (profileData->GetTokenFlagsData(TypeProfilingData))
+        if (profileData && profileData->GetTokenFlagsData(TypeProfilingData))
         {
             if ((profileData->GetTypeProfilingFlagsOfToken(ppMTTemp->GetCl()) & (1 << ReadCCtorInfo)) == 0)
                 hot = false;
@@ -8010,7 +8014,7 @@ void ModuleCtorInfo::Save(DataImage *image, CorProfileData *profileData)
     }
 
     numHotHashes = numElementsHot ? RoundUpToPower2((numElementsHot * sizeof(PTR_MethodTable)) / CACHE_LINE_SIZE) : 0;
-    numColdHashes = (numElements - numElementsHot) ? RoundUpToPower2(((numElements - numElementsHot) * 
+    numColdHashes = (numElements - numElementsHot) ? RoundUpToPower2(((numElements - numElementsHot) *
                                                                     sizeof(PTR_MethodTable)) / CACHE_LINE_SIZE) : 0;
 
     LOG((LF_ZAP, LL_INFO10, "ModuleCtorInfo::numHotHashes:  0x%4x\n", numHotHashes));
@@ -8037,12 +8041,12 @@ void ModuleCtorInfo::Save(DataImage *image, CorProfileData *profileData)
 
     // Sort the two arrays by hash values to create regions with the same hash values.
     ClassCtorInfoEntryArraySort cctorInfoHotSort(hashArray, ppMT, numElementsHot);
-    ClassCtorInfoEntryArraySort cctorInfoColdSort(hashArray + numElementsHot, ppMT + numElementsHot, 
+    ClassCtorInfoEntryArraySort cctorInfoColdSort(hashArray + numElementsHot, ppMT + numElementsHot,
                                                     numElements - numElementsHot);
     cctorInfoHotSort.Sort();
     cctorInfoColdSort.Sort();
 
-    // Generate the indices that index into the correct "hash region" in the hot part of the ppMT array, and store 
+    // Generate the indices that index into the correct "hash region" in the hot part of the ppMT array, and store
     // them in the hotHashOffests arrays.
     DWORD curHash = 0;
     i = 0;
@@ -8056,7 +8060,7 @@ void ModuleCtorInfo::Save(DataImage *image, CorProfileData *profileData)
         {
             hotHashOffsets[curHash++] = i++;
         }
-        else 
+        else
         {
             i++;
         }
@@ -8066,7 +8070,7 @@ void ModuleCtorInfo::Save(DataImage *image, CorProfileData *profileData)
         hotHashOffsets[curHash++] = numElementsHot;
     }
 
-    // Generate the indices that index into the correct "hash region" in the hot part of the ppMT array, and store 
+    // Generate the indices that index into the correct "hash region" in the hot part of the ppMT array, and store
     // them in the coldHashOffsets arrays.
     curHash = 0;
     i = numElementsHot;
@@ -8118,7 +8122,7 @@ void ModuleCtorInfo::Save(DataImage *image, CorProfileData *profileData)
         pEntry->numBoxedStatics = numBoxedStatics;
         pEntry->hasFixedAddressVTStatics = !!pMT->HasFixedAddressVTStatics();
 
-        FieldDesc *pField = pMT->HasGenericsStaticsInfo() ? 
+        FieldDesc *pField = pMT->HasGenericsStaticsInfo() ?
             pMT->GetGenericsStaticFieldDescs() : (pMT->GetApproxFieldDescListRaw() + pMT->GetNumIntroducedInstanceFields());
         FieldDesc *pFieldEnd = pField + pMT->GetNumStaticFields();
 
@@ -8137,7 +8141,7 @@ void ModuleCtorInfo::Save(DataImage *image, CorProfileData *profileData)
                     pEntry->firstBoxedStaticOffset = pField->GetOffset();
                     pEntry->firstBoxedStaticMTIndex = iGCStaticMT;
                 }
-                _ASSERTE(pField->GetOffset() - pEntry->firstBoxedStaticOffset 
+                _ASSERTE(pField->GetOffset() - pEntry->firstBoxedStaticOffset
                     == (iGCStaticMT - pEntry->firstBoxedStaticMTIndex) * sizeof(MethodTable*));
 
                 TypeHandle th = pField->GetFieldTypeHandleThrowing();
@@ -8447,12 +8451,12 @@ void Module::Save(DataImage *image)
                         if (TypeFromToken(pBlobEntry->token) == ibcTypeSpec)
                         {
                             _ASSERTE(pBlobEntry->type == ParamTypeSpec);
-                            
+
                             if (pBlobEntry->token == token)
                             {
                                 CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry = (CORBBTPROF_BLOB_PARAM_SIG_ENTRY *) pBlobEntry;
                                 TypeHandle th = LoadIBCTypeHelper(image, pBlobSigEntry);
-                                
+
                                 if (!th.IsNull())
                                 {
                                     // When we have stale IBC data the type could have been rejected from this image.
@@ -8475,8 +8479,8 @@ void Module::Save(DataImage *image)
             // If we have V1 IBC data then we save the hot
             //  out-of-module generic instantiations here
 
-            CORBBTPROF_TOKEN_INFO * tokens_begin = profileData->GetTokenFlagsData(GenericTypeProfilingData);
-            CORBBTPROF_TOKEN_INFO * tokens_end = tokens_begin + profileData->GetTokenFlagsCount(GenericTypeProfilingData);
+            CORBBTPROF_TOKEN_INFO * tokens_begin = profileData ? profileData->GetTokenFlagsData(GenericTypeProfilingData) : NULL;
+            CORBBTPROF_TOKEN_INFO * tokens_end = tokens_begin + (profileData ? profileData->GetTokenFlagsCount(GenericTypeProfilingData) : 0);
 
             if (tokens_begin != tokens_end)
             {
@@ -8495,7 +8499,7 @@ void Module::Save(DataImage *image)
 #if defined(_DEBUG) && !defined(DACCESS_COMPILE)
                     g_pConfig->DebugCheckAndForceIBCFailure(EEConfig::CallSite_5);
 #endif
-                    
+
                     if (t.HasInstantiation())
                     {
                         SString tokenName;
@@ -8525,7 +8529,7 @@ void Module::Save(DataImage *image)
         {
             MethodTable * pMT = typeDefIter.GetElement();
 
-            if (pMT != NULL && 
+            if (pMT != NULL &&
                 !image->IsStored(pMT) && pMT->IsFullyLoaded())
             {
                 image->BeginAssociatingStoredObjectsWithMethodTable(pMT);
@@ -8585,7 +8589,7 @@ void Module::Save(DataImage *image)
 
     //
     // Now save any methods in the InstMethodHashTable
-    // 
+    //
     if (m_pInstMethodHashTable != NULL)
     {
         //
@@ -8689,7 +8693,7 @@ void Module::Save(DataImage *image)
     // paths to get the extra working set perf (you would be pulling in the jitter if
     // you need any of these classes), So we are basically simplifying this down, if we failed
     // to load or save any class we won't compress the statics block and will persist the original
-    // estimation. 
+    // estimation.
 
     // All classes were loaded and saved, cut down the block
     if (AreAllClassesFullyLoaded())
@@ -8720,7 +8724,7 @@ void Module::Save(DataImage *image)
     }
 
     InlineTrackingMap *inlineTrackingMap = image->GetInlineTrackingMap();
-    if (inlineTrackingMap) 
+    if (inlineTrackingMap)
     {
         m_pPersistentInlineTrackingMapNGen = new (image->GetHeap()) PersistentInlineTrackingMapNGen(this);
         m_pPersistentInlineTrackingMapNGen->Save(image, inlineTrackingMap);
@@ -8744,8 +8748,8 @@ void Module::Save(DataImage *image)
 #ifdef _DEBUG
 //
 // We call these methods to seal the
-// lists: m_pAvailableClasses and m_pAvailableParamTypes 
-// 
+// lists: m_pAvailableClasses and m_pAvailableParamTypes
+//
 void Module::SealGenericTypesAndMethods()
 {
     LIMITED_METHOD_CONTRACT;
@@ -8764,13 +8768,13 @@ void Module::SealGenericTypesAndMethods()
 }
 //
 // We call these methods to unseal the
-// lists: m_pAvailableClasses and m_pAvailableParamTypes 
-// 
+// lists: m_pAvailableClasses and m_pAvailableParamTypes
+//
 void Module::UnsealGenericTypesAndMethods()
 {
     LIMITED_METHOD_CONTRACT;
     // Allow us to create generic types and methods again
-    // 
+    //
     // We only decrement it after we have completed the ngen image
     //
     if (m_pAvailableParamTypes != NULL)
@@ -9082,7 +9086,7 @@ void Module::PlaceMethod(DataImage *image, MethodDesc *pMD, DWORD profilingFlags
         {
             NDirectMethodDesc *pNMD = (NDirectMethodDesc *)pMD;
             image->PlaceStructureForAddress((void*) pNMD->GetWriteableData(), CORCOMPILE_SECTION_WRITE);
-            
+
 #ifdef HAS_NDIRECT_IMPORT_PRECODE
             // The NDirect import thunk glue is used only if no marshaling is required
             if (!pNMD->MarshalingRequired())
@@ -9195,16 +9199,16 @@ void Module::Arrange(DataImage *image)
             else if (TypeFromToken(token) == ibcTypeSpec)
             {
                 CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry = profileData->GetBlobSigEntry(token);
-                
+
                 if (pBlobSigEntry == NULL)
                 {
                     //
                     // Print an error message for the type load failure
-                    // 
+                    //
                     StackSString msg(W("Did not find definition for type token "));
 
                     char buff[16];
-                    sprintf_s(buff, COUNTOF(buff), "%08x", token); 
+                    sprintf_s(buff, COUNTOF(buff), "%08x", token);
                     StackSString szToken(SString::Ascii, &buff[0]);
                     msg += szToken;
                     msg += W(" in profile data.\n");
@@ -9266,16 +9270,16 @@ void Module::Arrange(DataImage *image)
             else if (TypeFromToken(token) == ibcMethodSpec)
             {
                 CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry = profileData->GetBlobSigEntry(token);
-                
+
                 if (pBlobSigEntry == NULL)
                 {
                     //
                     // Print an error message for the type load failure
-                    // 
+                    //
                     StackSString msg(W("Did not find definition for method token "));
 
                     char buff[16];
-                    sprintf_s(buff, COUNTOF(buff), "%08x", token); 
+                    sprintf_s(buff, COUNTOF(buff), "%08x", token);
                     StackSString szToken(SString::Ascii, &buff[0]);
                     msg += szToken;
                     msg += W(" in profile data.\n");
@@ -9286,7 +9290,7 @@ void Module::Arrange(DataImage *image)
                 {
                     _ASSERTE(pBlobSigEntry->blob.token == token);
                     MethodDesc * pMD = LoadIBCMethodHelper(image, pBlobSigEntry);
-                    
+
                     if (pMD != NULL)
                     {
                         //
@@ -9343,7 +9347,7 @@ void ModuleCtorInfo::Fixup(DataImage *image)
     {
         image->ZeroPointerField(this, offsetof(ModuleCtorInfo, ppMT));
     }
-    
+
     if (numHotGCStaticsMTs > 0)
     {
         image->FixupPointerField(this, offsetof(ModuleCtorInfo, ppHotGCStaticsMTs));
@@ -9536,14 +9540,14 @@ void Module::Fixup(DataImage *image)
         {
             TADDR flags;
             TypeHandle th = TypeHandle::FromTAddr(dac_cast<TADDR>(typeRefIter.GetElementAndFlags(&flags)));
-            
+
             if (!th.IsNull())
             {
                 if (th.GetLoaderModule() != this || image->IsStored(th.AsPtr()))
                 {
                     PTR_TADDR hotItemValuePtr = m_TypeRefToMethodTableMap.FindHotItemValuePtr(rid);
                     BOOL fSet = FALSE;
-                   
+
                     if (image->CanEagerBindToTypeHandle(th))
                     {
                         if (image->CanHardBindToZapModule(th.GetLoaderModule()))
@@ -9553,13 +9557,13 @@ void Module::Fixup(DataImage *image)
 
                             _ASSERTE((flags & offset) == 0);
 
-                            image->FixupField(m_TypeRefToMethodTableMap.pTable, rid * sizeof(TADDR), 
+                            image->FixupField(m_TypeRefToMethodTableMap.pTable, rid * sizeof(TADDR),
                                 pTarget, flags | offset, IMAGE_REL_BASED_RelativePointer);
 
                             // In case this item is also in the hot item subtable, fix it up there as well
                             if (hotItemValuePtr != NULL)
                             {
-                                image->FixupField(m_TypeRefToMethodTableMap.hotItemList, 
+                                image->FixupField(m_TypeRefToMethodTableMap.hotItemList,
                                     (BYTE *)hotItemValuePtr - (BYTE *)m_TypeRefToMethodTableMap.hotItemList,
                                     pTarget, flags | offset, IMAGE_REL_BASED_RelativePointer);
                             }
@@ -9572,12 +9576,12 @@ void Module::Fixup(DataImage *image)
                             _ASSERTE((flags & FIXUP_POINTER_INDIRECTION) == 0);
 
                             ZapNode * pImport = image->GetTypeHandleImport(th);
-                            image->FixupFieldToNode(m_TypeRefToMethodTableMap.pTable, rid * sizeof(TADDR), 
+                            image->FixupFieldToNode(m_TypeRefToMethodTableMap.pTable, rid * sizeof(TADDR),
                                 pImport, flags | FIXUP_POINTER_INDIRECTION, IMAGE_REL_BASED_RelativePointer);
                             if (hotItemValuePtr != NULL)
                             {
-                                image->FixupFieldToNode(m_TypeRefToMethodTableMap.hotItemList, 
-                                    (BYTE *)hotItemValuePtr - (BYTE *)m_TypeRefToMethodTableMap.hotItemList, 
+                                image->FixupFieldToNode(m_TypeRefToMethodTableMap.hotItemList,
+                                    (BYTE *)hotItemValuePtr - (BYTE *)m_TypeRefToMethodTableMap.hotItemList,
                                     pImport, flags | FIXUP_POINTER_INDIRECTION, IMAGE_REL_BASED_RelativePointer);
                             }
                             fSet = TRUE;
@@ -9596,7 +9600,7 @@ void Module::Fixup(DataImage *image)
                     }
                 }
             }
-            
+
             rid++;
         }
         image->EndRegion(CORINFO_REGION_HOT);
@@ -9667,7 +9671,7 @@ void Module::Fixup(DataImage *image)
     image->ZeroPointerField(this, offsetof(Module, m_AssemblyRefByNameTable));
 
     image->ZeroPointerField(this,offsetof(Module, m_NativeMetadataAssemblyRefMap));
-    
+
     //
     // Fixup statics
     //
@@ -9710,7 +9714,7 @@ void Module::Fixup(DataImage *image)
     {
         image->FixupPointerField(this, offsetof(Module, m_pPersistentInlineTrackingMapNGen));
         m_pPersistentInlineTrackingMapNGen->Fixup(image);
-    } 
+    }
     else
     {
         image->ZeroPointerField(this, offsetof(Module, m_pPersistentInlineTrackingMapNGen));
@@ -9799,7 +9803,7 @@ Module *Module::GetModuleFromIndexIfLoaded(DWORD ix)
     }
     CONTRACT_END;
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
     RETURN ZapSig::DecodeModuleFromIndexIfLoaded(this, ix);
 #else // DACCESS_COMPILE
     DacNotImpl();
@@ -9807,7 +9811,7 @@ Module *Module::GetModuleFromIndexIfLoaded(DWORD ix)
 #endif // DACCESS_COMPILE
 }
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
 IMDInternalImport* Module::GetNativeAssemblyImport(BOOL loadAllowed)
 {
     CONTRACT(IMDInternalImport*)
@@ -9853,7 +9857,7 @@ BYTE* Module::GetNativeFixupBlobData(RVA rva)
 
 #ifdef FEATURE_PREJIT
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
 
 /*static*/
 void Module::RestoreMethodTablePointerRaw(MethodTable ** ppMT,
@@ -9881,7 +9885,7 @@ void Module::RestoreMethodTablePointerRaw(MethodTable ** ppMT,
 
     if (CORCOMPILE_IS_POINTER_TAGGED(fixup))
     {
-#ifdef BIT64 
+#ifdef BIT64
         CONSISTENCY_CHECK((CORCOMPILE_UNTAG_TOKEN(fixup)>>32) == 0);
 #endif
 
@@ -10030,7 +10034,7 @@ PCCOR_SIGNATURE Module::GetEncodedSig(RVA fixupRva, Module **ppDefiningModule)
     }
     CONTRACT_END;
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
     PCCOR_SIGNATURE pBuffer = GetNativeFixupBlobData(fixupRva);
 
     BYTE kind = *pBuffer++;
@@ -10056,7 +10060,7 @@ PCCOR_SIGNATURE Module::GetEncodedSigIfLoaded(RVA fixupRva, Module **ppDefiningM
     }
     CONTRACT_END;
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
     PCCOR_SIGNATURE pBuffer = GetNativeFixupBlobData(fixupRva);
 
     BYTE kind = *pBuffer++;
@@ -10086,7 +10090,7 @@ PTR_Module Module::RestoreModulePointerIfLoaded(DPTR(RelativeFixupPointer<PTR_Mo
     if (!ppModule->IsTagged(dac_cast<TADDR>(ppModule)))
         return ppModule->GetValue(dac_cast<TADDR>(ppModule));
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
     PTR_Module * ppValue = ppModule->GetValuePtr();
 
     // Ensure that the compiler won't fetch the value twice
@@ -10095,7 +10099,7 @@ PTR_Module Module::RestoreModulePointerIfLoaded(DPTR(RelativeFixupPointer<PTR_Mo
     if (CORCOMPILE_IS_POINTER_TAGGED(fixup))
     {
 
-#ifdef BIT64 
+#ifdef BIT64
         CONSISTENCY_CHECK((CORCOMPILE_UNTAG_TOKEN(fixup)>>32) == 0);
 #endif
 
@@ -10122,7 +10126,7 @@ PTR_Module Module::RestoreModulePointerIfLoaded(DPTR(RelativeFixupPointer<PTR_Mo
 #endif
 }
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
 
 /*static*/
 void Module::RestoreModulePointer(RelativeFixupPointer<PTR_Module> * ppModule, Module *pContainingModule)
@@ -10146,7 +10150,7 @@ void Module::RestoreModulePointer(RelativeFixupPointer<PTR_Module> * ppModule, M
 
     if (CORCOMPILE_IS_POINTER_TAGGED(fixup))
     {
-#ifdef BIT64 
+#ifdef BIT64
         CONSISTENCY_CHECK((CORCOMPILE_UNTAG_TOKEN(fixup)>>32) == 0);
 #endif
 
@@ -10194,7 +10198,7 @@ void Module::RestoreTypeHandlePointerRaw(TypeHandle *pHandle, Module* pContainin
         // in stubs-as-il signatures.
 
         //
-        // protect this unaligned read with the Module Crst for the rare case that 
+        // protect this unaligned read with the Module Crst for the rare case that
         // the TypeHandle to fixup is in a signature and unaligned.
         //
         if (NULL == pContainingModule)
@@ -10207,7 +10211,7 @@ void Module::RestoreTypeHandlePointerRaw(TypeHandle *pHandle, Module* pContainin
 
     if (CORCOMPILE_IS_POINTER_TAGGED(fixup))
     {
-#ifdef BIT64 
+#ifdef BIT64
         CONSISTENCY_CHECK((CORCOMPILE_UNTAG_TOKEN(fixup)>>32) == 0);
 #endif
 
@@ -10235,7 +10239,7 @@ void Module::RestoreTypeHandlePointerRaw(TypeHandle *pHandle, Module* pContainin
         else
         {
             //
-            // protect this unaligned write with the Module Crst for the rare case that 
+            // protect this unaligned write with the Module Crst for the rare case that
             // the TypeHandle to fixup is in a signature and unaligned.
             //
             CrstHolder ch(&pContainingModule->m_Crst);
@@ -10326,7 +10330,7 @@ void Module::RestoreMethodDescPointerRaw(PTR_MethodDesc * ppMD, Module *pContain
     {
         GCX_PREEMP();
 
-#ifdef BIT64 
+#ifdef BIT64
         CONSISTENCY_CHECK((CORCOMPILE_UNTAG_TOKEN(fixup)>>32) == 0);
 #endif
 
@@ -10423,7 +10427,7 @@ void Module::RestoreFieldDescPointer(RelativeFixupPointer<PTR_FieldDesc> * ppFD)
 
     if (CORCOMPILE_IS_POINTER_TAGGED(fixup))
     {
-#ifdef BIT64 
+#ifdef BIT64
         CONSISTENCY_CHECK((CORCOMPILE_UNTAG_TOKEN(fixup)>>32) == 0);
 #endif
 
@@ -10446,7 +10450,7 @@ void Module::RestoreFieldDescPointer(RelativeFixupPointer<PTR_FieldDesc> * ppFD)
 
 //-----------------------------------------------------------------------------
 
-#if 0 
+#if 0
 
         This diagram illustrates the layout of fixups in the ngen image.
         This is the case where function foo2 has a class-restore fixup
@@ -10559,7 +10563,7 @@ void Module::RunEagerFixups()
                 // Ensure that the compiler won't fetch the value twice
                 SIZE_T fixup = VolatileLoadWithoutBarrier(fixupCell);
 
-                // This method may execute multiple times in multi-domain scenarios. Check that the fixup has not been 
+                // This method may execute multiple times in multi-domain scenarios. Check that the fixup has not been
                 // fixed up yet.
                 if (CORCOMPILE_IS_FIXUP_TAGGED(fixup, pSection))
                 {
@@ -10605,7 +10609,7 @@ void Module::LoadTokenTables()
     //patch up the ngen image to point to this address so that the JIT bypasses JMC if there is no debugger
     static DWORD g_dummyJMCFlag = 0;
     pEEInfo->addrOfJMCFlag = g_pDebugInterface ? g_pDebugInterface->GetJMCFlagAddr(this) : &g_dummyJMCFlag;
-   
+
     pEEInfo->gsCookie = GetProcessGSCookie();
 
     if (!IsSystem())
@@ -10641,7 +10645,7 @@ CORCOMPILE_DEBUG_ENTRY Module::GetMethodDebugInfoOffset(MethodDesc *pMD)
         RETURN 0;
 
     COUNT_T size;
-    PTR_CORCOMPILE_DEBUG_RID_ENTRY ridTable = 
+    PTR_CORCOMPILE_DEBUG_RID_ENTRY ridTable =
         dac_cast<PTR_CORCOMPILE_DEBUG_RID_ENTRY>(GetNativeImage()->GetNativeDebugMap(&size));
 
     COUNT_T count = size / sizeof(CORCOMPILE_DEBUG_RID_ENTRY);
@@ -10713,7 +10717,7 @@ PTR_BYTE Module::GetNativeDebugInfo(MethodDesc * pMD)
 }
 #endif //FEATURE_PREJIT
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
 
 //-----------------------------------------------------------------------------
 
@@ -10754,7 +10758,7 @@ BOOL Module::FixupNativeEntry(CORCOMPILE_IMPORT_SECTION* pSection, SIZE_T fixupI
         else
         {
             //
-            // Handle tables are special. We may need to restore static handle or previous 
+            // Handle tables are special. We may need to restore static handle or previous
             // attempts to load handle could have been partial.
             //
             if (pSection->Type == CORCOMPILE_IMPORT_TYPE_TYPE_HANDLE)
@@ -10800,7 +10804,7 @@ ICorJitInfo::BlockCounts * Module::AllocateMethodBlockCounts(mdToken _token, DWO
 
     CORCOMPILE_METHOD_PROFILE_LIST * methodProfileList = (CORCOMPILE_METHOD_PROFILE_LIST *) (memory + 0);
     CORBBTPROF_METHOD_HEADER *       methodProfileData = (CORBBTPROF_METHOD_HEADER *)       (memory + listSize);
-    
+
     // Note: Memory allocated on the LowFrequencyHeap is zero filled
 
     methodProfileData->size          = headerSize + blockSize;
@@ -10841,7 +10845,7 @@ HANDLE Module::OpenMethodProfileDataLogFile(GUID mvid)
         LPCWSTR assemblyFileName = wcsrchr(assemblyPath, DIRECTORY_SEPARATOR_CHAR_W);
         if (assemblyFileName)
             assemblyFileName++;                         // skip past the \ char
-        else 
+        else
             assemblyFileName = assemblyPath;
 
         path.Set(ibcDir);                               // yes, put it in the directory, named with the assembly name.
@@ -10984,7 +10988,7 @@ public:
         {
             CORBBTPROF_FILE_HEADER *fileHeader;
             fileHeader = (CORBBTPROF_FILE_HEADER *) profileMap->Allocate(sizeof(CORBBTPROF_FILE_HEADER));
-            
+
             fileHeader->HeaderSize = sizeof(CORBBTPROF_FILE_HEADER);
             fileHeader->Magic      = CORBBTPROF_MAGIC;
             fileHeader->Version    = CORBBTPROF_CURRENT_VERSION;
@@ -11011,7 +11015,7 @@ public:
 
             tableHeader->NumEntries = numSections;
             tableEntryOffset = profileMap->getCurrentOffset();
-            
+
             CORBBTPROF_SECTION_TABLE_ENTRY *tableEntry;
             tableEntry = (CORBBTPROF_SECTION_TABLE_ENTRY *)
                 profileMap->Allocate(sizeof(CORBBTPROF_SECTION_TABLE_ENTRY) * numSections);
@@ -11026,18 +11030,18 @@ public:
             {
                 SIZE_T offset = profileMap->getCurrentOffset();
                 assert((offset & 0x3) == 0);
-                
+
                 SIZE_T actualSize  = pSec->profileMap.getCurrentOffset();
                 SIZE_T alignUpSize = AlignUp(actualSize, sizeof(DWORD));
-                
+
                 profileMap->Allocate(alignUpSize);
-                
+
                 memcpy(profileMap->getOffsetPtr(offset), pSec->profileMap.getOffsetPtr(0), actualSize);
                 if (alignUpSize > actualSize)
                 {
-                    memset(((BYTE*)profileMap->getOffsetPtr(offset))+actualSize, 0, (alignUpSize - actualSize)); 
+                    memset(((BYTE*)profileMap->getOffsetPtr(offset))+actualSize, 0, (alignUpSize - actualSize));
                 }
-                
+
                 CORBBTPROF_SECTION_TABLE_ENTRY *tableEntry;
                 tableEntry = (CORBBTPROF_SECTION_TABLE_ENTRY *) profileMap->getOffsetPtr(tableEntryOffset);
                 tableEntry += secCount;
@@ -11053,7 +11057,7 @@ public:
         {
             ULONG *endToken;
             endToken = (ULONG *) profileMap->Allocate(sizeof(ULONG));
-            
+
             *endToken = CORBBTPROF_END_TOKEN;
         }
     }
@@ -11099,7 +11103,7 @@ bool        TypeSpecBlobEntry::IsEqual(const ProfilingBlobEntry *  other) const
 
     PCCOR_SIGNATURE  p1 = this->pSig();
     PCCOR_SIGNATURE  p2 = other2->pSig();
-    
+
     for (DWORD i=0; (i < this->cbSig()); i++)
         if (p1[i] != p2[i])
             return false;
@@ -11145,8 +11149,8 @@ TypeSpecBlobEntry::TypeSpecBlobEntry(DWORD _cbSig, PCCOR_SIGNATURE _pSig)
     m_pSig = const_cast<PCCOR_SIGNATURE>(pNewSig);
 }
 
-/* static */ const TypeSpecBlobEntry *  TypeSpecBlobEntry::FindOrAdd(PTR_Module      pModule, 
-                                                                     DWORD           _cbSig, 
+/* static */ const TypeSpecBlobEntry *  TypeSpecBlobEntry::FindOrAdd(PTR_Module      pModule,
+                                                                     DWORD           _cbSig,
                                                                      PCCOR_SIGNATURE _pSig)
 {
     CONTRACTL
@@ -11166,7 +11170,7 @@ TypeSpecBlobEntry::TypeSpecBlobEntry(DWORD _cbSig, PCCOR_SIGNATURE _pSig)
     {
         //
         // Not Found, add a new type spec profiling blob entry
-        // 
+        //
         TypeSpecBlobEntry * newEntry = new (nothrow) TypeSpecBlobEntry(_cbSig, _pSig);
         if (newEntry == NULL)
             return NULL;
@@ -11179,7 +11183,7 @@ TypeSpecBlobEntry::TypeSpecBlobEntry(DWORD _cbSig, PCCOR_SIGNATURE _pSig)
 
     //
     // Return the type spec entry that we found or the new one that we just created
-    // 
+    //
     _ASSERTE(pEntry->kind() == ParamTypeSpec);
     return static_cast<const TypeSpecBlobEntry *>(pEntry);
 }
@@ -11198,7 +11202,7 @@ bool        MethodSpecBlobEntry::IsEqual(const ProfilingBlobEntry *  other) cons
 
     PCCOR_SIGNATURE  p1 = this->pSig();
     PCCOR_SIGNATURE  p2 = other2->pSig();
-    
+
     for (DWORD i=0; (i < this->cbSig()); i++)
         if (p1[i] != p2[i])
             return false;
@@ -11244,8 +11248,8 @@ MethodSpecBlobEntry::MethodSpecBlobEntry(DWORD _cbSig, PCCOR_SIGNATURE _pSig)
     m_pSig = const_cast<PCCOR_SIGNATURE>(pNewSig);
 }
 
-/* static */ const MethodSpecBlobEntry *  MethodSpecBlobEntry::FindOrAdd(PTR_Module      pModule, 
-                                                                         DWORD           _cbSig, 
+/* static */ const MethodSpecBlobEntry *  MethodSpecBlobEntry::FindOrAdd(PTR_Module      pModule,
+                                                                         DWORD           _cbSig,
                                                                          PCCOR_SIGNATURE _pSig)
 {
     CONTRACTL
@@ -11265,7 +11269,7 @@ MethodSpecBlobEntry::MethodSpecBlobEntry(DWORD _cbSig, PCCOR_SIGNATURE _pSig)
     {
         //
         // Not Found, add a new method spec profiling blob entry
-        // 
+        //
         MethodSpecBlobEntry * newEntry = new (nothrow) MethodSpecBlobEntry(_cbSig, _pSig);
         if (newEntry == NULL)
             return NULL;
@@ -11278,7 +11282,7 @@ MethodSpecBlobEntry::MethodSpecBlobEntry(DWORD _cbSig, PCCOR_SIGNATURE _pSig)
 
     //
     // Return the method spec entry that we found or the new one that we just created
-    // 
+    //
     _ASSERTE(pEntry->kind() == ParamMethodSpec);
     return static_cast<const MethodSpecBlobEntry *>(pEntry);
 }
@@ -11297,7 +11301,7 @@ bool        ExternalNamespaceBlobEntry::IsEqual(const ProfilingBlobEntry *  othe
 
     LPCSTR p1 = this->pName();
     LPCSTR p2 = other2->pName();
-    
+
     for (DWORD i=0; (i < this->cbName()); i++)
         if (p1[i] != p2[i])
             return false;
@@ -11361,7 +11365,7 @@ ExternalNamespaceBlobEntry::ExternalNamespaceBlobEntry(LPCSTR _pName)
     {
         //
         // Not Found, add a new external namespace blob entry
-        // 
+        //
         ExternalNamespaceBlobEntry * newEntry = new (nothrow) ExternalNamespaceBlobEntry(_pName);
         if (newEntry == NULL)
             return NULL;
@@ -11374,7 +11378,7 @@ ExternalNamespaceBlobEntry::ExternalNamespaceBlobEntry(LPCSTR _pName)
 
     //
     // Return the external namespace entry that we found or the new one that we just created
-    // 
+    //
     _ASSERTE(pEntry->kind() == ExternalNamespaceDef);
     return static_cast<const ExternalNamespaceBlobEntry *>(pEntry);
 }
@@ -11402,7 +11406,7 @@ bool        ExternalTypeBlobEntry::IsEqual(const ProfilingBlobEntry *  other) co
 
     LPCSTR p1 = this->pName();
     LPCSTR p2 = other2->pName();
-    
+
     for (DWORD i=0; (i < this->cbName()); i++)
         if (p1[i] != p2[i])
             return false;
@@ -11421,16 +11425,16 @@ size_t     ExternalTypeBlobEntry::Hash() const
     hashValue = HashCombine(hashValue, nameSpace());
 
     LPCSTR p1 = pName();
-    
+
     for (DWORD i=0; (i < cbName()); i++)
         hashValue = HashCombine(hashValue, p1[i]);
 
     return hashValue;
 }
 
-ExternalTypeBlobEntry::ExternalTypeBlobEntry(mdToken _assemblyRef, 
+ExternalTypeBlobEntry::ExternalTypeBlobEntry(mdToken _assemblyRef,
                                              mdToken _nestedClass,
-                                             mdToken _nameSpace, 
+                                             mdToken _nameSpace,
                                              LPCSTR  _pName)
 {
    CONTRACTL
@@ -11442,9 +11446,9 @@ ExternalTypeBlobEntry::ExternalTypeBlobEntry(mdToken _assemblyRef,
     CONTRACTL_END;
 
     m_token  = idExternalTypeNil;
-    m_assemblyRef = mdAssemblyRefNil; 
-    m_nestedClass = idExternalTypeNil; 
-    m_nameSpace   = idExternalNamespaceNil; 
+    m_assemblyRef = mdAssemblyRefNil;
+    m_nestedClass = idExternalTypeNil;
+    m_nameSpace   = idExternalNamespaceNil;
     m_cbName = 0;
     m_pName  = NULL;
 
@@ -11461,10 +11465,10 @@ ExternalTypeBlobEntry::ExternalTypeBlobEntry(mdToken _assemblyRef,
     }
 }
 
-/* static */ const ExternalTypeBlobEntry *  ExternalTypeBlobEntry::FindOrAdd(PTR_Module pModule, 
-                                                                             mdToken    _assemblyRef, 
+/* static */ const ExternalTypeBlobEntry *  ExternalTypeBlobEntry::FindOrAdd(PTR_Module pModule,
+                                                                             mdToken    _assemblyRef,
                                                                              mdToken    _nestedClass,
-                                                                             mdToken    _nameSpace, 
+                                                                             mdToken    _nameSpace,
                                                                              LPCSTR     _pName)
 {
    CONTRACTL
@@ -11484,7 +11488,7 @@ ExternalTypeBlobEntry::ExternalTypeBlobEntry(mdToken _assemblyRef,
     {
         //
         // Not Found, add a new external type blob entry
-        // 
+        //
         ExternalTypeBlobEntry *  newEntry = new (nothrow) ExternalTypeBlobEntry(_assemblyRef, _nestedClass, _nameSpace, _pName);
         if (newEntry == NULL)
             return NULL;
@@ -11497,7 +11501,7 @@ ExternalTypeBlobEntry::ExternalTypeBlobEntry(mdToken _assemblyRef,
 
     //
     // Return the external type entry that we found or the new one that we just created
-    // 
+    //
     _ASSERTE(pEntry->kind() == ExternalTypeDef);
     return static_cast<const ExternalTypeBlobEntry *>(pEntry);
 }
@@ -11516,7 +11520,7 @@ bool        ExternalSignatureBlobEntry::IsEqual(const ProfilingBlobEntry *  othe
 
     PCCOR_SIGNATURE  p1 = this->pSig();
     PCCOR_SIGNATURE  p2 = other2->pSig();
-    
+
     for (DWORD i=0; (i < this->cbSig()); i++)
         if (p1[i] != p2[i])
             return false;
@@ -11533,7 +11537,7 @@ size_t     ExternalSignatureBlobEntry::Hash() const
     hashValue = HashCombine(hashValue, cbSig());
 
     PCCOR_SIGNATURE  p1 = pSig();
-    
+
     for (DWORD i=0; (i < cbSig()); i++)
         hashValue = HashCombine(hashValue, p1[i]);
 
@@ -11563,8 +11567,8 @@ ExternalSignatureBlobEntry::ExternalSignatureBlobEntry(DWORD _cbSig, PCCOR_SIGNA
     m_pSig = const_cast<PCCOR_SIGNATURE>(pNewSig);
 }
 
-/* static */ const ExternalSignatureBlobEntry *  ExternalSignatureBlobEntry::FindOrAdd(PTR_Module      pModule, 
-                                                                                       DWORD           _cbSig, 
+/* static */ const ExternalSignatureBlobEntry *  ExternalSignatureBlobEntry::FindOrAdd(PTR_Module      pModule,
+                                                                                       DWORD           _cbSig,
                                                                                        PCCOR_SIGNATURE _pSig)
 {
     CONTRACTL
@@ -11584,7 +11588,7 @@ ExternalSignatureBlobEntry::ExternalSignatureBlobEntry(DWORD _cbSig, PCCOR_SIGNA
     {
         //
         // Not Found, add a new external signature blob entry
-        // 
+        //
         ExternalSignatureBlobEntry * newEntry = new (nothrow) ExternalSignatureBlobEntry(_cbSig, _pSig);
         if (newEntry == NULL)
             return NULL;
@@ -11597,7 +11601,7 @@ ExternalSignatureBlobEntry::ExternalSignatureBlobEntry(DWORD _cbSig, PCCOR_SIGNA
 
     //
     // Return the external signature entry that we found or the new one that we just created
-    // 
+    //
     _ASSERTE(pEntry->kind() == ExternalSignatureDef);
     return static_cast<const ExternalSignatureBlobEntry *>(pEntry);
 }
@@ -11622,7 +11626,7 @@ bool        ExternalMethodBlobEntry::IsEqual(const ProfilingBlobEntry *  other) 
 
     LPCSTR p1 = this->pName();
     LPCSTR p2 = other2->pName();
-    
+
     for (DWORD i=0; (i < this->cbName()); i++)
         if (p1[i] != p2[i])
             return false;
@@ -11640,15 +11644,15 @@ size_t     ExternalMethodBlobEntry::Hash() const
     hashValue = HashCombine(hashValue, signature());
 
     LPCSTR p1 = pName();
-    
+
     for (DWORD i=0; (i < cbName()); i++)
         hashValue = HashCombine(hashValue, p1[i]);
 
     return hashValue;
 }
 
-ExternalMethodBlobEntry::ExternalMethodBlobEntry(mdToken _nestedClass, 
-                                                 mdToken _signature, 
+ExternalMethodBlobEntry::ExternalMethodBlobEntry(mdToken _nestedClass,
+                                                 mdToken _signature,
                                                  LPCSTR  _pName)
 {
     CONTRACTL
@@ -11660,8 +11664,8 @@ ExternalMethodBlobEntry::ExternalMethodBlobEntry(mdToken _nestedClass,
     CONTRACTL_END;
 
     m_token       = idExternalMethodNil;
-    m_nestedClass = idExternalTypeNil; 
-    m_signature   = idExternalSignatureNil; 
+    m_nestedClass = idExternalTypeNil;
+    m_signature   = idExternalSignatureNil;
     m_cbName      = 0;
 
     DWORD _cbName = (DWORD) strlen(_pName) + 1;
@@ -11677,9 +11681,9 @@ ExternalMethodBlobEntry::ExternalMethodBlobEntry(mdToken _nestedClass,
         }
 
 /* static */ const ExternalMethodBlobEntry *  ExternalMethodBlobEntry::FindOrAdd(
-                                                             PTR_Module pModule, 
-                                                             mdToken    _nestedClass, 
-                                                             mdToken    _signature, 
+                                                             PTR_Module pModule,
+                                                             mdToken    _nestedClass,
+                                                             mdToken    _signature,
                                                              LPCSTR     _pName)
 {
     CONTRACTL
@@ -11700,7 +11704,7 @@ ExternalMethodBlobEntry::ExternalMethodBlobEntry(mdToken _nestedClass,
     {
         //
         // Not Found, add a new external type blob entry
-        // 
+        //
         ExternalMethodBlobEntry *  newEntry;
         newEntry = new (nothrow) ExternalMethodBlobEntry(_nestedClass, _signature, _pName);
         if (newEntry == NULL)
@@ -11714,7 +11718,7 @@ ExternalMethodBlobEntry::ExternalMethodBlobEntry(mdToken _nestedClass,
 
     //
     // Return the external method entry that we found or the new one that we just created
-    // 
+    //
     _ASSERTE(pEntry->kind() == ExternalMethodDef);
     return static_cast<const ExternalMethodBlobEntry *>(pEntry);
 }
@@ -11821,7 +11825,7 @@ void SaveManagedCommandLine(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR *argv)
 
     // We will append pwzAssemblyPath to the 'corerun' osCommandLine
     commandLineLen += (wcslen(pwzAssemblyPath) + 1);
-    
+
     for (int i = 0; i < argc; i++)
     {
         commandLineLen += (wcslen(argv[i]) + 1);
@@ -11843,7 +11847,7 @@ void SaveManagedCommandLine(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR *argv)
     }
 
     s_pCommandLine = pNewCommandLine;
-#endif 
+#endif
 }
 
 static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR scopeName, GUID* pMvid)
@@ -11865,7 +11869,7 @@ static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR sc
     {
         CORBBTPROF_SCENARIO_INFO_SECTION_HEADER *siHeader;
         siHeader = (CORBBTPROF_SCENARIO_INFO_SECTION_HEADER *) profileMap->Allocate(sizeof(CORBBTPROF_SCENARIO_INFO_SECTION_HEADER));
-        
+
         siHeader->NumScenarios = 1;
         siHeader->TotalNumRuns = 1;
     }
@@ -11890,7 +11894,7 @@ static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR sc
         {
             ThrowHR(COR_E_OVERFLOW);
         }
-        
+
         LPCWSTR  pSystemInfo = W("<machine,OS>");
         S_SIZE_T cSystemInfo = S_SIZE_T(wcslen(pSystemInfo));
         cSystemInfo += 1;
@@ -11898,13 +11902,13 @@ static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR sc
         {
             ThrowHR(COR_E_OVERFLOW);
         }
-        
+
         FILETIME runTime, unused1, unused2, unused3;
         GetProcessTimes(GetCurrentProcess(), &runTime, &unused1, &unused2, &unused3);
-        
+
         WCHAR    scenarioName[256];
         GetBasename(pCmdLine, &scenarioName[0], 256);
-        
+
         LPCWSTR  pName      = &scenarioName[0];
         S_SIZE_T cName      = S_SIZE_T(wcslen(pName));
         cName += 1;
@@ -11919,7 +11923,7 @@ static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR sc
         {
             ThrowHR(COR_E_OVERFLOW);
         }
-        
+
         S_SIZE_T sizeRun    = S_SIZE_T(sizeof(CORBBTPROF_SCENARIO_RUN));
         sizeRun += cCmdLine * S_SIZE_T(sizeof(WCHAR));
         sizeRun += cSystemInfo * S_SIZE_T(sizeof(WCHAR));
@@ -11927,10 +11931,10 @@ static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR sc
         {
             ThrowHR(COR_E_OVERFLOW);
         }
-        
+
         //
         // Allocate the Scenario Header struct
-        // 
+        //
         SIZE_T sHeaderOffset;
         {
             CORBBTPROF_SCENARIO_HEADER *sHeader;
@@ -11939,10 +11943,10 @@ static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR sc
             {
                 ThrowHR(COR_E_OVERFLOW);
             }
-            
+
             sHeaderOffset = profileMap->getCurrentOffset();
             sHeader = (CORBBTPROF_SCENARIO_HEADER *) profileMap->Allocate(sizeHeader.Value());
-            
+
             sHeader->size              = sHeaderSize.Value();
             sHeader->scenario.ordinal  = 1;
             sHeader->scenario.mask     = 1;
@@ -11954,11 +11958,11 @@ static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR sc
 
         //
         // Allocate the Scenario Run struct
-        // 
+        //
         {
             CORBBTPROF_SCENARIO_RUN *sRun;
             sRun = (CORBBTPROF_SCENARIO_RUN *)  profileMap->Allocate(sizeRun.Value());
-            
+
             sRun->runTime     = runTime;
             sRun->mvid        = *pMvid;
             sRun->cCmdLine    = cCmdLine.Value();
@@ -11988,7 +11992,7 @@ static void ProfileDataAllocateMethodBlockCounts(ProfileEmitter * pEmitter, CORC
     CONTRACTL_END;
 
     ProfileMap *profileMap = pEmitter->EmitNewSection(MethodBlockCounts);
-    
+
     //
     // Allocate and initialize the method block count section
     //
@@ -12008,14 +12012,14 @@ static void ProfileDataAllocateMethodBlockCounts(ProfileEmitter * pEmitter, CORC
          methodProfileList = methodProfileList->next)
     {
         CORBBTPROF_METHOD_HEADER * pInfo = methodProfileList->GetInfo();
-        
+
         assert(pInfo->size == pInfo->Size());
-        
+
         //
         // We set methodWasExecuted based upon the ExecutionCount of the very first block
-        // 
+        //
         bool methodWasExecuted = (pInfo->method.block[0].ExecutionCount > 0);
-        
+
         //
         // If the method was not executed then we don't need to output this methods block counts
         //
@@ -12028,7 +12032,7 @@ static void ProfileDataAllocateMethodBlockCounts(ProfileEmitter * pEmitter, CORC
             memcpy(methodHeader, pInfo, profileDataSize);
             numMethods++;
         }
-        
+
         // Reset all of the basic block counts to zero
         for (UINT32 i=0; (i <  pInfo->method.cBlock); i++ )
         {
@@ -12036,11 +12040,11 @@ static void ProfileDataAllocateMethodBlockCounts(ProfileEmitter * pEmitter, CORC
             // If methodWasExecuted is false then every block's ExecutionCount should also be zero
             //
             _ASSERTE(methodWasExecuted  || (pInfo->method.block[i].ExecutionCount == 0));
-            
+
             pInfo->method.block[i].ExecutionCount = 0;
         }
     }
-    
+
     {
         CORBBTPROF_METHOD_BLOCK_COUNTS_SECTION_HEADER *mbcHeader;
         // We have to refetch the mbcHeader as calls to Allocate will resize and thus move the mbcHeader
@@ -12068,19 +12072,19 @@ static void ProfileDataAllocateMethodBlockCounts(ProfileEmitter * pEmitter, CORC
         for (int format = 0; format < (int)SectionFormatCount; format++)
         {
             CQuickArray<CORBBTPROF_TOKEN_INFO> *pTokenArray = &(pTokenProfileData->m_formats[format].tokenArray);
-            
+
             if (pTokenArray->Size() != 0)
             {
                 ProfileMap *  profileMap = pEmitter->EmitNewSection((SectionFormat) format);
-                
+
                 CORBBTPROF_TOKEN_LIST_SECTION_HEADER *header;
                 header = (CORBBTPROF_TOKEN_LIST_SECTION_HEADER *)
                     profileMap->Allocate(sizeof(CORBBTPROF_TOKEN_LIST_SECTION_HEADER) +
                                          pTokenArray->Size() * sizeof(CORBBTPROF_TOKEN_INFO));
-                
+
                 header->NumTokens = pTokenArray->Size();
                 memcpy( (header + 1), &((*pTokenArray)[0]), pTokenArray->Size() * sizeof(CORBBTPROF_TOKEN_INFO));
-                
+
                 // Reset the collected tokens
                 for (unsigned i = 0; i < CORBBTPROF_TOKEN_MAX_NUM_FLAGS; i++)
                 {
@@ -12115,8 +12119,8 @@ static void ProfileDataAllocateTokenDefinitions(ProfileEmitter * pEmitter, Modul
     size_t totalSize = 0;
 
     for (ProfilingBlobTable::Iterator cur = pModule->GetProfilingBlobTable()->Begin(),
-                                      end = pModule->GetProfilingBlobTable()->End(); 
-         (cur != end); 
+                                      end = pModule->GetProfilingBlobTable()->End();
+         (cur != end);
          cur++)
     {
         const ProfilingBlobEntry * pEntry = *cur;
@@ -12157,8 +12161,8 @@ static void ProfileDataAllocateTokenDefinitions(ProfileEmitter * pEmitter, Modul
     // Traverse each element and record it
     size_t blobElementSize = 0;
     for (ProfilingBlobTable::Iterator cur = pModule->GetProfilingBlobTable()->Begin(),
-                                      end = pModule->GetProfilingBlobTable()->End(); 
-         (cur != end); 
+                                      end = pModule->GetProfilingBlobTable()->End();
+         (cur != end);
          cur++, currentPos += blobElementSize)
     {
         const ProfilingBlobEntry * pEntry = *cur;
@@ -12210,7 +12214,7 @@ static void ProfileDataAllocateTokenDefinitions(ProfileEmitter * pEmitter, Modul
             memcpy(&bProfileData->name[0], namespaceBlobEntry->pName(), namespaceBlobEntry->cbName());
             break;
         }
-            
+
         case ExternalTypeDef:
         {
             CORBBTPROF_BLOB_TYPE_DEF_ENTRY *       bProfileData        = (CORBBTPROF_BLOB_TYPE_DEF_ENTRY*) profileData;
@@ -12228,7 +12232,7 @@ static void ProfileDataAllocateTokenDefinitions(ProfileEmitter * pEmitter, Modul
             memcpy(&bProfileData->name[0], typeBlobEntry->pName(), typeBlobEntry->cbName());
             break;
         }
-            
+
         case ExternalSignatureDef:
         {
             CORBBTPROF_BLOB_SIGNATURE_DEF_ENTRY *  bProfileData        = (CORBBTPROF_BLOB_SIGNATURE_DEF_ENTRY*) profileData;
@@ -12266,20 +12270,20 @@ static void ProfileDataAllocateTokenDefinitions(ProfileEmitter * pEmitter, Modul
             break;
         }
     }
-    
+
     _ASSERTE(currentPos == totalSize);
-    
+
     // Emit a terminating entry with type EndOfBlobStream to mark the end
     DWORD mdElementSize = sizeof(CORBBTPROF_BLOB_ENTRY);
     void *profileData = profileMap->Allocate(mdElementSize);
     memset(profileData, 0, mdElementSize);
-    
+
     CORBBTPROF_BLOB_ENTRY* mdProfileData = (CORBBTPROF_BLOB_ENTRY*) profileData;
     mdProfileData->type = EndOfBlobStream;
     mdProfileData->size = sizeof(CORBBTPROF_BLOB_ENTRY);
 }
 
-// Responsible for writing out the profile data if the COMPlus_BBInstr 
+// Responsible for writing out the profile data if the COMPlus_BBInstr
 // environment variable is set.  This is called when the module is unloaded
 // (usually at shutdown).
 HRESULT Module::WriteMethodProfileDataLogFile(bool cleanup)
@@ -12310,9 +12314,9 @@ HRESULT Module::WriteMethodProfileDataLogFile(bool cleanup)
             LPCSTR pszName;
             GUID mvid;
             IfFailThrow(GetMDImport()->GetScopeProps(&pszName, &mvid));
-            
+
             CrstHolder ch(&m_tokenProfileData->crst);
-            
+
             //
             // Create the scenario info section
             //
@@ -12320,19 +12324,19 @@ HRESULT Module::WriteMethodProfileDataLogFile(bool cleanup)
 
             //
             // Create the method block count section
-            // 
+            //
             ProfileDataAllocateMethodBlockCounts(pEmitter, m_methodProfileList);
 
             //
             // Create the token list sections
-            // 
+            //
             ProfileDataAllocateTokenLists(pEmitter, m_tokenProfileData);
 
             //
             // Create the ibc token definition section (aka the Blob stream)
-            // 
+            //
             ProfileDataAllocateTokenDefinitions(pEmitter, this);
-  
+
             //
             // Now store the profile data in the ibc file
             //
@@ -12413,13 +12417,13 @@ PTR_ProfilingBlobTable Module::GetProfilingBlobTable()
 void Module::CreateProfilingData()
 {
     TokenProfileData *tpd = TokenProfileData::CreateNoThrow();
-    
+
     PVOID pv = InterlockedCompareExchangeT(&m_tokenProfileData, tpd, NULL);
     if (pv != NULL)
     {
         delete tpd;
     }
-    
+
     PTR_ProfilingBlobTable ppbt = new (nothrow) ProfilingBlobTable();
 
     if (ppbt != NULL)
@@ -12437,8 +12441,8 @@ void Module::DeleteProfilingData()
     if (m_pProfilingBlobTable != NULL)
     {
         for (ProfilingBlobTable::Iterator cur = m_pProfilingBlobTable->Begin(),
-                                          end = m_pProfilingBlobTable->End(); 
-             (cur != end); 
+                                          end = m_pProfilingBlobTable->End();
+             (cur != end);
              cur++)
         {
             const ProfilingBlobEntry *  pCurrentEntry = *cur;
@@ -12453,7 +12457,7 @@ void Module::DeleteProfilingData()
         delete m_tokenProfileData;
         m_tokenProfileData = NULL;
     }
-    
+
     // the metadataProfileData is free'ed in destructor of the corresponding MetaDataTracker
 }
 
@@ -12511,7 +12515,7 @@ void Module::LogTokenAccess(mdToken token, SectionFormat format, ULONG flagnum)
     }
     CONTRACTL_END;
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
 
     //
     // If we are in ngen instrumentation mode, then we should record this token.
@@ -12559,7 +12563,7 @@ void Module::LogTokenAccess(mdToken token, SectionFormat format, ULONG flagnum)
     {
         return;
     }
-    
+
     CQuickArray<CORBBTPROF_TOKEN_INFO> * pTokenArray  = &m_tokenProfileData->m_formats[format].tokenArray;
     RidBitmap *                          pTokenBitmap = &m_tokenProfileData->m_formats[tkKind].tokenBitmaps[flagnum];
 
@@ -12649,34 +12653,34 @@ void Module::LogTokenAccess(mdToken token, ULONG flagNum)
     mdAssemblyRef        mdAssemblyRef      = TokenFromRid(index, mdtAssemblyRef);
     IMDInternalImport *  pImport            = pReferencedModule->GetMDImport();
     LPCUTF8              szName             = NULL;
-    
+
     if (TypeFromToken(*pToken) == mdtTypeDef)
     {
         //
         // Compute nested type (if any)
-        // 
+        //
         mdTypeDef mdEnclosingType = idExternalTypeNil;
         hr = pImport->GetNestedClassProps(*pToken, &mdEnclosingType);
         // If there's not enclosing type, then hr=CLDB_E_RECORD_NOTFOUND and mdEnclosingType is unchanged
         _ASSERTE((hr == S_OK) || (hr == CLDB_E_RECORD_NOTFOUND));
-        
+
         if (!IsNilToken(mdEnclosingType))
         {
             _ASSERT(TypeFromToken(mdEnclosingType) ==  mdtTypeDef);
             TokenDefinitionHelper(pModuleContext, pReferencedModule, index, &mdEnclosingType);
         }
         _ASSERT(TypeFromToken(mdEnclosingType) == ibcExternalType);
-        
+
         //
         // Compute type name and namespace.
         //
         LPCUTF8 szNamespace = NULL;
         hr = pImport->GetNameOfTypeDef(*pToken, &szName, &szNamespace);
         _ASSERTE(hr == S_OK);
-        
+
         //
         // Transform namespace string into ibc external namespace token
-        // 
+        //
         idExternalNamespace idNamespace = idExternalNamespaceNil;
         if (szNamespace != NULL)
         {
@@ -12691,14 +12695,14 @@ void Module::LogTokenAccess(mdToken token, ULONG flagNum)
 
         //
         // Transform type name into ibc external type token
-        // 
+        //
         idExternalType idType = idExternalTypeNil;
         _ASSERTE(szName != NULL);
         const ExternalTypeBlobEntry *  pTypeEntry = NULL;
-        pTypeEntry = ExternalTypeBlobEntry::FindOrAdd(pReferencingModule, 
-                                                      mdAssemblyRef, 
+        pTypeEntry = ExternalTypeBlobEntry::FindOrAdd(pReferencingModule,
+                                                      mdAssemblyRef,
                                                       mdEnclosingType,
-                                                      idNamespace, 
+                                                      idNamespace,
                                                       szName);
         if (pTypeEntry != NULL)
         {
@@ -12706,13 +12710,13 @@ void Module::LogTokenAccess(mdToken token, ULONG flagNum)
         }
         _ASSERTE(TypeFromToken(idType) == ibcExternalType);
 
-        *pToken = idType;   // Remap pToken to our idExternalType token 
+        *pToken = idType;   // Remap pToken to our idExternalType token
     }
     else if (TypeFromToken(*pToken) == mdtMethodDef)
     {
         //
         // Compute nested type (if any)
-        // 
+        //
         mdTypeDef mdEnclosingType = idExternalTypeNil;
         hr = pImport->GetParentToken(*pToken, &mdEnclosingType);
         _ASSERTE(!FAILED(hr));
@@ -12726,15 +12730,15 @@ void Module::LogTokenAccess(mdToken token, ULONG flagNum)
 
         //
         // Compute the method name and signature
-        // 
+        //
         PCCOR_SIGNATURE pSig = NULL;
         DWORD           cbSig = 0;
         hr = pImport->GetNameAndSigOfMethodDef(*pToken, &pSig, &cbSig, &szName);
         _ASSERTE(hr == S_OK);
-        
+
         //
         // Transform signature into ibc external signature token
-        // 
+        //
         idExternalSignature idSignature = idExternalSignatureNil;
         if (pSig != NULL)
         {
@@ -12749,13 +12753,13 @@ void Module::LogTokenAccess(mdToken token, ULONG flagNum)
 
         //
         // Transform method name into ibc external method token
-        // 
+        //
         idExternalMethod idMethod = idExternalMethodNil;
         _ASSERTE(szName != NULL);
         const ExternalMethodBlobEntry *  pMethodEntry = NULL;
-        pMethodEntry = ExternalMethodBlobEntry::FindOrAdd(pReferencingModule, 
+        pMethodEntry = ExternalMethodBlobEntry::FindOrAdd(pReferencingModule,
                                                           mdEnclosingType,
-                                                          idSignature, 
+                                                          idSignature,
                                                           szName);
         if (pMethodEntry != NULL)
         {
@@ -12763,7 +12767,7 @@ void Module::LogTokenAccess(mdToken token, ULONG flagNum)
         }
         _ASSERTE(TypeFromToken(idMethod) == ibcExternalMethod);
 
-        *pToken = idMethod;   // Remap pToken to our idMethodSpec token 
+        *pToken = idMethod;   // Remap pToken to our idMethodSpec token
     }
     else
     {
@@ -12799,7 +12803,7 @@ idTypeSpec Module::LogInstantiatedType(TypeHandle typeHnd, ULONG flagNum)
 
         SigBuilder sigBuilder;
 
-        ZapSig zapSig(this, this, ZapSig::IbcTokens, 
+        ZapSig zapSig(this, this, ZapSig::IbcTokens,
                         Module::EncodeModuleHelper, Module::TokenDefinitionHelper);
         BOOL fSuccess = zapSig.GetSignatureForTypeHandle(typeHnd, &sigBuilder);
 
@@ -12841,15 +12845,15 @@ idMethodSpec Module::LogInstantiatedMethod(const MethodDesc * md, ULONG flagNum)
     {
         CONTRACT_VIOLATION(ThrowsViolation|FaultViolation|GCViolation);
 
-        if (!m_tokenProfileData) 
-        { 
-            CreateProfilingData(); 
-        } 
+        if (!m_tokenProfileData)
+        {
+            CreateProfilingData();
+        }
 
-        if (!m_tokenProfileData) 
-        { 
-            return idMethodSpecNil; 
-        } 
+        if (!m_tokenProfileData)
+        {
+            return idMethodSpecNil;
+        }
 
         // get data
         SigBuilder sigBuilder;
@@ -13017,20 +13021,20 @@ void ReflectionModule::Destruct()
 }
 
 // Returns true iff metadata capturing is suppressed.
-// 
+//
 // Notes:
-//   This is during the window after code:ReflectionModule.SuppressMetadataCapture and before 
+//   This is during the window after code:ReflectionModule.SuppressMetadataCapture and before
 //   code:ReflectionModule.ResumeMetadataCapture.
-//   
+//
 //   If metadata updates are suppressed, then class-load notifications should be suppressed too.
 bool ReflectionModule::IsMetadataCaptureSuppressed()
 {
     return m_fSuppressMetadataCapture;
 }
-// 
+//
 // Holder of changed value of MDUpdateMode via IMDInternalEmit::SetMDUpdateMode.
 // Returns back the original value on release.
-// 
+//
 class MDUpdateModeHolder
 {
 public:
@@ -13048,21 +13052,21 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         HRESULT hr = S_OK;
-        
+
         _ASSERTE(updateMode != UINT32_MAX);
-        
+
         IfFailRet(pEmitter->QueryInterface(IID_IMDInternalEmit, (void **)&m_pInternalEmitter));
         _ASSERTE(m_pInternalEmitter != NULL);
-        
+
         IfFailRet(m_pInternalEmitter->SetMDUpdateMode(updateMode, &m_OriginalMDUpdateMode));
         _ASSERTE(m_OriginalMDUpdateMode != UINT32_MAX);
-        
+
         return hr;
     }
     HRESULT Release(ULONG expectedPreviousUpdateMode = UINT32_MAX)
     {
         HRESULT hr = S_OK;
-        
+
         if (m_OriginalMDUpdateMode != UINT32_MAX)
         {
             _ASSERTE(m_pInternalEmitter != NULL);
@@ -13070,7 +13074,7 @@ public:
             // Ignore the error when releasing
             hr = m_pInternalEmitter->SetMDUpdateMode(m_OriginalMDUpdateMode, &previousUpdateMode);
             m_OriginalMDUpdateMode = UINT32_MAX;
-            
+
             if (expectedPreviousUpdateMode != UINT32_MAX)
             {
                 if ((hr == S_OK) && (expectedPreviousUpdateMode != previousUpdateMode))
@@ -13099,24 +13103,24 @@ private:
 
 // Called in live paths to fetch metadata for dynamic modules. This makes the metadata available to the
 // debugger from out-of-process.
-// 
+//
 // Notes:
-//    This buffer can be retrieved by the debugger via code:ReflectionModule.GetDynamicMetadataBuffer 
-//    
+//    This buffer can be retrieved by the debugger via code:ReflectionModule.GetDynamicMetadataBuffer
+//
 //    Threading:
 //    - Callers must ensure nobody else is adding to the metadata.
 //    - This function still takes its own locks to cooperate with the Debugger's out-of-process access.
 //      The debugger can slip this thread outside the locks to ensure the data is consistent.
-//    
+//
 //    This does not raise a debug notification to invalidate the metadata. Reasoning is that this only
 //    happens in two cases:
-//    1) manifest module is updated with the name of a new dynamic module. 
+//    1) manifest module is updated with the name of a new dynamic module.
 //    2) on each class load, in which case we already send a debug event. In this case, we already send a
 //    class-load notification, so sending a separate "metadata-refresh" would make the eventing twice as
 //    chatty. Class-load events are high-volume and events are slow.
 //    Thus we can avoid the chatiness by ensuring the debugger knows that Class-load also means "refresh
 //    metadata".
-//    
+//
 void ReflectionModule::CaptureModuleMetaDataToMemory()
 {
     CONTRACTL
@@ -13131,7 +13135,7 @@ void ReflectionModule::CaptureModuleMetaDataToMemory()
     // If a debugger is attached, then the CLR will still send ClassLoad notifications for dynamic modules,
     // which mean we still need to keep the metadata available. This is the same as Whidbey.
     // An alternative (and better) design would be to suppress ClassLoad notifications too, but then we'd
-    // need some way of sending a "catchup" notification to the debugger after we re-enable notifications. 
+    // need some way of sending a "catchup" notification to the debugger after we re-enable notifications.
     if (IsMetadataCaptureSuppressed() && !CORDebuggerAttached())
     {
         return;
@@ -13142,11 +13146,11 @@ void ReflectionModule::CaptureModuleMetaDataToMemory()
     _ASSERTE(pEmitter != NULL);
 
     HRESULT hr;
-    
+
     MDUpdateModeHolder hMDUpdateMode;
     IfFailThrow(hMDUpdateMode.SetMDUpdateMode(pEmitter, MDUpdateExtension));
     _ASSERTE(hMDUpdateMode.GetOriginalMDUpdateMode() == MDUpdateFull);
-    
+
     DWORD numBytes;
     hr = pEmitter->GetSaveSize(cssQuick, &numBytes);
     IfFailThrow(hr);
@@ -13158,40 +13162,40 @@ void ReflectionModule::CaptureModuleMetaDataToMemory()
     // ReflectionModule is still in a consistent state, and now we're just operating on local data to
     // assemble the new metadata buffer. If this fails, then worst case is that metadata does not include
     // recently generated classes.
-    
+
     // Caller ensures serialization that guarantees that the metadata doesn't grow underneath us.
     BYTE * pRawData = pBuffer->OpenRawBuffer(numBytes);
     hr = pEmitter->SaveToMemory(pRawData, numBytes);
     pBuffer->CloseRawBuffer();
 
     IfFailThrow(hr);
-    
+
     // Now that we're successful, transfer ownership back into the module.
     {
         CrstHolder ch(&m_CrstLeafLock);
 
         delete m_pDynamicMetadata;
-        
+
         m_pDynamicMetadata = pBuffer.Extract();
     }
 
-    // 
-    
+    //
+
     hr = hMDUpdateMode.Release(MDUpdateExtension);
     // Will be S_FALSE if someone changed the MDUpdateMode (from MDUpdateExtension) meanwhile
     _ASSERTE(hr == S_OK);
 }
 
 // Suppress the eager metadata serialization.
-// 
+//
 // Notes:
 //    This casues code:ReflectionModule.CaptureModuleMetaDataToMemory to be a nop.
 //    This is not nestable.
-//    This exists purely for performance reasons. 
-//    
-//    Don't call this directly. Use a SuppressMetadataCaptureHolder holder to ensure it's 
+//    This exists purely for performance reasons.
+//
+//    Don't call this directly. Use a SuppressMetadataCaptureHolder holder to ensure it's
 //    balanced with code:ReflectionModule.ResumeMetadataCapture
-//    
+//
 //    Types generating while eager metadata-capture is suppressed should not actually be executed until
 //    after metadata capture is restored.
 void ReflectionModule::SuppressMetadataCapture()
@@ -13203,17 +13207,17 @@ void ReflectionModule::SuppressMetadataCapture()
 }
 
 // Resumes eager metadata serialization.
-// 
+//
 // Notes:
 //    This casues code:ReflectionModule.CaptureModuleMetaDataToMemory to resume eagerly serializing metadata.
 //    This must be called after code:ReflectionModule.SuppressMetadataCapture.
-//    
+//
 void ReflectionModule::ResumeMetadataCapture()
 {
     WRAPPER_NO_CONTRACT;
     _ASSERTE(m_fSuppressMetadataCapture);
     m_fSuppressMetadataCapture = false;
-    
+
     CaptureModuleMetaDataToMemory();
 }
 
@@ -13235,10 +13239,10 @@ void ReflectionModule::ReleaseILData()
 
 #ifdef DACCESS_COMPILE
 // Accessor to expose m_pDynamicMetadata to debugger.
-// 
+//
 // Returns:
 //    Pointer to SBuffer  containing metadata buffer. May be null.
-//    
+//
 // Notes:
 //    Only used by the debugger, so only accessible via DAC.
 //    The buffer is updated via code:ReflectionModule.CaptureModuleMetaDataToMemory
@@ -13248,19 +13252,19 @@ PTR_SBuffer ReflectionModule::GetDynamicMetadataBuffer() const
 
     // If we ask for metadata, but have been suppressing capture, then we're out of date.
     // However, the debugger may be debugging already baked types in the module and so may need the metadata
-    // for that. So we return what we do have. 
-    // 
+    // for that. So we return what we do have.
+    //
     // Debugger will get the next metadata update:
     // 1) with the next load class
     // 2) or if this is right after the last class, see code:ReflectionModule.CaptureModuleMetaDataToMemory
 
-    return m_pDynamicMetadata; 
+    return m_pDynamicMetadata;
 }
 #endif
 
 TADDR ReflectionModule::GetIL(RVA il) // virtual
 {
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
     WRAPPER_NO_CONTRACT;
 
     BYTE* pByte = NULL;
@@ -13276,7 +13280,7 @@ TADDR ReflectionModule::GetIL(RVA il) // virtual
 PTR_VOID ReflectionModule::GetRvaField(RVA field, BOOL fZapped) // virtual
 {
     _ASSERTE(!fZapped);
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
     WRAPPER_NO_CONTRACT;
     // This function should be call only if the target is a field or a field with RVA.
     PTR_BYTE pByte = NULL;
@@ -13289,7 +13293,7 @@ PTR_VOID ReflectionModule::GetRvaField(RVA field, BOOL fZapped) // virtual
 #endif // DACCESS_COMPILE
 }
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
 
 // ===========================================================================
 // VASigCookies
@@ -13336,9 +13340,9 @@ VASigCookie *Module::GetVASigCookie(Signature vaSignature)
 
         // Compute the size of args first, outside of the lock.
 
-        // @TODO GENERICS: We may be calling a varargs method from a 
-        // generic type/method. Using an empty context will make such a 
-        // case cause an unexpected exception. To make this work, 
+        // @TODO GENERICS: We may be calling a varargs method from a
+        // generic type/method. Using an empty context will make such a
+        // case cause an unexpected exception. To make this work,
         // we need to create a specialized signature for every instantiation
         SigTypeContext typeContext;
 
@@ -13417,7 +13421,7 @@ void LookupMapBase::CreateHotItemList(DataImage *image, CorProfileData *profileD
     if (profileData)
     {
         DWORD numInTokenList = profileData->GetHotTokens(table, 1<<RidMap, 1<<RidMap, NULL, 0);
-        
+
         if (numInTokenList > 0)
         {
             HotItem *itemList = (HotItem*)(void*)image->GetModule()->GetLoaderAllocator()->GetHighFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(HotItem)) * S_SIZE_T(numInTokenList));
@@ -13507,9 +13511,9 @@ void LookupMapBase::Save(DataImage *image, DataImage::ItemKind kind, CorProfileD
     }
 
     // Determine whether we want to compress this lookup map (to improve density of cold pages in the map on
-    // hot item cache misses). We only enable this optimization for the TypeDefToMethodTable, the 
-    // GenericTypeDefToCanonMethodTable, and the MethodDefToDesc maps since (a) they're the largest and 
-    // as a result reap the most space savings and (b) these maps are fully populated in an ngen image and immutable 
+    // hot item cache misses). We only enable this optimization for the TypeDefToMethodTable, the
+    // GenericTypeDefToCanonMethodTable, and the MethodDefToDesc maps since (a) they're the largest and
+    // as a result reap the most space savings and (b) these maps are fully populated in an ngen image and immutable
     // at runtime, something that's important when dealing with a compressed version of the table.
     if (kind == DataImage::ITEM_TYPEDEF_MAP || kind == DataImage::ITEM_GENERICTYPEDEF_MAP || kind == DataImage::ITEM_METHODDEF_MAP)
     {
@@ -13650,7 +13654,7 @@ void LookupMapBase::Fixup(DataImage *image, BOOL fFixupEntries /*=TRUE*/)
                 image->ZeroPointerField(pTable, rid * sizeof(TADDR));
                 // In case this item is also in the hot item subtable, zero it there as well
                 if (hotItemValuePtr != NULL)
-                    image->ZeroPointerField(hotItemList, 
+                    image->ZeroPointerField(hotItemList,
                         (BYTE *)hotItemValuePtr - (BYTE *)hotItemList);
             }
 
@@ -13662,7 +13666,7 @@ void LookupMapBase::Fixup(DataImage *image, BOOL fFixupEntries /*=TRUE*/)
 
 #endif // !DACCESS_COMPILE
 
-#ifdef DACCESS_COMPILE 
+#ifdef DACCESS_COMPILE
 
 void
 LookupMapBase::EnumMemoryRegions(CLRDataEnumMemoryFlags flags,
@@ -13700,7 +13704,7 @@ LookupMapBase::EnumMemoryRegions(CLRDataEnumMemoryFlags flags,
             DacEnumMemoryRegion(dac_cast<TADDR>(pTable),
                                 dwCount * sizeof(TADDR));
     }
-#ifdef FEATURE_PREJIT 
+#ifdef FEATURE_PREJIT
     if (dwNumHotItems && hotItemList.IsValid())
     {
         DacEnumMemoryRegion(dac_cast<TADDR>(hotItemList),
@@ -13795,7 +13799,7 @@ CHECK Module::CheckActivated()
     }
     CONTRACTL_END;
 
-#ifndef DACCESS_COMPILE 
+#ifndef DACCESS_COMPILE
     DomainFile *pDomainFile = GetDomainFile();
     CHECK(pDomainFile != NULL);
     PREFIX_ASSUME(pDomainFile != NULL);
@@ -13804,7 +13808,7 @@ CHECK Module::CheckActivated()
     CHECK_OK;
 }
 
-#ifdef DACCESS_COMPILE 
+#ifdef DACCESS_COMPILE
 
 void
 ModuleCtorInfo::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
@@ -13961,7 +13965,7 @@ void Module::EnumMemoryRegions(CLRDataEnumMemoryFlags flags,
         }
 
     }   // !CLRDATA_ENUM_MEM_MINI && !CLRDATA_ENUM_MEM_TRIAGE
-    
+
 
     LookupMap<PTR_Module>::Iterator fileRefIter(&m_FileReferencesMap);
     while (fileRefIter.Next())
@@ -14016,7 +14020,7 @@ LPCWSTR Module::GetPathForErrorMessages()
     CONTRACTL_END
 
     PEFile *pFile = GetFile();
-    
+
     if (pFile)
     {
         return pFile->GetPathForErrorMessages();
@@ -14084,8 +14088,8 @@ void Module::ExpandAll()
             EX_TRY
             {
                 th = ClassLoader::LoadTypeDefOrRefOrSpecThrowing(
-                    pModule, 
-                    tok, 
+                    pModule,
+                    tok,
                     NULL /*SigTypeContext*/);
             }
             EX_CATCH
@@ -14261,7 +14265,7 @@ NOINLINE void NgenForceFailure_AV()
 NOINLINE void NgenForceFailure_TypeLoadException()
 {
     WRAPPER_NO_CONTRACT;
-    ::ThrowTypeLoadException("ForceIBC", "Failure", W("Assembly"), NULL, IDS_CLASSLOAD_BADFORMAT);       
+    ::ThrowTypeLoadException("ForceIBC", "Failure", W("Assembly"), NULL, IDS_CLASSLOAD_BADFORMAT);
 }
 
 void EEConfig::DebugCheckAndForceIBCFailure(BitForMask bitForMask)
@@ -14276,12 +14280,12 @@ void EEConfig::DebugCheckAndForceIBCFailure(BitForMask bitForMask)
     static DWORD s_ibcCheckCount = 0;
 
     // Both of these must be set to non-zero values for us to force a failure
-    // 
+    //
     if ((NgenForceFailureCount() == 0) || (NgenForceFailureKind() == 0))
         return;
 
     // The bitForMask value must also beset in the FailureMask
-    // 
+    //
     if ((((DWORD) bitForMask) & NgenForceFailureMask()) == 0)
         return;
 
@@ -14290,7 +14294,7 @@ void EEConfig::DebugCheckAndForceIBCFailure(BitForMask bitForMask)
         return;
 
     // We force one failure every NgenForceFailureCount()
-    // 
+    //
     s_ibcCheckCount = 0;
     switch (NgenForceFailureKind())
     {

--- a/src/vm/gcinfodecoder.cpp
+++ b/src/vm/gcinfodecoder.cpp
@@ -26,7 +26,14 @@
 #if defined(DACCESS_COMPILE) || defined(CROSSGEN_COMPILE)
 #define VALIDATE_OBJECTREF(objref, fDeep)
 #else // DACCESS_COMPILE || CROSSGEN_COMPILE
-#define VALIDATE_OBJECTREF(objref, fDeep) OBJECTREF_TO_UNCHECKED_OBJECTREF(objref)->Validate(fDeep)
+#define VALIDATE_OBJECTREF(objref, fDeep)                          \
+    do {                                                           \
+        Object* objPtr = OBJECTREF_TO_UNCHECKED_OBJECTREF(objref); \
+        if (objPtr)                                                \
+        {                                                          \
+            objPtr->Validate(fDeep);                               \
+        }                                                          \
+    } while(0)
 #endif // DACCESS_COMPILE || CROSSGEN_COMPILE
 #endif // !VALIDATE_OBJECTREF
 
@@ -69,7 +76,7 @@ bool GcInfoDecoder::SetIsInterruptibleCB (UINT32 startOffset, UINT32 stopOffset,
 {
     GcInfoDecoder *pThis = (GcInfoDecoder*)hCallback;
 
-    
+
     bool fStop = pThis->m_InstructionOffset >= startOffset && pThis->m_InstructionOffset < stopOffset;
 
     if (fStop)
@@ -131,7 +138,7 @@ GcInfoDecoder::GcInfoDecoder(
     m_HasTailCalls             = ((headerFlags & GC_INFO_HAS_TAILCALLS) != 0);
 #endif // _TARGET_AMD64_
     int hasSizeOfEditAndContinuePreservedArea = headerFlags & GC_INFO_HAS_EDIT_AND_CONTINUE_PRESERVED_SLOTS;
-    
+
     int hasReversePInvokeFrame = false;
     if (gcInfoToken.IsReversePInvokeFrameAvailable())
     {
@@ -165,14 +172,14 @@ GcInfoDecoder::GcInfoDecoder(
 
     if (hasGSCookie)
     {
-        // Note that normalization as a code offset can be different than 
+        // Note that normalization as a code offset can be different than
         //  normalization as code legnth
         UINT32 normCodeLength = NORMALIZE_CODE_OFFSET(m_CodeLength);
 
         // Decode prolog/epilog information
         UINT32 normPrologSize = (UINT32) m_Reader.DecodeVarLengthUnsigned(NORM_PROLOG_SIZE_ENCBASE) + 1;
         UINT32 normEpilogSize = (UINT32) m_Reader.DecodeVarLengthUnsigned(NORM_EPILOG_SIZE_ENCBASE);
-       
+
         m_ValidRangeStart = (UINT32) DENORMALIZE_CODE_OFFSET(normPrologSize);
         m_ValidRangeEnd = (UINT32) DENORMALIZE_CODE_OFFSET(normCodeLength - normEpilogSize);
         _ASSERTE(m_ValidRangeStart < m_ValidRangeEnd);
@@ -329,7 +336,7 @@ GcInfoDecoder::GcInfoDecoder(
     }
     else if(flags & DECODE_FOR_RANGES_CALLBACK)
     {
-        // Note that normalization as a code offset can be different than 
+        // Note that normalization as a code offset can be different than
         //  normalization as code legnth
         UINT32 normCodeLength = NORMALIZE_CODE_OFFSET(m_CodeLength);
 
@@ -380,7 +387,7 @@ bool GcInfoDecoder::IsSafePoint(UINT32 codeOffset)
     UINT32 safePointIndex = FindSafePoint(codeOffset);
     m_Reader.SetCurrentPos(savedPos);
     return (bool) (safePointIndex != m_NumSafePoints);
-    
+
 }
 
 UINT32 GcInfoDecoder::FindSafePoint(UINT32 breakOffset)
@@ -400,7 +407,7 @@ UINT32 GcInfoDecoder::FindSafePoint(UINT32 breakOffset)
 #endif
     {
         const UINT32 normBreakOffset = NORMALIZE_CODE_OFFSET(breakOffset);
-    
+
         INT32 low = 0;
         INT32 high = (INT32)m_NumSafePoints;
 
@@ -415,7 +422,7 @@ UINT32 GcInfoDecoder::FindSafePoint(UINT32 breakOffset)
                 result = (UINT32) mid;
                 break;
             }
-        
+
             if(normOffset < normBreakOffset)
                 low = mid+1;
             else
@@ -546,7 +553,7 @@ bool GcInfoDecoder::WantsReportOnlyLeaf()
     return m_WantsReportOnlyLeaf;
 #else
     return true;
-#endif    
+#endif
 }
 
 UINT32 GcInfoDecoder::GetCodeLength()
@@ -632,10 +639,10 @@ bool GcInfoDecoder::EnumerateLiveSlots(
     // Normalized break offset
     // Relative to interruptible ranges #if PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
 #ifdef PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
-    UINT32 pseudoBreakOffset = 0;  
+    UINT32 pseudoBreakOffset = 0;
     UINT32 numInterruptibleLength = 0;
 #else
-    UINT32 pseudoBreakOffset = normBreakOffset;  
+    UINT32 pseudoBreakOffset = normBreakOffset;
     UINT32 numInterruptibleLength = NORMALIZE_CODE_OFFSET(m_CodeLength);
 #endif
 
@@ -698,7 +705,7 @@ bool GcInfoDecoder::EnumerateLiveSlots(
                 goto ExitSuccess;
             }
         }
-    }        
+    }
 #else   // !PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
 
     // Skip interruptibility information
@@ -707,7 +714,7 @@ bool GcInfoDecoder::EnumerateLiveSlots(
         m_Reader.DecodeVarLengthUnsigned( INTERRUPTIBLE_RANGE_DELTA1_ENCBASE );
         m_Reader.DecodeVarLengthUnsigned( INTERRUPTIBLE_RANGE_DELTA2_ENCBASE );
     }
-#endif        
+#endif
 
 
     //------------------------------------------------------------------------------
@@ -717,9 +724,9 @@ bool GcInfoDecoder::EnumerateLiveSlots(
 
     slotDecoder.DecodeSlotTable(m_Reader);
 
-    {   
+    {
         UINT32 numSlots = slotDecoder.GetNumTracked();
-        
+
         if(!numSlots)
             goto ReportUntracked;
 
@@ -800,7 +807,7 @@ bool GcInfoDecoder::EnumerateLiveSlots(
                 }
             }
             goto ReportUntracked;
-        }        
+        }
         else
         {
             m_Reader.Skip(m_NumSafePoints * numSlots);
@@ -808,10 +815,10 @@ bool GcInfoDecoder::EnumerateLiveSlots(
                 goto ReportUntracked;
         }
 #endif // PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
-        
+
         _ASSERTE(m_NumInterruptibleRanges);
         _ASSERTE(numInterruptibleLength);
-        
+
         // If no info is found for the call site, we default to fully-interruptbile
         LOG((LF_GCROOTS, LL_INFO1000000, "No GC info found for call site at offset %x. Defaulting to fully-interruptible information.\n", (int) m_InstructionOffset));
 
@@ -823,7 +830,7 @@ bool GcInfoDecoder::EnumerateLiveSlots(
 
         if(!numBitsPerPointer)
             goto ReportUntracked;
-            
+
         size_t pointerTablePos = m_Reader.GetCurrentPos();
 
         size_t chunkPointer;
@@ -837,7 +844,7 @@ bool GcInfoDecoder::EnumerateLiveSlots(
 
             if(chunk-- == 0)
                 goto ReportUntracked;
-        }     
+        }
 
         size_t chunksStartPos = ((pointerTablePos + numChunks * numBitsPerPointer + 7) & (~7));
         size_t chunkPos = chunksStartPos + chunkPointer - 1;
@@ -869,7 +876,7 @@ bool GcInfoDecoder::EnumerateLiveSlots(
                 _ASSERTE(readSlots == numSlots);
 
             }
-            else 
+            else
             {
                 for(UINT32 i = 0; i < numSlots; i++)
                 {
@@ -878,7 +885,7 @@ bool GcInfoDecoder::EnumerateLiveSlots(
                 }
             }
             _ASSERTE(numCouldBeLiveSlots > 0);
-            
+
             BitStreamReader finalStateReader(m_Reader);
 
             m_Reader.Skip(numCouldBeLiveSlots);
@@ -919,9 +926,9 @@ bool GcInfoDecoder::EnumerateLiveSlots(
                     slotIndex += tmp;
                     cnt = (UINT32)couldBeLiveReader.DecodeVarLengthUnsigned( LIVESTATE_RLE_SKIP_ENCBASE );
                 }
-                
+
                 UINT32 isLive = (UINT32) finalStateReader.Read(1);
-                
+
                 if(chunk == breakChunk)
                 {
                     // Read transitions
@@ -940,7 +947,7 @@ bool GcInfoDecoder::EnumerateLiveSlots(
                             isLive ^= 1;
                         }
                     }
-                }        
+                }
 
                 if(isLive)
                 {
@@ -1059,7 +1066,7 @@ void GcSlotDecoder::DecodeSlotTable(BitStreamReader& reader)
     m_NumSlots = m_NumRegisters + numStackSlots + m_NumUntracked;
 
     UINT32 i = 0;
-    
+
     if(m_NumRegisters > 0)
     {
         // We certainly predecode the first register
@@ -1093,11 +1100,11 @@ void GcSlotDecoder::DecodeSlotTable(BitStreamReader& reader)
             m_SlotArray[i].Flags = flags;
         }
     }
-    
+
     if((numStackSlots > 0) && (i < MAX_PREDECODED_SLOTS))
     {
         // We have stack slots left and more room to predecode
-        
+
         GcStackSlotBase spBase = (GcStackSlotBase) reader.Read(2);
         UINT32 normSpOffset = (INT32) reader.DecodeVarLengthSigned(STACK_SLOT_ENCBASE);
         INT32 spOffset = DENORMALIZE_STACK_SLOT(normSpOffset);
@@ -1134,7 +1141,7 @@ void GcSlotDecoder::DecodeSlotTable(BitStreamReader& reader)
     if((m_NumUntracked > 0) && (i < MAX_PREDECODED_SLOTS))
     {
         // We have untracked stack slots left and more room to predecode
-        
+
         GcStackSlotBase spBase = (GcStackSlotBase) reader.Read(2);
         UINT32 normSpOffset = (INT32) reader.DecodeVarLengthSigned(STACK_SLOT_ENCBASE);
         INT32 spOffset = DENORMALIZE_STACK_SLOT(normSpOffset);
@@ -1177,15 +1184,15 @@ void GcSlotDecoder::DecodeSlotTable(BitStreamReader& reader)
         _ASSERTE(i == MAX_PREDECODED_SLOTS);
         m_NumDecodedSlots = i;
         m_pLastSlot = &m_SlotArray[MAX_PREDECODED_SLOTS - 1];
-        
-        m_SlotReader = reader;       
+
+        m_SlotReader = reader;
 
         // Move the argument reader past the end of the table
-        
+
         GcSlotFlags flags = m_pLastSlot->Flags;
 
         // Skip any remaining registers
-            
+
         for(; i < m_NumRegisters; i++)
         {
             if(flags)
@@ -1281,7 +1288,7 @@ const GcSlotDesc* GcSlotDecoder::GetSlotDesc(UINT32 slotIndex)
             //
             // Decode a register
             //
-            
+
             if(m_NumDecodedSlots == 0)
             {
                 // Decode the first register
@@ -1322,7 +1329,7 @@ const GcSlotDesc* GcSlotDecoder::GetSlotDesc(UINT32 slotIndex)
             else
             {
                 m_pLastSlot->Slot.Stack.Base = (GcStackSlotBase) m_SlotReader.Read(2);
-                
+
                 if(m_pLastSlot->Flags)
                 {
                     INT32 normSpOffset = (INT32) m_SlotReader.DecodeVarLengthSigned(STACK_SLOT_ENCBASE);
@@ -1337,7 +1344,7 @@ const GcSlotDesc* GcSlotDecoder::GetSlotDesc(UINT32 slotIndex)
                 }
             }
         }
-        
+
         m_NumDecodedSlots++;
     }
 
@@ -1443,7 +1450,7 @@ void GcInfoDecoder::ReportRegisterToGC(  // AMD64
     LOG((LF_GCROOTS, LL_INFO1000, "Reporting " FMT_REG, regNum ));
 
     OBJECTREF* pObjRef = GetRegisterSlot( regNum, pRD );
-#if defined(FEATURE_PAL) && !defined(SOS_TARGET_AMD64) 
+#if defined(FEATURE_PAL) && !defined(SOS_TARGET_AMD64)
     // On PAL, we don't always have the context pointers available due to
     // a limitation of an unwinding library. In such case, the context
     // pointers for some nonvolatile registers are NULL.
@@ -1452,13 +1459,13 @@ void GcInfoDecoder::ReportRegisterToGC(  // AMD64
     if (pObjRef == NULL)
     {
         // Report a pinned object to GC only in the promotion phase when the
-        // GC is scanning roots. 
+        // GC is scanning roots.
         GCCONTEXT* pGCCtx = (GCCONTEXT*)(hCallBack);
         if (!pGCCtx->sc->promotion)
         {
             return;
         }
-        
+
         pObjRef = GetCapturedRegister(regNum, pRD);
 
         gcFlags |= GC_CALL_PINNED;
@@ -1512,7 +1519,7 @@ OBJECTREF* GcInfoDecoder::GetRegisterSlot(
     }
 
     ppReg = &pRD->pCurrentContextPointers->R4;
-	
+
     return (OBJECTREF*)*(ppReg + regNum-4);
 
 }
@@ -1624,7 +1631,7 @@ OBJECTREF* GcInfoDecoder::GetRegisterSlot(
     }
 
     ppReg = &pRD->pCurrentContextPointers->X19;
-	
+
     return (OBJECTREF*)*(ppReg + regNum-19);
 }
 
@@ -1632,7 +1639,7 @@ bool GcInfoDecoder::IsScratchRegister(int regNum,  PREGDISPLAY pRD)
 {
     _ASSERTE(regNum >= 0 && regNum <= 30);
     _ASSERTE(regNum != 18);
-    
+
     return regNum <= 17 || regNum >= 29; // R12 and R14/LR are both scratch registers
 }
 

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -23,14 +23,14 @@
 #include "eventtrace.h"
 #include "threadsuspend.h"
 
-#if defined(_DEBUG) && !defined (WRITE_BARRIER_CHECK) 
+#if defined(_DEBUG) && !defined (WRITE_BARRIER_CHECK)
 #define WRITE_BARRIER_CHECK 1
 #endif
 
 // To test with MON_DEBUG off, comment out the following line. DO NOT simply define
 // to be 0 as the checks are for #ifdef not #if 0.
-// 
-#ifdef _DEBUG 
+//
+#ifdef _DEBUG
 #define MON_DEBUG 1
 #endif
 
@@ -64,7 +64,7 @@ extern "C" LONG g_global_alloc_lock;
 extern "C" void STDCALL JIT_WriteBarrierReg_PreGrow();// JIThelp.asm/JIThelp.s
 extern "C" void STDCALL JIT_WriteBarrierReg_PostGrow();// JIThelp.asm/JIThelp.s
 
-#ifdef _DEBUG 
+#ifdef _DEBUG
 extern "C" void STDCALL WriteBarrierAssert(BYTE* ptr, Object* obj)
 {
     WRAPPER_NO_CONTRACT;
@@ -76,8 +76,11 @@ extern "C" void STDCALL WriteBarrierAssert(BYTE* ptr, Object* obj)
 
     if (fVerifyHeap)
     {
-        obj->Validate(FALSE);
-        if(GCHeapUtilities::GetGCHeap()->IsHeapPointer(ptr))
+        if (obj)
+        {
+            obj->Validate(FALSE);
+        }
+        if (GCHeapUtilities::GetGCHeap()->IsHeapPointer(ptr))
         {
             Object* pObj = *(Object**)ptr;
             _ASSERTE (pObj == NULL || GCHeapUtilities::GetGCHeap()->IsHeapPointer(pObj));
@@ -246,7 +249,7 @@ extern "C" __declspec(naked) Object* F_CALL_CONV JIT_IsInstanceOfClass(MethodTab
 #if defined(FEATURE_TYPEEQUIVALENCE)
     SlowPath:
         jmp             JITutil_IsInstanceOfAny
-#endif            
+#endif
     }
 }
 
@@ -581,7 +584,7 @@ void JIT_TrialAlloc::EmitCore(CPUSTUBLINKER *psl, CodeLabel *noLock, CodeLabel *
     }
 
 
-#ifdef INCREMENTAL_MEMCLR 
+#ifdef INCREMENTAL_MEMCLR
     // <TODO>We're planning to get rid of this anyhow according to Patrick</TODO>
     _ASSERTE(!"NYI");
 #endif // INCREMENTAL_MEMCLR
@@ -860,7 +863,7 @@ void *JIT_TrialAlloc::GenAllocArray(Flags flags)
         sl.X86EmitCondJump(noLock, X86CondCode::kJA);
     }
 
-#if DATA_ALIGNMENT == 4 
+#if DATA_ALIGNMENT == 4
     if (flags & OBJ_ARRAY)
     {
         // No need for rounding in this case - element size is 4, and m_BaseSize is guaranteed
@@ -1151,7 +1154,7 @@ static const void * const c_rgWriteBarriers[NUM_WRITE_BARRIERS] = {
     (void *)JIT_WriteBarrierEBP,
 };
 
-#ifdef WRITE_BARRIER_CHECK 
+#ifdef WRITE_BARRIER_CHECK
 static const void * const c_rgDebugWriteBarriers[NUM_WRITE_BARRIERS] = {
     (void *)JIT_DebugWriteBarrierEAX,
     (void *)JIT_DebugWriteBarrierECX,
@@ -1227,9 +1230,9 @@ void InitJITHelpers1()
         }
     }
 
-    if (!(TrackAllocationsEnabled() 
+    if (!(TrackAllocationsEnabled()
         || LoggingOn(LF_GCALLOC, LL_INFO10)
-#ifdef _DEBUG 
+#ifdef _DEBUG
         || (g_pConfig->ShouldInjectFault(INJECTFAULT_GCHEAP) != 0)
 #endif
          )
@@ -1311,7 +1314,7 @@ void InitJITHelpers1()
         pBuf[3] &= 0xf8;
         pBuf[3] |= reg;
 
-#ifdef WRITE_BARRIER_CHECK 
+#ifdef WRITE_BARRIER_CHECK
         // Don't do the fancy optimization just jump to the old one
         // Use the slow one from time to time in a debug build because
         // there are some good asserts in the unoptimized one
@@ -1347,7 +1350,7 @@ const int PostGrow_CardTableFirstLocation = 24;
 const int PostGrow_CardTableSecondLocation = 36;
 
 
-#ifndef CODECOVERAGE        // Deactivate alignment validation for code coverage builds 
+#ifndef CODECOVERAGE        // Deactivate alignment validation for code coverage builds
                             // because the instrumented binaries will not preserve alignment constraints and we will fail.
 
 void ValidateWriteBarrierHelpers()
@@ -1361,7 +1364,7 @@ void ValidateWriteBarrierHelpers()
     if ((g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_BARRIERCHECK) || DEBUG_RANDOM_BARRIER_CHECK)
         return;
 #endif // WRITE_BARRIER_CHECK
-    
+
     // first validate the PreGrow helper
     BYTE* pWriteBarrierFunc = reinterpret_cast<BYTE*>(JIT_WriteBarrierEAX);
 
@@ -1417,7 +1420,7 @@ int StompWriteBarrierEphemeral(bool /* isRuntimeSuspended */)
 
     int stompWBCompleteActions = SWB_PASS;
 
-#ifdef WRITE_BARRIER_CHECK 
+#ifdef WRITE_BARRIER_CHECK
         // Don't do the fancy optimization if we are checking write barrier
     if (((BYTE *)JIT_WriteBarrierEAX)[0] == 0xE9)  // we are using slow write barrier
         return stompWBCompleteActions;
@@ -1473,7 +1476,7 @@ int StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
 
     int stompWBCompleteActions = SWB_PASS;
 
-#ifdef WRITE_BARRIER_CHECK 
+#ifdef WRITE_BARRIER_CHECK
         // Don't do the fancy optimization if we are checking write barrier
     if (((BYTE *)JIT_WriteBarrierEAX)[0] == 0xE9)  // we are using slow write barrier
         return stompWBCompleteActions;

--- a/src/vm/object.cpp
+++ b/src/vm/object.cpp
@@ -28,7 +28,7 @@ SVAL_IMPL(INT32, ArrayBase, s_arrayBoundsZero);
 DWORD Object::ComputeHashCode()
 {
     DWORD hashCode;
-   
+
     // note that this algorithm now uses at most HASHCODE_BITS so that it will
     // fit into the objheader if the hashcode has to be moved back into the objheader
     // such as for an object that is being frozen
@@ -45,7 +45,7 @@ DWORD Object::ComputeHashCode()
     return hashCode;
 }
 
-#ifndef DACCESS_COMPILE    
+#ifndef DACCESS_COMPILE
 INT32 Object::GetHashCodeEx()
 {
     CONTRACTL
@@ -124,7 +124,7 @@ INT32 Object::GetHashCodeEx()
                 // Header changed under us - let's restart this whole thing.
             }
         }
-    }    
+    }
 }
 #endif // #ifndef DACCESS_COMPILE
 
@@ -165,7 +165,7 @@ TypeHandle Object::GetGCSafeTypeHandleIfPossible() const
         NOTHROW;
         GC_NOTRIGGER;
         if(!IsGCThread()) { MODE_COOPERATIVE; }
-    } 
+    }
     CONTRACTL_END;
 
     // Although getting the type handle is unsafe and could cause recursive type lookups
@@ -181,24 +181,24 @@ TypeHandle Object::GetGCSafeTypeHandleIfPossible() const
     // Don't look at types that belong to an unloading AppDomain, or else
     // pObj->GetGCSafeTypeHandle() can AV. For example, we encountered this AV when pObj
     // was an array like this:
-    //     
+    //
     //     MyValueType1<MyValueType2>[] myArray
     //
     // where MyValueType1<T> & MyValueType2 are defined in different assemblies. In such
     // a case, looking up the type handle for myArray requires looking in
     // MyValueType1<T>'s module's m_AssemblyRefByNameTable, which is garbage if its
     // AppDomain is unloading.
-    // 
+    //
     // Another AV was encountered in a similar case,
-    // 
+    //
     //     MyRefType1<MyRefType2>[] myArray
-    // 
+    //
     // where MyRefType2's module was unloaded by the time the GC occurred. In at least
     // one case, the GC was caused by the AD unload itself (AppDomain::Unload ->
     // AppDomain::Exit -> GCInterface::AddMemoryPressure -> WKS::GCHeapUtilities::GarbageCollect).
-    // 
+    //
     // To protect against all scenarios, verify that
-    // 
+    //
     //     * The MT of the object is not getting unloaded, OR
     //     * In the case of arrays (potentially of arrays of arrays of arrays ...), the
     //         MT of the innermost element is not getting unloaded. This then ensures the
@@ -218,7 +218,7 @@ TypeHandle Object::GetGCSafeTypeHandleIfPossible() const
         // TypeDesc::GetLoaderModule() for the limited array case that we care about. In
         // case we're dealing with an array of arrays of arrays etc. traverse until we
         // find the deepest element, and that's the type we'll check
-        while (thElem.HasTypeParam()) 
+        while (thElem.HasTypeParam())
         {
             thElem = thElem.GetTypeParam();
         }
@@ -296,7 +296,7 @@ STRINGREF AllocateString(SString sstr)
         THROWS;
         GC_TRIGGERS;
     } CONTRACTL_END;
-    
+
     COUNT_T length = sstr.GetCount(); // count of WCHARs excluding terminating NULL
     STRINGREF strObj = AllocateString(length);
     memcpyNoGCRefs(strObj->GetBuffer(), sstr.GetUnicode(), length*sizeof(WCHAR));
@@ -337,12 +337,12 @@ void Object::ValidateHeap(Object *from, BOOL bDeep)
 #if defined (VERIFY_HEAP)
     //no need to verify next object's header in this case
     //since this is called in verify_heap, which will verfiy every object anyway
-    Validate(bDeep, FALSE); 
+    Validate(bDeep, FALSE);
 #endif
 }
 
 void Object::SetOffsetObjectRef(DWORD dwOffset, size_t dwValue)
-{ 
+{
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
     STATIC_CONTRACT_FORBID_FAULT;
@@ -374,8 +374,8 @@ void SetObjectReferenceUnchecked(OBJECTREF *dst,OBJECTREF ref)
 #endif
     ErectWriteBarrier(dst, ref);
 }
-    
-void STDCALL CopyValueClassUnchecked(void* dest, void* src, MethodTable *pMT) 
+
+void STDCALL CopyValueClassUnchecked(void* dest, void* src, MethodTable *pMT)
 {
 
     STATIC_CONTRACT_NOTHROW;
@@ -383,7 +383,7 @@ void STDCALL CopyValueClassUnchecked(void* dest, void* src, MethodTable *pMT)
     STATIC_CONTRACT_FORBID_FAULT;
     STATIC_CONTRACT_MODE_COOPERATIVE;
 
-    _ASSERTE(!pMT->IsArray());  // bunch of assumptions about arrays wrong. 
+    _ASSERTE(!pMT->IsArray());  // bunch of assumptions about arrays wrong.
 
     // <TODO> @todo Only call MemoryBarrier() if needed.
     // Reflection is a known use case where this is required.
@@ -391,16 +391,16 @@ void STDCALL CopyValueClassUnchecked(void* dest, void* src, MethodTable *pMT)
     // </TODO>
     MemoryBarrier();
 
-        // Copy the bulk of the data, and any non-GC refs. 
+        // Copy the bulk of the data, and any non-GC refs.
     switch (pMT->GetNumInstanceFieldBytes())
-    {        
+    {
     case 1:
         *(UINT8*)dest = *(UINT8*)src;
         break;
 #ifndef ALIGN_ACCESS
-        // we can hit an alignment fault if the value type has multiple 
-        // smaller fields.  Example: if there are two I4 fields, the 
-        // value class can be aligned to 4-byte boundaries, yet the 
+        // we can hit an alignment fault if the value type has multiple
+        // smaller fields.  Example: if there are two I4 fields, the
+        // value class can be aligned to 4-byte boundaries, yet the
         // NumInstanceFieldBytes is 8
     case 2:
         *(UINT16*)dest = *(UINT16*)src;
@@ -417,37 +417,37 @@ void STDCALL CopyValueClassUnchecked(void* dest, void* src, MethodTable *pMT)
         break;
     }
 
-        // Tell the GC about any copies.  
+        // Tell the GC about any copies.
     if (pMT->ContainsPointers())
-    {   
+    {
         CGCDesc* map = CGCDesc::GetCGCDescFromMT(pMT);
         CGCDescSeries* cur = map->GetHighestSeries();
         CGCDescSeries* last = map->GetLowestSeries();
         DWORD size = pMT->GetBaseSize();
         _ASSERTE(cur >= last);
-        do                                                                  
-        {   
+        do
+        {
             // offset to embedded references in this series must be
             // adjusted by the VTable pointer, when in the unboxed state.
             size_t offset = cur->GetSeriesOffset() - sizeof(void*);
             OBJECTREF* srcPtr = (OBJECTREF*)(((BYTE*) src) + offset);
             OBJECTREF* destPtr = (OBJECTREF*)(((BYTE*) dest) + offset);
-            OBJECTREF* srcPtrStop = (OBJECTREF*)((BYTE*) srcPtr + cur->GetSeriesSize() + size);         
-            while (srcPtr < srcPtrStop)                                         
-            {   
+            OBJECTREF* srcPtrStop = (OBJECTREF*)((BYTE*) srcPtr + cur->GetSeriesSize() + size);
+            while (srcPtr < srcPtrStop)
+            {
                 SetObjectReference(destPtr, ObjectToOBJECTREF(*(Object**)srcPtr));
                 srcPtr++;
                 destPtr++;
-            }                                                               
-            cur--;                                                              
-        } while (cur >= last);                                              
+            }
+            cur--;
+        } while (cur >= last);
     }
 }
 
 // Copy value class into the argument specified by the argDest.
 // The destOffset is nonzero when copying values into Nullable<T>, it is the offset
 // of the T value inside of the Nullable<T>
-void STDCALL CopyValueClassArgUnchecked(ArgDestination *argDest, void* src, MethodTable *pMT, int destOffset) 
+void STDCALL CopyValueClassArgUnchecked(ArgDestination *argDest, void* src, MethodTable *pMT, int destOffset)
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -479,7 +479,7 @@ void STDCALL CopyValueClassArgUnchecked(ArgDestination *argDest, void* src, Meth
 
 // Initialize the value class argument to zeros
 void InitValueClassArg(ArgDestination *argDest, MethodTable *pMT)
-{ 
+{
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
     STATIC_CONTRACT_FORBID_FAULT;
@@ -493,7 +493,7 @@ void InitValueClassArg(ArgDestination *argDest, MethodTable *pMT)
         return;
     }
 
-#endif    
+#endif
     InitValueClass(argDest->GetDestinationAddress(), pMT);
 }
 
@@ -523,11 +523,6 @@ VOID Object::Validate(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncBlock)
     STATIC_CONTRACT_FORBID_FAULT;
     STATIC_CONTRACT_MODE_COOPERATIVE;
     STATIC_CONTRACT_CANNOT_TAKE_LOCK;
-
-    if (this == NULL)
-    {
-        return;     // NULL is ok
-    }
 
     if (g_IBCLogger.InstrEnabled() && !GCStress<cfg_any>::IsEnabled())
     {
@@ -586,7 +581,7 @@ VOID Object::ValidateInner(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncB
 
     EX_TRY
     {
-        // in order to avoid contract violations in the EH code we'll allow AVs here, 
+        // in order to avoid contract violations in the EH code we'll allow AVs here,
         // they'll be handled in the catch block
         AVInRuntimeImplOkayHolder avOk;
 
@@ -607,7 +602,7 @@ VOID Object::ValidateInner(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncB
             bSmallObjectHeapPtr = GCHeapUtilities::GetGCHeap()->IsHeapPointer(this, true);
             if (!bSmallObjectHeapPtr)
                 bLargeObjectHeapPtr = GCHeapUtilities::GetGCHeap()->IsHeapPointer(this);
-                
+
             CHECK_AND_TEAR_DOWN(bSmallObjectHeapPtr || bLargeObjectHeapPtr);
         }
 
@@ -617,7 +612,7 @@ VOID Object::ValidateInner(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncB
         {
             CHECK_AND_TEAR_DOWN(GetHeader()->Validate(bVerifySyncBlock));
         }
-        
+
         lastTest = 4;
 
         if (bDeep && (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)) {
@@ -639,8 +634,8 @@ VOID Object::ValidateInner(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncB
 
         _ASSERTE(GCHeapUtilities::IsGCHeapInitialized());
         // try to validate next object's header
-        if (bDeep 
-            && bVerifyNextHeader 
+        if (bDeep
+            && bVerifyNextHeader
             && GCHeapUtilities::GetGCHeap()->RuntimeStructuresValid()
             //NextObj could be very slow if concurrent GC is going on
             && !GCHeapUtilities::GetGCHeap ()->IsConcurrentGCInProgress ())
@@ -649,7 +644,7 @@ VOID Object::ValidateInner(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncB
             if ((nextObj != NULL) &&
                 (nextObj->GetGCSafeMethodTable() != g_pFreeObjectMethodTable))
             {
-                // we need a read barrier here - to make sure we read the object header _after_                
+                // we need a read barrier here - to make sure we read the object header _after_
                 // reading data that tells us that the object is eligible for verification
                 // (also see: gc.cpp/a_fit_segment_end_p)
                 VOLATILE_MEMORY_BARRIER();
@@ -793,13 +788,13 @@ STRINGREF StringObject::NewString(const WCHAR *pwsz)
             return GetEmptyString();
         }
 
-#if 0        
-        //        
-        // This assert is disabled because it is valid for us to get a 
+#if 0
+        //
+        // This assert is disabled because it is valid for us to get a
         // pointer from the gc heap here as long as it is pinned.  This
-        // can happen when a string is marshalled to unmanaged by 
+        // can happen when a string is marshalled to unmanaged by
         // pinning and then later put into a struct and that struct is
-        // then marshalled to managed.  
+        // then marshalled to managed.
         //
         _ASSERTE(!GCHeapUtilities::GetGCHeap()->IsHeapPointer((BYTE *) pwsz) ||
                  !"pwsz can not point to GC Heap");
@@ -814,7 +809,7 @@ STRINGREF StringObject::NewString(const WCHAR *pwsz)
 }
 
 #if defined(_MSC_VER) && defined(_TARGET_X86_)
-#pragma optimize("y", on)        // Small critical routines, don't put in EBP frame 
+#pragma optimize("y", on)        // Small critical routines, don't put in EBP frame
 #endif
 
 STRINGREF StringObject::NewString(const WCHAR *pwsz, int length) {
@@ -832,13 +827,13 @@ STRINGREF StringObject::NewString(const WCHAR *pwsz, int length) {
     else if (length <= 0) {
         return GetEmptyString();
     } else {
-#if 0        
-        //        
-        // This assert is disabled because it is valid for us to get a 
+#if 0
+        //
+        // This assert is disabled because it is valid for us to get a
         // pointer from the gc heap here as long as it is pinned.  This
-        // can happen when a string is marshalled to unmanaged by 
+        // can happen when a string is marshalled to unmanaged by
         // pinning and then later put into a struct and that struct is
-        // then marshalled to managed.  
+        // then marshalled to managed.
         //
         _ASSERTE(!GCHeapUtilities::GetGCHeap()->IsHeapPointer((BYTE *) pwsz) ||
                  !"pwsz can not point to GC Heap");
@@ -970,7 +965,7 @@ BOOL StringObject::CaseInsensitiveCompHelper(__in_ecount(aLength) WCHAR *strACha
     unsigned charA;
     unsigned charB;
 
-    for(;;) {        
+    for(;;) {
         charA = *strAChars;
         charB = (unsigned) *strBChars;
 
@@ -981,10 +976,10 @@ BOOL StringObject::CaseInsensitiveCompHelper(__in_ecount(aLength) WCHAR *strACha
             return FALSE;
         }
 
-        // uppercase both chars. 
+        // uppercase both chars.
         if (charA>='a' && charA<='z') {
             charA ^= 0x20;
-        } 
+        }
         if (charB>='a' && charB<='z') {
             charB ^= 0x20;
         }
@@ -1000,21 +995,21 @@ BOOL StringObject::CaseInsensitiveCompHelper(__in_ecount(aLength) WCHAR *strACha
         {
             if (bLength == -1)
             {
-                *result = aLength - static_cast<INT32>(strAChars - strAStart); 
+                *result = aLength - static_cast<INT32>(strAChars - strAStart);
                 return TRUE;
             }
             if (strAChars==strAStart + aLength || strBChars==strBStart + bLength)
             {
-                *result = aLength - bLength; 
+                *result = aLength - bLength;
                 return TRUE;
             }
             // else both embedded zeros
-        } 
+        }
 
         // Next char
         strAChars++; strBChars++;
     }
-    
+
 }
 
 /*============================InternalTrailByteCheck============================
@@ -1031,7 +1026,7 @@ BOOL StringObject::CaseInsensitiveCompHelper(__in_ecount(aLength) WCHAR *strACha
 ==============================================================================*/
 BOOL StringObject::HasTrailByte() {
     WRAPPER_NO_CONTRACT;
-    
+
     SyncBlock * pSyncBlock = PassiveGetSyncBlock();
     if(pSyncBlock != NULL)
     {
@@ -1127,7 +1122,7 @@ OBJECTREF::OBJECTREF(const OBJECTREF & objref)
         _ASSERTE(!"Write Barrier violation. Must use SetObjectReference() to assign OBJECTREF's into the GC heap!");
     }
     m_asObj = objref.m_asObj;
-    
+
     if (m_asObj != 0) {
         ENABLESTRESSHEAP();
     }
@@ -1172,7 +1167,7 @@ OBJECTREF::OBJECTREF(Object *pObject)
     STATIC_CONTRACT_FORBID_FAULT;
 
     DEBUG_ONLY_FUNCTION;
-    
+
     if ((pObject != 0) &&
         ((IGCHeap*)GCHeapUtilities::GetGCHeap())->IsHeapPointer( (BYTE*)this ))
     {
@@ -1189,7 +1184,10 @@ OBJECTREF::OBJECTREF(Object *pObject)
 void OBJECTREF::Validate(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncBlock)
 {
     LIMITED_METHOD_CONTRACT;
-    m_asObj->Validate(bDeep, bVerifyNextHeader, bVerifySyncBlock);
+    if (m_asObj)
+    {
+        m_asObj->Validate(bDeep, bVerifyNextHeader, bVerifySyncBlock);
+    }
 }
 
 //-------------------------------------------------------------
@@ -1233,7 +1231,7 @@ int OBJECTREF::operator==(const OBJECTREF &objref) const
         VALIDATEOBJECT(m_asObj);
         // If this assert fires, you probably did not protect
         // your OBJECTREF and a GC might have occurred.  To
-        // where the possible GC was, set a breakpoint in Thread::TriggersGC 
+        // where the possible GC was, set a breakpoint in Thread::TriggersGC
         _ASSERTE(Thread::IsObjRefValid(this));
 
         if (m_asObj != 0 || objref.m_asObj != 0) {
@@ -1271,7 +1269,7 @@ int OBJECTREF::operator!=(const OBJECTREF &objref) const
         VALIDATEOBJECT(m_asObj);
         // If this assert fires, you probably did not protect
         // your OBJECTREF and a GC might have occurred.  To
-        // where the possible GC was, set a breakpoint in Thread::TriggersGC 
+        // where the possible GC was, set a breakpoint in Thread::TriggersGC
         _ASSERTE(Thread::IsObjRefValid(this));
 
         if (m_asObj != 0 || objref.m_asObj != 0) {
@@ -1295,7 +1293,7 @@ Object* OBJECTREF::operator->()
     VALIDATEOBJECT(m_asObj);
         // If this assert fires, you probably did not protect
         // your OBJECTREF and a GC might have occurred.  To
-        // where the possible GC was, set a breakpoint in Thread::TriggersGC 
+        // where the possible GC was, set a breakpoint in Thread::TriggersGC
     _ASSERTE(Thread::IsObjRefValid(this));
 
     if (m_asObj != 0) {
@@ -1320,7 +1318,7 @@ const Object* OBJECTREF::operator->() const
     VALIDATEOBJECT(m_asObj);
         // If this assert fires, you probably did not protect
         // your OBJECTREF and a GC might have occurred.  To
-        // where the possible GC was, set a breakpoint in Thread::TriggersGC 
+        // where the possible GC was, set a breakpoint in Thread::TriggersGC
     _ASSERTE(Thread::IsObjRefValid(this));
 
     if (m_asObj != 0) {
@@ -1371,7 +1369,7 @@ OBJECTREF& OBJECTREF::operator=(const OBJECTREF &objref)
 }
 
 //-------------------------------------------------------------
-// Allows for the assignment of NULL to a OBJECTREF 
+// Allows for the assignment of NULL to a OBJECTREF
 //-------------------------------------------------------------
 
 OBJECTREF& OBJECTREF::operator=(TADDR nul)
@@ -1422,9 +1420,9 @@ void* __cdecl GCSafeMemCpy(void * dest, const void * src, size_t len)
 // This function clears a piece of memory in a GC safe way.  It makes the guarantee
 // that it will clear memory in at least pointer sized chunks whenever possible.
 // Unaligned memory at the beginning and remaining bytes at the end are written bytewise.
-// We must make this guarantee whenever we clear memory in the GC heap that could contain 
-// object references.  The GC or other user threads can read object references at any time, 
-// clearing them bytewise can result in a read on another thread getting incorrect data.  
+// We must make this guarantee whenever we clear memory in the GC heap that could contain
+// object references.  The GC or other user threads can read object references at any time,
+// clearing them bytewise can result in a read on another thread getting incorrect data.
 void __fastcall ZeroMemoryInGCHeap(void* mem, size_t size)
 {
     WRAPPER_NO_CONTRACT;
@@ -1482,12 +1480,12 @@ void StackTraceArray::CheckState() const
         MODE_COOPERATIVE;
     }
     CONTRACTL_END;
-    
+
     if (!m_array)
         return;
 
     assert(GetObjectThread() == GetThread());
-    
+
     size_t size = Size();
     StackTraceElement const * p;
     p = GetData();
@@ -1524,7 +1522,7 @@ void StackTraceArray::Grow(size_t grow_size)
         size_t new_capacity = Max(Capacity() * 2, raw_size);
 
         _ASSERTE(new_capacity >= grow_size * sizeof(StackTraceElement) + sizeof(ArrayHeader));
-        
+
         I1ARRAYREF newarr = (I1ARRAYREF) AllocatePrimitiveArray(ELEMENT_TYPE_I1, static_cast<DWORD>(new_capacity));
         memcpyNoGCRefs(newarr->GetDirectPointerToNonObjectElements(),
                        GetRaw(),
@@ -1554,7 +1552,7 @@ void StackTraceArray::EnsureThreadAffinity()
 }
 
 #ifdef _MSC_VER
-#pragma warning(disable: 4267) 
+#pragma warning(disable: 4267)
 #endif
 
 // Deep copies the stack trace array
@@ -1589,9 +1587,9 @@ void StackTraceArray::CopyFrom(StackTraceArray const & src)
 #ifdef _DEBUG
 //===============================================================================
 // Code that insures that our unmanaged version of Nullable is consistant with
-// the managed version Nullable<T> for all T.  
+// the managed version Nullable<T> for all T.
 
-void Nullable::CheckFieldOffsets(TypeHandle nullableType) 
+void Nullable::CheckFieldOffsets(TypeHandle nullableType)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -1649,10 +1647,10 @@ BOOL Nullable::IsNullableForTypeHelperNoGC(MethodTable* nullableMT, MethodTable*
     if (!nullableMT->IsNullable())
         return FALSE;
 
-    // we require an exact match of the parameter types 
+    // we require an exact match of the parameter types
     return TypeHandle(paramMT) == nullableMT->GetInstantiation()[0];
 }
-    
+
 //===============================================================================
 CLR_BOOL* Nullable::HasValueAddr(MethodTable* nullableMT) {
 
@@ -1727,7 +1725,7 @@ BOOL Nullable::UnBox(void* destPtr, OBJECTREF boxedVal, MethodTable* destMT)
         // We better have a concrete instantiation, or our field offset asserts are not useful
     _ASSERTE(!destMT->ContainsGenericVariables());
 
-    if (boxedVal == NULL) 
+    if (boxedVal == NULL)
     {
         // Logically we are doing *dest->HasValueAddr(destMT) = false;
         // We zero out the whole structure becasue it may contain GC references
@@ -1735,12 +1733,12 @@ BOOL Nullable::UnBox(void* destPtr, OBJECTREF boxedVal, MethodTable* destMT)
         InitValueClass(destPtr, destMT);
         fRet = TRUE;
     }
-    else 
+    else
     {
         GCPROTECT_BEGIN(boxedVal);
         if (!IsNullableForType(destMT, boxedVal->GetMethodTable()))
         {
-            // For safety's sake, also allow true nullables to be unboxed normally.  
+            // For safety's sake, also allow true nullables to be unboxed normally.
             // This should not happen normally, but we want to be robust
             if (destMT->IsEquivalentTo(boxedVal->GetMethodTable()))
             {
@@ -1783,18 +1781,18 @@ BOOL Nullable::UnBoxNoGC(void* destPtr, OBJECTREF boxedVal, MethodTable* destMT)
         // We better have a concrete instantiation, or our field offset asserts are not useful
     _ASSERTE(!destMT->ContainsGenericVariables());
 
-    if (boxedVal == NULL) 
+    if (boxedVal == NULL)
     {
         // Logically we are doing *dest->HasValueAddr(destMT) = false;
         // We zero out the whole structure becasue it may contain GC references
         // and these need to be initialized to zero.   (could optimize in the non-GC case)
         InitValueClass(destPtr, destMT);
     }
-    else 
+    else
     {
         if (!IsNullableForTypeNoGC(destMT, boxedVal->GetMethodTable()))
         {
-            // For safety's sake, also allow true nullables to be unboxed normally.  
+            // For safety's sake, also allow true nullables to be unboxed normally.
             // This should not happen normally, but we want to be robust
             if (destMT == boxedVal->GetMethodTable())
             {
@@ -1811,7 +1809,7 @@ BOOL Nullable::UnBoxNoGC(void* destPtr, OBJECTREF boxedVal, MethodTable* destMT)
 }
 
 //===============================================================================
-// Special Logic to unbox a boxed T as a nullable<T> into an argument 
+// Special Logic to unbox a boxed T as a nullable<T> into an argument
 // specified by the argDest.
 // Does not handle type equivalence (may conservatively return FALSE)
 BOOL Nullable::UnBoxIntoArgNoGC(ArgDestination *argDest, OBJECTREF boxedVal, MethodTable* destMT)
@@ -1833,18 +1831,18 @@ BOOL Nullable::UnBoxIntoArgNoGC(ArgDestination *argDest, OBJECTREF boxedVal, Met
         // We better have a concrete instantiation, or our field offset asserts are not useful
         _ASSERTE(!destMT->ContainsGenericVariables());
 
-        if (boxedVal == NULL) 
+        if (boxedVal == NULL)
         {
             // Logically we are doing *dest->HasValueAddr(destMT) = false;
             // We zero out the whole structure becasue it may contain GC references
             // and these need to be initialized to zero.   (could optimize in the non-GC case)
             InitValueClassArg(argDest, destMT);
         }
-        else 
+        else
         {
             if (!IsNullableForTypeNoGC(destMT, boxedVal->GetMethodTable()))
             {
-                // For safety's sake, also allow true nullables to be unboxed normally.  
+                // For safety's sake, also allow true nullables to be unboxed normally.
                 // This should not happen normally, but we want to be robust
                 if (destMT == boxedVal->GetMethodTable())
                 {
@@ -1887,18 +1885,18 @@ void Nullable::UnBoxNoCheck(void* destPtr, OBJECTREF boxedVal, MethodTable* dest
         // We better have a concrete instantiation, or our field offset asserts are not useful
     _ASSERTE(!destMT->ContainsGenericVariables());
 
-    if (boxedVal == NULL) 
+    if (boxedVal == NULL)
     {
         // Logically we are doing *dest->HasValueAddr(destMT) = false;
         // We zero out the whole structure becasue it may contain GC references
         // and these need to be initialized to zero.   (could optimize in the non-GC case)
         InitValueClass(destPtr, destMT);
     }
-    else 
+    else
     {
         if (IsNullableType(boxedVal->GetMethodTable()))
         {
-            // For safety's sake, also allow true nullables to be unboxed normally.  
+            // For safety's sake, also allow true nullables to be unboxed normally.
             // This should not happen normally, but we want to be robust
             CopyValueClass(dest, boxedVal->GetData(), destMT);
         }
@@ -1924,7 +1922,7 @@ OBJECTREF Nullable::NormalizeBox(OBJECTREF obj) {
 
     if (obj != NULL) {
         MethodTable* retMT = obj->GetMethodTable();
-        if (Nullable::IsNullableType(retMT)) 
+        if (Nullable::IsNullableType(retMT))
             obj = Nullable::Box(obj->GetData(), retMT);
     }
     return obj;

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -5,7 +5,7 @@
 // OBJECT.H
 //
 // Definitions of a Com+ Object
-// 
+//
 
 // See code:EEStartup#TableOfContents for overview
 
@@ -26,7 +26,7 @@ extern "C" void __fastcall ZeroMemoryInGCHeap(void*, size_t);
 void ErectWriteBarrierForMT(MethodTable **dst, MethodTable *ref);
 
 /*
- #ObjectModel 
+ #ObjectModel
  * COM+ Internal Object Model
  *
  *
@@ -53,7 +53,7 @@ void ErectWriteBarrierForMT(MethodTable **dst, MethodTable *ref);
  *  |       |   ...
  *  |       |
  *  |       +-  PtrArray   - Array of OBJECTREFs, different than base arrays because of pObjectClass
- *  |              
+ *  |
  *  +-- code:AssemblyBaseObject - The base object for the class Assembly
  *
  *
@@ -77,7 +77,7 @@ void ErectWriteBarrierForMT(MethodTable **dst, MethodTable *ref);
  */
 
 // <TODO>
-// @TODO:  #define COW         0x04     
+// @TODO:  #define COW         0x04
 // @TODO: MOO, MOO - no, not bovine, really Copy On Write bit for StringBuffer, requires 8 byte align MT
 // @TODL: which we don't have yet</TODO>
 
@@ -111,7 +111,7 @@ struct RCW;
 
 //
 // The generational GC requires that every object be at least 12 bytes
-// in size.   
+// in size.
 
 #define MIN_OBJECT_SIZE     (2*TARGET_POINTER_SIZE + OBJHEADER_SIZE)
 
@@ -123,15 +123,15 @@ struct RCW;
 #endif //!PtrAlign
 
 // code:Object is the respesentation of an managed object on the GC heap.
-//   
-// See  code:#ObjectModel for some important subclasses of code:Object 
-// 
+//
+// See  code:#ObjectModel for some important subclasses of code:Object
+//
 // The only fields mandated by all objects are
-// 
+//
 //     * a pointer to the code:MethodTable at offset 0
 //     * a poiner to a code:ObjHeader at a negative offset. This is often zero.  It holds information that
-//         any addition information that we might need to attach to arbitrary objects. 
-// 
+//         any addition information that we might need to attach to arbitrary objects.
+//
 class Object
 {
   protected:
@@ -140,7 +140,7 @@ class Object
   protected:
     Object() { LIMITED_METHOD_CONTRACT; };
    ~Object() { LIMITED_METHOD_CONTRACT; };
-   
+
   public:
     MethodTable *RawGetMethodTable() const
     {
@@ -156,9 +156,9 @@ class Object
 
     VOID SetMethodTable(MethodTable *pMT
                         DEBUG_ARG(BOOL bAllowArray = FALSE))
-    { 
+    {
         LIMITED_METHOD_CONTRACT;
-        m_pMethTab = pMT; 
+        m_pMethTab = pMT;
 
 #ifdef _DEBUG
         if (!bAllowArray)
@@ -186,13 +186,13 @@ class Object
 
 #define MARKED_BIT 0x1
 
-    PTR_MethodTable GetMethodTable() const              
-    { 
+    PTR_MethodTable GetMethodTable() const
+    {
         LIMITED_METHOD_DAC_CONTRACT;
 
 #ifndef DACCESS_COMPILE
-        // We should always use GetGCSafeMethodTable() if we're running during a GC. 
-        // If the mark bit is set then we're running during a GC     
+        // We should always use GetGCSafeMethodTable() if we're running during a GC.
+        // If the mark bit is set then we're running during a GC
         _ASSERTE((dac_cast<TADDR>(m_pMethTab) & MARKED_BIT) == 0);
 
         return m_pMethTab;
@@ -219,10 +219,10 @@ class Object
     inline DWORD    GetNumComponents();
     inline SIZE_T   GetSize();
 
-    CGCDesc*        GetSlotMap()                        
-    { 
+    CGCDesc*        GetSlotMap()
+    {
         WRAPPER_NO_CONTRACT;
-        return( CGCDesc::GetCGCDescFromMT(GetMethodTable())); 
+        return( CGCDesc::GetCGCDescFromMT(GetMethodTable()));
     }
 
     // Sync Block & Synchronization services
@@ -267,13 +267,13 @@ class Object
 
     // DO NOT ADD ANY ASSERTS TO THIS METHOD.
     // DO NOT USE THIS METHOD.
-    // Yes folks, for better or worse the debugger pokes supposed object addresses 
+    // Yes folks, for better or worse the debugger pokes supposed object addresses
     // to try to see if objects are valid, possibly firing an AccessViolation or worse,
     // and then catches the AV and reports a failure to the debug client.  This makes
     // the debugger slightly more robust should any corrupted object references appear
-    // in a session. Thus it is "correct" behaviour for this to AV when used with 
+    // in a session. Thus it is "correct" behaviour for this to AV when used with
     // an invalid object pointer, and incorrect behaviour for it to
-    // assert.  
+    // assert.
     BOOL ValidateObjectWithPossibleAV();
 
     // Validate an object ref out of the Promote routine in the GC
@@ -290,10 +290,10 @@ class Object
 
     static DWORD ComputeHashCode();
 
-#ifndef DACCESS_COMPILE    
+#ifndef DACCESS_COMPILE
     INT32 GetHashCodeEx();
 #endif // #ifndef DACCESS_COMPILE
-    
+
     // Synchronization
 #ifndef DACCESS_COMPILE
 
@@ -328,7 +328,7 @@ class Object
         WRAPPER_NO_CONTRACT;
         return GetHeader()->LeaveObjMonitor();
     }
-    
+
     // should be called only from unwind code; used in the
     // case where EnterObjMonitor failed to allocate the
     // sync-object.
@@ -376,7 +376,7 @@ class Object
     }
 
    PTR_VOID UnBox();      // if it is a value class, get the pointer to the first field
-  
+
     PTR_BYTE   GetData(void)
     {
         LIMITED_METHOD_CONTRACT;
@@ -391,25 +391,25 @@ class Object
     }
 
     DWORD   GetOffset32(DWORD dwOffset)
-    { 
+    {
         WRAPPER_NO_CONTRACT;
         return * PTR_DWORD(GetData() + dwOffset);
     }
 
     USHORT  GetOffset16(DWORD dwOffset)
-    { 
+    {
         WRAPPER_NO_CONTRACT;
         return * PTR_USHORT(GetData() + dwOffset);
     }
 
     BYTE    GetOffset8(DWORD dwOffset)
-    { 
+    {
         WRAPPER_NO_CONTRACT;
         return * PTR_BYTE(GetData() + dwOffset);
     }
 
     __int64 GetOffset64(DWORD dwOffset)
-    { 
+    {
         WRAPPER_NO_CONTRACT;
         return (__int64) * PTR_ULONG64(GetData() + dwOffset);
     }
@@ -421,7 +421,7 @@ class Object
     }
 
 #ifndef DACCESS_COMPILE
-    
+
     void SetOffsetObjectRef(DWORD dwOffset, size_t dwValue);
 
     void SetOffsetPtr(DWORD dwOffset, LPVOID value)
@@ -429,27 +429,27 @@ class Object
         WRAPPER_NO_CONTRACT;
         *(LPVOID *) &GetData()[dwOffset] = value;
     }
-        
+
     void SetOffset32(DWORD dwOffset, DWORD dwValue)
-    { 
+    {
         WRAPPER_NO_CONTRACT;
         *(DWORD *) &GetData()[dwOffset] = dwValue;
     }
 
     void SetOffset16(DWORD dwOffset, DWORD dwValue)
-    { 
+    {
         WRAPPER_NO_CONTRACT;
         *(USHORT *) &GetData()[dwOffset] = (USHORT) dwValue;
     }
 
     void SetOffset8(DWORD dwOffset, DWORD dwValue)
-    { 
+    {
         WRAPPER_NO_CONTRACT;
         *(BYTE *) &GetData()[dwOffset] = (BYTE) dwValue;
     }
 
     void SetOffset64(DWORD dwOffset, __int64 qwValue)
-    { 
+    {
         WRAPPER_NO_CONTRACT;
         *(__int64 *) &GetData()[dwOffset] = qwValue;
     }
@@ -464,7 +464,7 @@ class Object
         SUPPORTS_DAC;
 
         // lose GC marking bit and the reserved bit
-        // A method table pointer should always be aligned.  During GC we set the least 
+        // A method table pointer should always be aligned.  During GC we set the least
         // significant bit for marked objects, and the second to least significant
         // bit is reserved.  So if we want the actual MT pointer during a GC
         // we must zero out the lowest 2 bits.
@@ -474,13 +474,13 @@ class Object
     // There are some cases where it is unsafe to get the type handle during a GC.
     // This occurs when the type has already been unloaded as part of an in-progress appdomain shutdown.
     TypeHandle GetGCSafeTypeHandleIfPossible() const;
-    
+
     inline TypeHandle GetGCSafeTypeHandle() const;
 
 #ifdef DACCESS_COMPILE
     void EnumMemoryRegions(void);
 #endif
-    
+
  private:
     VOID ValidateInner(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncBlock);
 
@@ -496,7 +496,7 @@ class Object
 };
 
 /*
- * Object ref setting routines.  You must use these to do 
+ * Object ref setting routines.  You must use these to do
  * proper write barrier support.
  */
 
@@ -509,10 +509,10 @@ void EnableStressHeapHelper();
 #endif
 
 //Used to clear the object reference
-inline void ClearObjectReference(OBJECTREF* dst) 
-{ 
+inline void ClearObjectReference(OBJECTREF* dst)
+{
     LIMITED_METHOD_CONTRACT;
-    *(void**)(dst) = NULL; 
+    *(void**)(dst) = NULL;
 }
 
 // CopyValueClass sets a value class field
@@ -521,7 +521,7 @@ void STDCALL CopyValueClassUnchecked(void* dest, void* src, MethodTable *pMT);
 void STDCALL CopyValueClassArgUnchecked(ArgDestination *argDest, void* src, MethodTable *pMT, int destOffset);
 
 inline void InitValueClass(void *dest, MethodTable *pMT)
-{ 
+{
     WRAPPER_NO_CONTRACT;
     ZeroMemoryInGCHeap(dest, pMT->GetNumInstanceFieldBytes());
 }
@@ -530,8 +530,8 @@ inline void InitValueClass(void *dest, MethodTable *pMT)
 void InitValueClassArg(ArgDestination *argDest, MethodTable *pMT);
 
 #define SetObjectReference(_d,_r)        SetObjectReferenceUnchecked(_d, _r)
-#define CopyValueClass(_d,_s,_m)         CopyValueClassUnchecked(_d,_s,_m)       
-#define CopyValueClassArg(_d,_s,_m,_o)   CopyValueClassArgUnchecked(_d,_s,_m,_o)       
+#define CopyValueClass(_d,_s,_m)         CopyValueClassUnchecked(_d,_s,_m)
+#define CopyValueClassArg(_d,_s,_m,_o)   CopyValueClassArgUnchecked(_d,_s,_m,_o)
 
 #include <pshpack4.h>
 
@@ -543,7 +543,7 @@ void InitValueClassArg(ArgDestination *argDest, MethodTable *pMT);
 // In addition the layout of an array in memory is also affected by
 // whether the method table is shared (eg in the case of arrays of object refs)
 // or not.  In the shared case, the array has to hold the type handle of
-// the element type.  
+// the element type.
 //
 // ArrayBase encapuslates all of these details.  In theory you should never
 // have to peek inside this abstraction
@@ -554,7 +554,7 @@ class ArrayBase : public Object
     friend class CObjectHeader;
     friend class Object;
     friend OBJECTREF AllocateSzArray(MethodTable *pArrayMT, INT32 length, GC_ALLOC_FLAGS flags, BOOL bAllocateInLargeHeap);
-    friend OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, GC_ALLOC_FLAGS flags, BOOL bAllocateInLargeHeap); 
+    friend OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, GC_ALLOC_FLAGS flags, BOOL bAllocateInLargeHeap);
     friend FCDECL2(Object*, JIT_NewArr1VC_MP_FastPortable, CORINFO_CLASS_HANDLE arrayMT, INT_PTR size);
     friend FCDECL2(Object*, JIT_NewArr1OBJ_MP_FastPortable, CORINFO_CLASS_HANDLE arrayMT, INT_PTR size);
     friend class JIT_TrialAlloc;
@@ -564,7 +564,7 @@ class ArrayBase : public Object
 private:
     // This MUST be the first field, so that it directly follows Object.  This is because
     // Object::GetSize() looks at m_NumComponents even though it may not be an array (the
-    // values is shifted out if not an array, so it's ok). 
+    // values is shifted out if not an array, so it's ok).
     DWORD       m_NumComponents;
 #ifdef _TARGET_64BIT_
     DWORD       pad;
@@ -573,7 +573,7 @@ private:
     SVAL_DECL(INT32, s_arrayBoundsZero); // = 0
 
     // What comes after this conceputally is:
-    // INT32      bounds[rank];       The bounds are only present for Multidimensional arrays   
+    // INT32      bounds[rank];       The bounds are only present for Multidimensional arrays
     // INT32      lowerBounds[rank];  Valid indexes are lowerBounds[i] <= index[i] < lowerBounds[i] + bounds[i]
 
 public:
@@ -626,7 +626,7 @@ public:
         return pMT->RawGetComponentSize();
     }
 
-        // Note that this can be a multidimensional array of rank 1 
+        // Note that this can be a multidimensional array of rank 1
         // (for example if we had a 1-D array with lower bounds
     BOOL IsMultiDimArray() const {
         WRAPPER_NO_CONTRACT;
@@ -635,11 +635,11 @@ public:
     }
 
         // Get pointer to the begining of the bounds (counts for each dim)
-        // Works for any array type 
+        // Works for any array type
     PTR_INT32 GetBoundsPtr() const {
         WRAPPER_NO_CONTRACT;
         MethodTable * pMT = GetMethodTable();
-        if (pMT->IsMultiDimArray()) 
+        if (pMT->IsMultiDimArray())
         {
             return dac_cast<PTR_INT32>(
                 dac_cast<TADDR>(this) + sizeof(*this));
@@ -651,7 +651,7 @@ public:
         }
     }
 
-        // Works for any array type 
+        // Works for any array type
     PTR_INT32 GetLowerBoundsPtr() const {
         WRAPPER_NO_CONTRACT;
         if (IsMultiDimArray())
@@ -691,25 +691,25 @@ template < class KIND >
 class Array : public ArrayBase
 {
   public:
-      
+
     typedef DPTR(KIND) PTR_KIND;
     typedef DPTR(const KIND) PTR_CKIND;
 
     KIND          m_Array[1];
 
     PTR_KIND        GetDirectPointerToNonObjectElements()
-    { 
+    {
         WRAPPER_NO_CONTRACT;
         SUPPORTS_DAC;
-        // return m_Array; 
+        // return m_Array;
         return PTR_KIND(GetDataPtr()); // This also handles arrays of dim 1 with lower bounds present
 
     }
 
     PTR_CKIND  GetDirectConstPointerToNonObjectElements() const
-    { 
+    {
         WRAPPER_NO_CONTRACT;
-        // return m_Array; 
+        // return m_Array;
         return PTR_CKIND(GetDataPtr()); // This also handles arrays of dim 1 with lower bounds present
     }
 };
@@ -720,7 +720,7 @@ class PtrArray : public ArrayBase
 {
     friend class GCHeap;
     friend class ClrDataAccess;
-    friend OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, DWORD flags, BOOL bAllocateInLargeHeap); 
+    friend OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, DWORD flags, BOOL bAllocateInLargeHeap);
     friend class JIT_TrialAlloc;
     friend class CheckAsmOffsets;
 
@@ -791,15 +791,15 @@ public:
 
 #define OFFSETOF__PtrArray__m_Array_              ARRAYBASE_SIZE
 
-/* a TypedByRef is a structure that is used to implement VB's BYREF variants.  
+/* a TypedByRef is a structure that is used to implement VB's BYREF variants.
    it is basically a tuple of an address of some data along with a TypeHandle
    that indicates the type of the address */
-class TypedByRef 
+class TypedByRef
 {
 public:
 
     PTR_VOID data;
-    TypeHandle type;  
+    TypeHandle type;
 };
 
 typedef DPTR(TypedByRef) PTR_TypedByRef;
@@ -817,7 +817,7 @@ typedef Array<WCHAR>   CHARArray;
 typedef Array<U4>   U4Array;
 typedef Array<U8>   U8Array;
 typedef Array<UPTR> UPTRArray;
-typedef PtrArray    PTRArray;  
+typedef PtrArray    PTRArray;
 
 typedef DPTR(I1Array)   PTR_I1Array;
 typedef DPTR(I2Array)   PTR_I2Array;
@@ -891,7 +891,7 @@ typedef PTR_Utf8StringObject UTF8STRINGREF;
 /*
  * StringObject
  *
- * Special String implementation for performance.   
+ * Special String implementation for performance.
  *
  *   m_StringLength - Length of string in number of WCHARs
  *   m_FirstChar    - The string buffer
@@ -919,13 +919,13 @@ class StringObject : public Object
   protected:
     StringObject() {LIMITED_METHOD_CONTRACT; }
    ~StringObject() {LIMITED_METHOD_CONTRACT; }
-   
+
   public:
     static DWORD GetBaseSize();
     static SIZE_T GetSize(DWORD stringLength);
 
     DWORD   GetStringLength()                           { LIMITED_METHOD_DAC_CONTRACT; return( m_StringLength );}
-    WCHAR*  GetBuffer()                                 { LIMITED_METHOD_CONTRACT; _ASSERTE(this != nullptr); return (WCHAR*)( dac_cast<TADDR>(this) + offsetof(StringObject, m_FirstChar) );  }
+    WCHAR*  GetBuffer()                                 { LIMITED_METHOD_CONTRACT; return (WCHAR*)( dac_cast<TADDR>(this) + offsetof(StringObject, m_FirstChar) );  }
 
     static UINT GetBufferOffset()
     {
@@ -978,7 +978,7 @@ class StringObject : public Object
     // !!!! sure that you have a pin handle on ref, or use GCPROTECT_BEGINPINNING on ref.
     void RefInterpretGetStringValuesDangerousForGC(__deref_out_ecount(*length + 1) WCHAR **chars, int *length) {
         WRAPPER_NO_CONTRACT;
-    
+
         _ASSERTE(GetGCSafeMethodTable() == g_pStringClass);
         *length = GetStringLength();
         *chars  = GetBuffer();
@@ -1035,7 +1035,7 @@ inline STRINGREF* StringObject::GetEmptyStringRefPtr() {
     return refptr;
 }
 
-// This is used to account for the remoting cache on RuntimeType, 
+// This is used to account for the remoting cache on RuntimeType,
 // RuntimeMethodInfo, and RtFieldInfo.
 class BaseObjectWithCachedData : public Object
 {
@@ -1152,7 +1152,7 @@ public:
     // !!!! sure that you have a pin handle on ref, or use GCPROTECT_BEGINPINNING on ref.
     void RefInterpretGetStringValuesDangerousForGC(__deref_out_ecount(*length + 1) CHAR **chars, int *length) {
         WRAPPER_NO_CONTRACT;
-    
+
         _ASSERTE(GetGCSafeMethodTable() == g_pUtf8StringClass);
         *length = GetStringLength();
         *chars  = GetBuffer();
@@ -1162,7 +1162,7 @@ public:
     }
 
     DWORD   GetStringLength()                           { LIMITED_METHOD_DAC_CONTRACT; return( m_StringLength );}
-    CHAR*   GetBuffer()                                 { LIMITED_METHOD_CONTRACT; _ASSERTE(this != nullptr); return (CHAR*)( dac_cast<TADDR>(this) + offsetof(Utf8StringObject, m_FirstChar) );  }
+    CHAR*   GetBuffer()                                 { LIMITED_METHOD_CONTRACT;  return (CHAR*)( dac_cast<TADDR>(this) + offsetof(Utf8StringObject, m_FirstChar) );  }
 
     static DWORD GetBaseSize();
     static SIZE_T GetSize(DWORD stringLength);
@@ -1173,7 +1173,7 @@ public:
 //  A Method has adddition information.
 //   m_pMD - A pointer to the actual MethodDesc of the method.
 //   m_object - a field that has a reference type in it. Used only for RuntimeMethodInfoStub to keep the real type alive.
-// This structure matches the structure up to the m_pMD for several different managed types. 
+// This structure matches the structure up to the m_pMD for several different managed types.
 // (RuntimeConstructorInfo, RuntimeMethodInfo, and RuntimeMethodInfoStub). These types are unrelated in the type
 // system except that they all implement a particular interface. It is important that that interface is not attached to any
 // type that does not sufficiently match this data structure.
@@ -1216,7 +1216,7 @@ public:
 //  A Method has adddition information.
 //   m_pFD - A pointer to the actual MethodDesc of the method.
 //   m_object - a field that has a reference type in it. Used only for RuntimeFieldInfoStub to keep the real type alive.
-// This structure matches the structure up to the m_pFD for several different managed types. 
+// This structure matches the structure up to the m_pFD for several different managed types.
 // (RtFieldInfo and RuntimeFieldInfoStub). These types are unrelated in the type
 // system except that they all implement a particular interface. It is important that that interface is not attached to any
 // type that does not sufficiently match this data structure.
@@ -1251,13 +1251,13 @@ public:
     }
 };
 
-// ReflectModuleBaseObject 
+// ReflectModuleBaseObject
 // This class is the base class for managed Module.
 //  This class will connect the Object back to the underlying VM representation
 //  m_ReflectClass -- This is the real Class that was used for reflection
 //      This class was used to get at this object
 //  m_pData -- this is a generic pointer which usually points CorModule
-//  
+//
 class ReflectModuleBaseObject : public Object
 {
     friend class MscorlibBinder;
@@ -1266,7 +1266,7 @@ class ReflectModuleBaseObject : public Object
     // READ ME:
     // Modifying the order or fields of this object may require other changes to the
     //  classlib class definition of this object.
-    OBJECTREF          m_runtimeType;    
+    OBJECTREF          m_runtimeType;
     OBJECTREF          m_runtimeAssembly;
     void*              m_ReflectClass;  // Pointer to the ReflectClass structure
     Module*            m_pData;         // Pointer to the Module
@@ -1276,7 +1276,7 @@ class ReflectModuleBaseObject : public Object
   protected:
     ReflectModuleBaseObject() {LIMITED_METHOD_CONTRACT;}
    ~ReflectModuleBaseObject() {LIMITED_METHOD_CONTRACT;}
-   
+
   public:
     void SetModule(Module* p) {
         LIMITED_METHOD_CONTRACT;
@@ -1316,7 +1316,7 @@ private:
     // These field are also defined in the managed representation.  (SecurityContext.cs)If you
     // add or change these field you must also change the managed code so that
     // it matches these.  This is necessary so that the object is the proper
-    // size. 
+    // size.
     CLR_BOOL _requireWaitNotification;
 public:
     BOOL IsWaitNotificationRequired() const
@@ -1421,7 +1421,7 @@ private:
     // m_InternalThread is always valid -- unless the thread has finalized and been
     // resurrected.  (The thread stopped running before it was finalized).
     Thread       *m_InternalThread;
-    INT32         m_Priority;    
+    INT32         m_Priority;
 
     //We need to cache the thread id in managed code for perf reasons.
     INT32         m_ManagedThreadId;
@@ -1454,15 +1454,15 @@ public:
     }
 
     OBJECTREF GetThreadStartArg() { LIMITED_METHOD_CONTRACT; return m_ThreadStartArg; }
-    void SetThreadStartArg(OBJECTREF newThreadStartArg) 
+    void SetThreadStartArg(OBJECTREF newThreadStartArg)
     {
         WRAPPER_NO_CONTRACT;
-    
+
         _ASSERTE(newThreadStartArg == NULL);
-        // Note: this is an unchecked assignment.  We are cleaning out the ThreadStartArg field when 
+        // Note: this is an unchecked assignment.  We are cleaning out the ThreadStartArg field when
         // a thread starts so that ADU does not cause problems
         SetObjectReference( (OBJECTREF *)&m_ThreadStartArg, newThreadStartArg);
-    
+
     }
 
     STRINGREF GetName() {
@@ -1488,13 +1488,13 @@ public:
         LIMITED_METHOD_CONTRACT;
         m_Name = NULL;
     }
-  
+
     void SetPriority(INT32 priority)
     {
         LIMITED_METHOD_CONTRACT;
         m_Priority = priority;
     }
-    
+
     INT32 GetPriority() const
     {
         LIMITED_METHOD_CONTRACT;
@@ -1502,16 +1502,16 @@ public:
     }
 };
 
-// MarshalByRefObjectBaseObject 
+// MarshalByRefObjectBaseObject
 // This class is the base class for MarshalByRefObject
-//  
+//
 class MarshalByRefObjectBaseObject : public Object
 {
 };
 
-// AssemblyBaseObject 
+// AssemblyBaseObject
 // This class is the base class for assemblies
-//  
+//
 class AssemblyBaseObject : public Object
 {
     friend class Assembly;
@@ -1529,16 +1529,16 @@ class AssemblyBaseObject : public Object
   protected:
     AssemblyBaseObject() { LIMITED_METHOD_CONTRACT; }
    ~AssemblyBaseObject() { LIMITED_METHOD_CONTRACT; }
-   
+
   public:
 
-    void SetAssembly(DomainAssembly* p) 
+    void SetAssembly(DomainAssembly* p)
     {
         LIMITED_METHOD_CONTRACT;
         m_pAssembly = p;
     }
 
-    DomainAssembly* GetDomainAssembly() 
+    DomainAssembly* GetDomainAssembly()
     {
         LIMITED_METHOD_CONTRACT;
         return m_pAssembly;
@@ -1602,9 +1602,9 @@ class AssemblyLoadContextBaseObject : public Object
 #include "poppack.h"
 #endif // defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 
-// AssemblyNameBaseObject 
+// AssemblyNameBaseObject
 // This class is the base class for assembly names
-//  
+//
 class AssemblyNameBaseObject : public Object
 {
     friend class AssemblyNative;
@@ -1616,7 +1616,7 @@ class AssemblyNameBaseObject : public Object
     // Modifying the order or fields of this object may require other changes to the
     //  classlib class definition of this object.
 
-    OBJECTREF     _name; 
+    OBJECTREF     _name;
     U1ARRAYREF    _publicKey;
     U1ARRAYREF    _publicKeyToken;
     OBJECTREF     _cultureInfo;
@@ -1630,7 +1630,7 @@ class AssemblyNameBaseObject : public Object
   protected:
     AssemblyNameBaseObject() { LIMITED_METHOD_CONTRACT; }
    ~AssemblyNameBaseObject() { LIMITED_METHOD_CONTRACT; }
-   
+
   public:
     OBJECTREF GetSimpleName() { LIMITED_METHOD_CONTRACT; return _name; }
     U1ARRAYREF GetPublicKey() { LIMITED_METHOD_CONTRACT; return _publicKey; }
@@ -1659,11 +1659,11 @@ class VersionBaseObject : public Object
     int m_Minor;
     int m_Build;
     int m_Revision;
- 
+
     VersionBaseObject() {LIMITED_METHOD_CONTRACT;}
    ~VersionBaseObject() {LIMITED_METHOD_CONTRACT;}
 
-  public:    
+  public:
     int GetMajor() { LIMITED_METHOD_CONTRACT; return m_Major; }
     int GetMinor() { LIMITED_METHOD_CONTRACT; return m_Minor; }
     int GetBuild() { LIMITED_METHOD_CONTRACT; return m_Build; }
@@ -1771,8 +1771,8 @@ CHARARRAYREF AllocateCharArray(DWORD dwArrayLength);
 
 //-------------------------------------------------------------
 // class ComObject, Exposed class __ComObject
-// 
-// 
+//
+//
 //-------------------------------------------------------------
 class ComObject : public MarshalByRefObjectBaseObject
 {
@@ -1814,17 +1814,17 @@ public:
     //-----------------------------------------------------------
     // Redirection for ToString
     static FCDECL1(MethodDesc *, GetRedirectedToStringMD, Object *pThisUNSAFE);
-    static FCDECL2(StringObject *, RedirectToString, Object *pThisUNSAFE, MethodDesc *pToStringMD);    
+    static FCDECL2(StringObject *, RedirectToString, Object *pThisUNSAFE, MethodDesc *pToStringMD);
 
     //-----------------------------------------------------------
     // Redirection for GetHashCode
     static FCDECL1(MethodDesc *, GetRedirectedGetHashCodeMD, Object *pThisUNSAFE);
-    static FCDECL2(int, RedirectGetHashCode, Object *pThisUNSAFE, MethodDesc *pGetHashCodeMD);    
+    static FCDECL2(int, RedirectGetHashCode, Object *pThisUNSAFE, MethodDesc *pGetHashCodeMD);
 
     //-----------------------------------------------------------
     // Redirection for Equals
     static FCDECL1(MethodDesc *, GetRedirectedEqualsMD, Object *pThisUNSAFE);
-    static FCDECL3(FC_BOOL_RET, RedirectEquals, Object *pThisUNSAFE, Object *pOtherUNSAFE, MethodDesc *pEqualsMD);    
+    static FCDECL3(FC_BOOL_RET, RedirectEquals, Object *pThisUNSAFE, Object *pOtherUNSAFE, MethodDesc *pEqualsMD);
 };
 
 #ifdef USE_CHECKED_OBJECTREFS
@@ -1836,8 +1836,8 @@ typedef ComObject*     COMOBJECTREF;
 
 //-------------------------------------------------------------
 // class UnknownWrapper, Exposed class UnknownWrapper
-// 
-// 
+//
+//
 //-------------------------------------------------------------
 class UnknownWrapper : public Object
 {
@@ -1872,8 +1872,8 @@ typedef UnknownWrapper*     UNKNOWNWRAPPEROBJECTREF;
 
 //-------------------------------------------------------------
 // class DispatchWrapper, Exposed class DispatchWrapper
-// 
-// 
+//
+//
 //-------------------------------------------------------------
 class DispatchWrapper : public Object
 {
@@ -1908,8 +1908,8 @@ typedef DispatchWrapper*     DISPATCHWRAPPEROBJECTREF;
 
 //-------------------------------------------------------------
 // class VariantWrapper, Exposed class VARIANTWRAPPEROBJECTREF
-// 
-// 
+//
+//
 //-------------------------------------------------------------
 class VariantWrapper : public Object
 {
@@ -1944,8 +1944,8 @@ typedef VariantWrapper*     VARIANTWRAPPEROBJECTREF;
 
 //-------------------------------------------------------------
 // class ErrorWrapper, Exposed class ErrorWrapper
-// 
-// 
+//
+//
 //-------------------------------------------------------------
 class ErrorWrapper : public Object
 {
@@ -1980,8 +1980,8 @@ typedef ErrorWrapper*     ERRORWRAPPEROBJECTREF;
 
 //-------------------------------------------------------------
 // class CurrencyWrapper, Exposed class CurrencyWrapper
-// 
-// 
+//
+//
 //-------------------------------------------------------------
 
 // Keep this in sync with code:MethodTableBuilder.CheckForSystemTypes where
@@ -2026,8 +2026,8 @@ typedef CurrencyWrapper*     CURRENCYWRAPPEROBJECTREF;
 
 //-------------------------------------------------------------
 // class BStrWrapper, Exposed class BSTRWRAPPEROBJECTREF
-// 
-// 
+//
+//
 //-------------------------------------------------------------
 class BStrWrapper : public Object
 {
@@ -2095,7 +2095,7 @@ class SafeHandle : public Object
 
     // To use the SafeHandle from native, look at the SafeHandleHolder, which
     // will do the AddRef & Release for you.
-    LPVOID GetHandle() const { 
+    LPVOID GetHandle() const {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(((unsigned int) m_state) >= SH_RefCountOne);
         return m_handle;
@@ -2140,7 +2140,7 @@ typedef CriticalHandle * CRITICALHANDLEREF;
 #endif // USE_CHECKED_OBJECTREFS
 
 // WaitHandleBase
-// Base class for WaitHandle 
+// Base class for WaitHandle
 class WaitHandleBase :public MarshalByRefObjectBaseObject
 {
     friend class MscorlibBinder;
@@ -2171,7 +2171,7 @@ class DelegateObject : public Object
 
 public:
     BOOL IsWrapperDelegate() { LIMITED_METHOD_CONTRACT; return _methodPtrAux == NULL; }
-    
+
     OBJECTREF GetTarget() { LIMITED_METHOD_CONTRACT; return _target; }
     void SetTarget(OBJECTREF target) { WRAPPER_NO_CONTRACT; SetObjectReference(&_target, target); }
     static int GetOffsetOfTarget() { LIMITED_METHOD_CONTRACT; return offsetof(DelegateObject, _target); }
@@ -2195,7 +2195,7 @@ public:
     void SetMethodBase(OBJECTREF newMethodBase) { LIMITED_METHOD_CONTRACT; SetObjectReference((OBJECTREF*)&_methodBase, newMethodBase); }
 
     // README:
-    // If you modify the order of these fields, make sure to update the definition in 
+    // If you modify the order of these fields, make sure to update the definition in
     // BCL for this object.
 private:
     // System.Delegate
@@ -2241,7 +2241,7 @@ public:
     {
         WRAPPER_NO_CONTRACT;
     }
-    
+
     StackTraceArray(I1ARRAYREF array)
         : m_array(array)
     {
@@ -2262,7 +2262,7 @@ public:
         m_array = rhs.m_array;
         rhs.m_array = t;
     }
-    
+
     size_t Size() const
     {
         WRAPPER_NO_CONTRACT;
@@ -2271,7 +2271,7 @@ public:
         else
             return GetSize();
     }
-    
+
     StackTraceElement const & operator[](size_t index) const;
     StackTraceElement & operator[](size_t index);
 
@@ -2285,7 +2285,7 @@ public:
 
     // Deep copies the array
     void CopyFrom(StackTraceArray const & src);
-    
+
 private:
     StackTraceArray(StackTraceArray const & rhs) = delete;
 
@@ -2302,7 +2302,7 @@ private:
 
         return m_array->GetNumComponents();
     }
-    
+
     size_t GetSize() const
     {
         WRAPPER_NO_CONTRACT;
@@ -2436,7 +2436,7 @@ public:
     }
 
     // README:
-    // If you modify the order of these fields, make sure to update the definition in 
+    // If you modify the order of these fields, make sure to update the definition in
     // BCL for this object.
 protected:
     LOADERALLOCATORSCOUTREF m_pLoaderAllocatorScout;
@@ -2619,7 +2619,7 @@ public:
         return _watsonBuckets;
     }
 
-    // This method will return a BOOL to indicate if the 
+    // This method will return a BOOL to indicate if the
     // watson buckets are present or not.
     BOOL AreWatsonBucketsPresent()
     {
@@ -2653,7 +2653,7 @@ public:
     }
 
     // README:
-    // If you modify the order of these fields, make sure to update the definition in 
+    // If you modify the order of these fields, make sure to update the definition in
     // BCL for this object.
 private:
     OBJECTREF   _exceptionMethod;  //Needed for serialization.
@@ -2715,53 +2715,53 @@ typedef PTR_ContractExceptionObject CONTRACTEXCEPTIONREF;
 //===============================================================================
 // #NullableFeature
 // #NullableArchitecture
-// 
+//
 // In a nutshell it is counterintuitive to have a boxed Nullable<T>, since a boxed
-// object already has a representation for null (the null pointer), and having 
+// object already has a representation for null (the null pointer), and having
 // multiple representations for the 'not present' value just causes grief.  Thus the
 // feature is build make Nullable<T> box to a boxed<T> (not boxed<Nullable<T>).
 //
-// We want to do this in a way that does not impact the perf of the runtime in the 
-// non-nullable case.  
+// We want to do this in a way that does not impact the perf of the runtime in the
+// non-nullable case.
 //
-// To do this we need to 
+// To do this we need to
 //     * Modify the boxing helper code:JIT_Box (we don't need a special one because
 //           the JIT inlines the common case, so this only gets call in uncommon cases)
 //     * Make a new helper for the Unbox case (see code:JIT_Unbox_Nullable)
-//     * Plumb the JIT to ask for what kind of Boxing helper is needed 
+//     * Plumb the JIT to ask for what kind of Boxing helper is needed
 //          (see code:CEEInfo.getBoxHelper, code:CEEInfo.getUnBoxHelper
 //     * change all the places in the CLR where we box or unbox by hand, and force
-//          them to use code:MethodTable.Box, and code:MethodTable.Unbox which in 
-//          turn call code:Nullable.Box and code:Nullable.UnBox, most of these 
+//          them to use code:MethodTable.Box, and code:MethodTable.Unbox which in
+//          turn call code:Nullable.Box and code:Nullable.UnBox, most of these
 //          are in reflection, and remoting (passing and returning value types).
 //
 // #NullableVerification
 //
 // Sadly, the IL Verifier also needs to know about this change.  Basically the 'box'
-// instruction returns a boxed(T) (not a boxed(Nullable<T>)) for the purposes of 
+// instruction returns a boxed(T) (not a boxed(Nullable<T>)) for the purposes of
 // verfication.  The JIT finds out what box returns by calling back to the EE with
-// the code:CEEInfo.getTypeForBox API.  
+// the code:CEEInfo.getTypeForBox API.
 //
-// #NullableDebugging 
+// #NullableDebugging
 //
-// Sadly, because the debugger also does its own boxing 'by hand' for expression 
+// Sadly, because the debugger also does its own boxing 'by hand' for expression
 // evaluation inside visual studio, it measn that debuggers also need to be aware
 // of the fact that Nullable<T> boxes to a boxed<T>.  It is the responcibility of
-// debuggers to follow this convention (which is why this is sad). 
-// 
+// debuggers to follow this convention (which is why this is sad).
+//
 
 //===============================================================================
-// Nullable represents the managed generic value type Nullable<T> 
+// Nullable represents the managed generic value type Nullable<T>
 //
 // The runtime has special logic for this value class.  When it is boxed
 // it becomes either null or a boxed T.   Similarly a boxed T can be unboxed
 // either as a T (as normal), or as a Nullable<T>
 //
-// See code:Nullable#NullableArchitecture for more. 
+// See code:Nullable#NullableArchitecture for more.
 //
 class Nullable {
     Nullable();   // This is purposefully undefined.  Do not make instances
-                  // of this class.  
+                  // of this class.
 public:
     static void CheckFieldOffsets(TypeHandle nullableType);
     static BOOL IsNullableType(TypeHandle nullableType);
@@ -2789,7 +2789,7 @@ public:
         Nullable *nullable = (Nullable *)src;
         return nullable->ValueAddr(nullableMT);
     }
-    
+
 private:
     static BOOL IsNullableForTypeHelper(MethodTable* nullableMT, MethodTable* paramMT);
     static BOOL IsNullableForTypeHelperNoGC(MethodTable* nullableMT, MethodTable* paramMT);
@@ -2824,7 +2824,7 @@ class GCHeapHashObject : public Object
     INT32 GetCount() { LIMITED_METHOD_CONTRACT; return _count; }
     void IncrementCount(bool replacingDeletedItem)
     {
-        LIMITED_METHOD_CONTRACT; 
+        LIMITED_METHOD_CONTRACT;
         ++_count;
         if (replacingDeletedItem)
             --_deletedCount;
@@ -2882,7 +2882,7 @@ class LAHashDependentHashTrackerObject : public Object
     {
         if (pLoaderAllocator != _loaderAllocator)
             return false;
-        
+
         return IsLoaderAllocatorLive();
     }
 
@@ -2913,7 +2913,7 @@ class LAHashKeyToTrackersObject : public Object
     public:
     // _trackerOrTrackerSet is either a reference to a LAHashDependentHashTracker, or to a GCHeapHash of LAHashDependentHashTracker objects.
     OBJECTREF _trackerOrTrackerSet;
-    // _laLocalKeyValueStore holds an object that represents a Key value (which must always be valid for the lifetime of the 
+    // _laLocalKeyValueStore holds an object that represents a Key value (which must always be valid for the lifetime of the
     // CrossLoaderAllocatorHeapHash, and the values which must also be valid for that entire lifetime. When a value might
     // have a shorter lifetime it is accessed through the _trackerOrTrackerSet variable, which allows access to hashtables which
     // are associated with that remote loaderallocator through a dependent handle, so that lifetime can be managed.

--- a/src/vm/pefile.inl
+++ b/src/vm/pefile.inl
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 // --------------------------------------------------------------------------------
 // PEFile.inl
-// 
+//
 
 // --------------------------------------------------------------------------------
 
@@ -80,12 +80,12 @@ inline ULONG PEFile::Release()
         MODE_ANY;
     }
     CONTRACT_END;
-    
+
     LONG result = FastInterlockDecrement(&m_refCount);
     _ASSERTE(result >= 0);
     if (result == 0)
         delete this;
-    
+
     RETURN result;
 }
 
@@ -135,7 +135,7 @@ inline void PEFile::ValidateForExecution()
     //
     // Ensure platform is valid for execution
     //
-    if (!IsDynamic() && !IsResource()) 
+    if (!IsDynamic() && !IsResource())
     {
         if (IsMarkedAsNoPlatform())
         {
@@ -175,7 +175,7 @@ inline void PEFile::GetMVID(GUID *pMvid)
         MODE_ANY;
     }
     CONTRACTL_END;
-    
+
     IfFailThrow(GetPersistentMDImport()->GetScopeProps(NULL, pMvid));
 }
 
@@ -238,7 +238,7 @@ inline LPCWSTR PEFile::GetDebugName()
         CANNOT_TAKE_LOCK;
     }
     CONTRACTL_END;
-    
+
 #ifdef _DEBUG
     return m_pDebugName;
 #else
@@ -262,8 +262,6 @@ inline PTR_PEAssembly PEFile::AsAssembly()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    if (this == nullptr)
-        return dac_cast<PTR_PEAssembly>(nullptr);
     if (IsAssembly())
         return dac_cast<PTR_PEAssembly>(this);
     else
@@ -282,8 +280,6 @@ inline PTR_PEModule PEFile::AsModule()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    if (this == nullptr)
-        return dac_cast<PTR_PEModule>(nullptr);
     if (IsModule())
         return dac_cast<PTR_PEModule>(this);
     else
@@ -360,7 +356,7 @@ inline IMDInternalImportHolder PEFile::GetMDImport()
 inline IMDInternalImport* PEFile::GetPersistentMDImport()
 {
 /*
-    CONTRACT(IMDInternalImport *) 
+    CONTRACT(IMDInternalImport *)
     {
         INSTANCE_CHECK;
         PRECONDITION(!IsResource());
@@ -389,7 +385,7 @@ inline IMDInternalImport* PEFile::GetPersistentMDImport()
 inline IMDInternalImport *PEFile::GetMDImportWithRef()
 {
 /*
-    CONTRACT(IMDInternalImport *) 
+    CONTRACT(IMDInternalImport *)
     {
         INSTANCE_CHECK;
         PRECONDITION(!IsResource());
@@ -428,7 +424,7 @@ inline IMDInternalImport *PEFile::GetMDImportWithRef()
 
 inline IMetaDataImport2 *PEFile::GetRWImporter()
 {
-    CONTRACT(IMetaDataImport2 *) 
+    CONTRACT(IMetaDataImport2 *)
     {
         INSTANCE_CHECK;
         PRECONDITION(!IsResource());
@@ -448,7 +444,7 @@ inline IMetaDataImport2 *PEFile::GetRWImporter()
 
 inline IMetaDataEmit *PEFile::GetEmitter()
 {
-    CONTRACT(IMetaDataEmit *) 
+    CONTRACT(IMetaDataEmit *)
     {
         INSTANCE_CHECK;
         MODE_ANY;
@@ -487,12 +483,12 @@ inline LPCUTF8 PEFile::GetSimpleName()
 
     if (IsAssembly())
         RETURN dac_cast<PTR_PEAssembly>(this)->GetSimpleName();
-    else 
+    else
     {
         LPCUTF8 szScopeName;
         if (FAILED(GetScopeName(&szScopeName)))
         {
-            szScopeName = ""; 
+            szScopeName = "";
         }
         RETURN szScopeName;
     }
@@ -592,7 +588,7 @@ inline WORD PEFile::GetSubsystem()
     }
 #endif // DACCESS_COMPILE
 #endif // FEATURE_PREJIT
- 
+
     return GetLoadedIL()->GetSubsystem();
 }
 
@@ -640,7 +636,7 @@ inline BOOL PEFile::IsNativeLoaded()
 inline void PEFile::MarkNativeImageInvalidIfOwned()
 {
     WRAPPER_NO_CONTRACT;
-    // If owned, mark the PEFile as dummy, so the image does not get reused 
+    // If owned, mark the PEFile as dummy, so the image does not get reused
     PEImageHolder nativeImage(GetNativeImageWithRef());
     Module * pNativeModule = nativeImage->GetLoadedLayout()->GetPersistedModuleImage();
     PEFile ** ppNativeFile = (PEFile**) (PBYTE(pNativeModule) + Module::GetFileOffset());
@@ -659,7 +655,7 @@ inline BOOL PEFile::IsILOnly()
     SUPPORTS_DAC;
 
     CONTRACT_VIOLATION(ThrowsViolation|GCViolation|FaultViolation);
-    
+
     if (IsResource() || IsDynamic())
         return FALSE;
 
@@ -736,9 +732,9 @@ inline PTR_VOID PEFile::GetRvaField(RVA field)
     }
     CONTRACT_END;
 
-    // Note that the native image Rva fields are currently cut off before 
+    // Note that the native image Rva fields are currently cut off before
     // this point.  We should not get here for an IL only native image.
-    
+
     RETURN dac_cast<PTR_VOID>(GetLoadedIL()->GetRvaData(field,NULL_OK));
 }
 
@@ -755,10 +751,10 @@ inline CHECK PEFile::CheckRvaField(RVA field)
         MODE_ANY;
     }
     CONTRACT_CHECK_END;
-        
-    // Note that the native image Rva fields are currently cut off before 
+
+    // Note that the native image Rva fields are currently cut off before
     // this point.  We should not get here for an IL only native image.
-    
+
     CHECK(GetLoadedIL()->CheckRva(field,NULL_OK));
     CHECK_OK;
 }
@@ -777,9 +773,9 @@ inline CHECK PEFile::CheckRvaField(RVA field, COUNT_T size)
     }
     CONTRACT_CHECK_END;
 
-    // Note that the native image Rva fields are currently cut off before 
+    // Note that the native image Rva fields are currently cut off before
     // this point.  We should not get here for an IL only native image.
-    
+
     CHECK(GetLoadedIL()->CheckRva(field, size,0,NULL_OK));
     CHECK_OK;
 }
@@ -846,11 +842,11 @@ inline UINT32 PEFile::GetFieldTlsOffset(RVA field)
         MODE_ANY;
     }
     CONTRACTL_END;
-        
-    return (UINT32)(dac_cast<PTR_BYTE>(GetRvaField(field)) - 
+
+    return (UINT32)(dac_cast<PTR_BYTE>(GetRvaField(field)) -
                                 dac_cast<PTR_BYTE>(GetLoadedIL()->GetTlsRange()));
 }
-        
+
 inline UINT32 PEFile::GetTlsIndex()
 {
     CONTRACTL
@@ -902,7 +898,7 @@ inline CHECK PEFile::CheckInternalPInvokeTarget(RVA target)
 
     CHECK(!IsILOnly());
     CHECK(GetLoadedIL()->CheckRva(target));
-    
+
     CHECK_OK;
 }
 
@@ -981,7 +977,7 @@ inline PTR_VOID PEFile::GetDebuggerContents(COUNT_T *pSize/*=NULL*/)
     }
     CONTRACT_END;
 
-    // We cannot in general force a LoadLibrary; we might be in the 
+    // We cannot in general force a LoadLibrary; we might be in the
     // helper thread.  The debugger will have to expect a zero base
     // in some circumstances.
 
@@ -1045,14 +1041,14 @@ inline const void *PEFile::GetManagedFileContents(COUNT_T *pSize/*=NULL*/)
     }
     CONTRACT_END;
 
-    // Right now, we will trigger a LoadLibrary for the caller's sake, 
+    // Right now, we will trigger a LoadLibrary for the caller's sake,
     // even if we are in a scenario where we could normally avoid it.
     LoadLibrary(FALSE);
 
     if (pSize != NULL)
         *pSize = GetLoadedIL()->GetSize();
 
-    
+
     RETURN GetLoadedIL()->GetBase();
 }
 #endif // DACCESS_COMPILE
@@ -1130,7 +1126,7 @@ inline BOOL PEFile::HasNativeOrReadyToRunImage()
     return (HasNativeImage() || IsILImageReadyToRun());
 }
 
-inline PTR_PEImageLayout PEFile::GetLoadedIL() 
+inline PTR_PEImageLayout PEFile::GetLoadedIL()
 {
     LIMITED_METHOD_CONTRACT;
     SUPPORTS_DAC;
@@ -1140,14 +1136,14 @@ inline PTR_PEImageLayout PEFile::GetLoadedIL()
     return GetOpenedILimage()->GetLoadedLayout();
 };
 
-inline PTR_PEImageLayout PEFile::GetAnyILWithRef() 
+inline PTR_PEImageLayout PEFile::GetAnyILWithRef()
 {
     WRAPPER_NO_CONTRACT;
     return GetILimage()->GetLayout(PEImageLayout::LAYOUT_ANY,PEImage::LAYOUT_CREATEIFNEEDED);
 };
 
 
-inline BOOL PEFile::IsLoaded(BOOL bAllowNative/*=TRUE*/) 
+inline BOOL PEFile::IsLoaded(BOOL bAllowNative/*=TRUE*/)
 {
     CONTRACTL
     {
@@ -1170,7 +1166,7 @@ inline BOOL PEFile::IsLoaded(BOOL bAllowNative/*=TRUE*/)
 };
 
 
-inline PTR_PEImageLayout PEFile::GetLoaded() 
+inline PTR_PEImageLayout PEFile::GetLoaded()
 {
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
@@ -1226,7 +1222,7 @@ inline PEImage *PEFile::GetNativeImageWithRef()
     {
         INSTANCE_CHECK;
         NOTHROW;
-        GC_TRIGGERS; 
+        GC_TRIGGERS;
         MODE_ANY;
         POSTCONDITION(CheckPointer(RETVAL,NULL_OK));
     }
@@ -1281,25 +1277,25 @@ inline BOOL PEFile::HasNativeImageMetadata()
         PBYTE pbPublicKey;
         DWORD cbPublicKey;
         if (FAILED(pImport->GetAssemblyProps(
-            mda, 
-            (const void **) &pbPublicKey, 
-            &cbPublicKey, 
-            NULL, 
-            &name, 
-            &context, 
+            mda,
+            (const void **) &pbPublicKey,
+            &cbPublicKey,
+            NULL,
+            &name,
+            &context,
             &dwFlags)))
         {
             _ASSERTE(!"If this fires, then we have to throw for corrupted images");
             result.SetUTF8("");
             return;
         }
-        
+
         result.SetUTF8(name);
-        
+
         result.AppendPrintf(W(", Version=%u.%u.%u.%u"),
                             context.usMajorVersion, context.usMinorVersion,
                             context.usBuildNumber, context.usRevisionNumber);
-        
+
         result.Append(W(", Culture="));
         if (!*context.szLocale)
         {
@@ -1309,7 +1305,7 @@ inline BOOL PEFile::HasNativeImageMetadata()
         {
             result.AppendUTF8(context.szLocale);
         }
-        
+
         if (cbPublicKey != 0)
         {
 #ifndef DACCESS_COMPILE
@@ -1317,7 +1313,7 @@ inline BOOL PEFile::HasNativeImageMetadata()
             StrongNameBufferHolder<BYTE> pbToken;
             DWORD cbToken;
             CQuickBytes qb;
-            
+
             if (StrongNameTokenFromPublicKey(pbPublicKey, cbPublicKey,
                                              &pbToken, &cbToken))
             {
@@ -1333,10 +1329,10 @@ inline BOOL PEFile::HasNativeImageMetadata()
                         WCHAR v = static_cast<WCHAR>(pbToken[x] >> 4);
                         szToken[y++] = TOHEX( v );
                         v = static_cast<WCHAR>(pbToken[x] & 0x0F);
-                        szToken[y++] = TOHEX( v ); 
+                        szToken[y++] = TOHEX( v );
                     }
                     szToken[y] = L'\0';
-                    
+
                     result.Append(W(", PublicKeyToken="));
                     result.Append(szToken);
 #undef TOHEX
@@ -1349,11 +1345,11 @@ inline BOOL PEFile::HasNativeImageMetadata()
         {
             result.Append(W(", PublicKeyToken=null"));
         }
-        
+
         if (dwFlags & afPA_Mask)
         {
             result.Append(W(", ProcessorArchitecture="));
-            
+
             if (dwFlags & afPA_MSIL)
                 result.Append(W("MSIL"));
             else if (dwFlags & afPA_x86)
@@ -1367,8 +1363,8 @@ inline BOOL PEFile::HasNativeImageMetadata()
         }
     }
 }
- 
- 
+
+
 // ------------------------------------------------------------
 // Descriptive strings
 // ------------------------------------------------------------
@@ -1386,7 +1382,7 @@ inline void PEAssembly::GetDisplayName(SString &result, DWORD flags)
         MODE_ANY;
     }
     CONTRACTL_END;
- 
+
 #ifndef DACCESS_COMPILE
 
     if ((flags == (ASM_DISPLAYF_VERSION | ASM_DISPLAYF_CULTURE | ASM_DISPLAYF_PUBLIC_KEY_TOKEN)) &&
@@ -1421,7 +1417,7 @@ inline LPCSTR PEAssembly::GetSimpleName()
         SUPPORTS_DAC;
     }
     CONTRACTL_END;
-    
+
     LPCSTR name = "";
     IMDInternalImportHolder pImport = GetMDImport();
     if (pImport != NULL)
@@ -1444,7 +1440,7 @@ inline BOOL PEFile::IsStrongNamed()
         MODE_ANY;
     }
     CONTRACTL_END;
-    
+
     DWORD flags = 0;
     IfFailThrow(GetMDImport()->GetAssemblyProps(TokenFromRid(1, mdtAssembly), NULL, NULL, NULL, NULL, NULL, &flags));
     return (flags & afPublicKey) != NULL;
@@ -1466,7 +1462,7 @@ inline const void *PEFile::GetPublicKey(DWORD *pcbPK)
         MODE_ANY;
     }
     CONTRACTL_END;
-    
+
     const void *pPK;
     IfFailThrow(GetMDImport()->GetAssemblyProps(TokenFromRid(1, mdtAssembly), &pPK, pcbPK, NULL, NULL, NULL, NULL));
     return pPK;
@@ -1481,7 +1477,7 @@ inline ULONG PEFile::GetHashAlgId()
         MODE_ANY;
     }
     CONTRACTL_END;
-    
+
     ULONG hashAlgId;
     IfFailThrow(GetMDImport()->GetAssemblyProps(TokenFromRid(1, mdtAssembly), NULL, NULL, &hashAlgId, NULL, NULL, NULL));
     return hashAlgId;
@@ -1496,7 +1492,7 @@ inline LPCSTR PEFile::GetLocale()
         MODE_ANY;
     }
     CONTRACTL_END;
-    
+
     AssemblyMetaDataInternal md;
     IfFailThrow(GetMDImport()->GetAssemblyProps(TokenFromRid(1, mdtAssembly), NULL, NULL, NULL, NULL, &md, NULL));
     return md.szLocale;
@@ -1558,7 +1554,7 @@ inline void PEFile::RestoreMDImport(IMDInternalImport* pImport)
         FORBID_FAULT;
     }
     CONTRACTL_END;
-    
+
     _ASSERTE(m_pMetadataLock->LockTaken() && m_pMetadataLock->IsWriterLock());
     if (m_pMDImport != NULL)
         return;
@@ -1605,7 +1601,7 @@ inline bool PEAssembly::IsWindowsRuntime()
         MODE_ANY;
     }
     CONTRACTL_END;
-    
+
     return IsAfContentType_WindowsRuntime(GetFlags());
 }
 

--- a/src/vm/peimage.cpp
+++ b/src/vm/peimage.cpp
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 // --------------------------------------------------------------------------------
 // PEImage.cpp
-// 
+//
 
 // --------------------------------------------------------------------------------
 
@@ -98,7 +98,7 @@ CHECK PEImage::CheckLayoutFormat(PEDecoder *pe)
     CHECK_OK;
 }
 
-CHECK PEImage::CheckILFormat() 
+CHECK PEImage::CheckILFormat()
 {
     WRAPPER_NO_CONTRACT;
 
@@ -364,8 +364,8 @@ void PEImage::GetPathFromDll(HINSTANCE hMod, SString &result)
     }
     CONTRACTL_END;
 
-    WszGetModuleFileName(hMod, result);   
-    
+    WszGetModuleFileName(hMod, result);
+
 }
 #endif // !FEATURE_PAL
 
@@ -524,7 +524,7 @@ void PEImage::OpenMDImport()
         if(FastInterlockCompareExchangePointer(&m_pMDImport, m_pNewImport, NULL))
         {
             m_pNewImport->Release();
-        } 
+        }
         else
         {
             // grab the module name. This information is only used for dac. But we need to get
@@ -566,9 +566,9 @@ void PEImage::GetMVID(GUID *pMvid)
         INJECT_FAULT(COMPlusThrowOM(););
     }
     CONTRACTL_END;
-    
+
     IfFailThrow(GetMDImport()->GetScopeProps(NULL, pMvid));
-    
+
 #ifdef _DEBUG
     COUNT_T cMeta;
     const void *pMeta = GetMetadata(&cMeta);
@@ -576,7 +576,7 @@ void PEImage::GetMVID(GUID *pMvid)
 
     if (pMeta == NULL)
         ThrowHR(COR_E_BADIMAGEFORMAT);
-    
+
     SafeComHolder<IMDInternalImport> pMDImport;
 
     IfFailThrow(GetMetaDataInternalInterface((void *) pMeta,
@@ -651,7 +651,7 @@ void PEImage::VerifyIsILOrNIAssembly(BOOL fIL)
 #endif
     if (!checkGoodFormat)
         ThrowFormat(COR_E_BADIMAGEFORMAT);
-    
+
     mdAssembly a;
     if (FAILED(GetMDImport()->GetAssemblyFromScope(&a)))
         ThrowFormat(COR_E_ASSEMBLYEXPECTED);
@@ -854,7 +854,7 @@ void PEImage::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 
                 // Triage dumps must not dump full paths as they may contain PII data.
                 // Thus, we replace debug directory's pdbs full path for with filaname only.
-                if (flags == CLRDATA_ENUM_MEM_TRIAGE &&                  
+                if (flags == CLRDATA_ENUM_MEM_TRIAGE &&
                     pDebugEntry[iIndex].Type == IMAGE_DEBUG_TYPE_CODEVIEW)
                 {
                     DWORD CvSignature = *(dac_cast<PTR_DWORD>(taEntryAddr));
@@ -862,7 +862,7 @@ void PEImage::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
                     {
                         CV_INFO_PDB70* pCvInfo = (CV_INFO_PDB70*)DacInstantiateTypeByAddressNoReport(taEntryAddr, sizeof(CV_INFO_PDB70), false);
 
-                        if (pCvInfo == NULL || pCvInfo->path == NULL)
+                        if (pCvInfo == NULL)
                         {
                             continue;
                         }
@@ -885,7 +885,7 @@ void PEImage::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
                         {
                             pCvInfo->path[i] = '\0';
                         }
-                        
+
                         DacUpdateMemoryRegion( taEntryAddr + offsetof(CV_INFO_PDB70, path), sizeof(pCvInfo->path), (PBYTE)pCvInfo->path );
                     }
                 }
@@ -957,7 +957,7 @@ PTR_PEImageLayout PEImage::GetLayout(DWORD imageLayoutMask,DWORD flags)
         SimpleReadLockHolder lock(m_pLayoutLock);
         pRetVal=GetLayoutInternal(imageLayoutMask,flags&(~LAYOUT_CREATEIFNEEDED));
     }
-    
+
     if (!(pRetVal || (flags&LAYOUT_CREATEIFNEEDED)==0))
     {
         SimpleWriteLockHolder lock(m_pLayoutLock);
@@ -990,9 +990,9 @@ PTR_PEImageLayout PEImage::GetLayoutInternal(DWORD imageLayoutMask,DWORD flags)
         MODE_ANY;
     }
     CONTRACTL_END;
-    
-    PTR_PEImageLayout pRetVal=GetExistingLayoutInternal(imageLayoutMask); 
- 
+
+    PTR_PEImageLayout pRetVal=GetExistingLayoutInternal(imageLayoutMask);
+
     if (pRetVal==NULL && (flags&LAYOUT_CREATEIFNEEDED))
     {
         _ASSERTE(HasID());
@@ -1055,7 +1055,7 @@ PTR_PEImageLayout PEImage::CreateLayoutMapped()
 
     if (m_bIsTrustedNativeImage || IsFile())
     {
-        // For CoreCLR, try to load all files via LoadLibrary first. If LoadLibrary did not work, retry using 
+        // For CoreCLR, try to load all files via LoadLibrary first. If LoadLibrary did not work, retry using
         // regular mapping - but not for native images.
         pLoadLayout = PEImageLayout::Load(this, FALSE /* bNTSafeLoad */, m_bIsTrustedNativeImage /* bThrowOnError */);
     }
@@ -1398,7 +1398,7 @@ HRESULT PEImage::TryOpenFile()
     STANDARD_VM_CONTRACT;
 
     SimpleWriteLockHolder lock(m_pLayoutLock);
-    
+
     if (m_hFile!=INVALID_HANDLE_VALUE)
         return S_OK;
     {

--- a/src/vm/stubhelpers.cpp
+++ b/src/vm/stubhelpers.cpp
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 //
 // File: stubhelpers.cpp
-// 
+//
 
 //
 
@@ -59,7 +59,10 @@ void StubHelpers::ValidateObjectInternal(Object *pObjUNSAFE, BOOL fValidateNextO
 
 	// validate the object - there's no need to validate next object's
 	// header since we validate the next object explicitly below
-	pObjUNSAFE->Validate(/*bDeep=*/ TRUE, /*bVerifyNextHeader=*/ FALSE, /*bVerifySyncBlock=*/ TRUE);
+	if (pObjUNSAFE)
+	{
+		pObjUNSAFE->Validate(/*bDeep=*/ TRUE, /*bVerifyNextHeader=*/ FALSE, /*bVerifySyncBlock=*/ TRUE);
+	}
 
 	// and the next object as required
 	if (fValidateNextObj)
@@ -106,7 +109,7 @@ void StubHelpers::FormatValidationMessage(MethodDesc *pMD, SString &ssErrorStrin
     {
         THROWS;
         GC_NOTRIGGER;
-        MODE_ANY;           
+        MODE_ANY;
     }
     CONTRACTL_END;
 
@@ -139,7 +142,7 @@ void StubHelpers::ProcessByrefValidationList()
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_ANY;           
+        MODE_ANY;
     }
     CONTRACTL_END;
 
@@ -236,7 +239,7 @@ FORCEINLINE static IUnknown *GetCOMIPFromRCW_GetIUnknownFromRCWCache(RCW *pRCW, 
     // The code in this helper is the "fast path" that used to be generated directly
     // to compiled ML stubs. The idea is to aim for an efficient RCW cache hit.
     SOleTlsData * pOleTlsData = GetOrCreateOleTlsData();
-    
+
     // test for free-threaded after testing for context match to optimize for apartment-bound objects
     if (pOleTlsData->pCurrentCtx == pRCW->GetWrapperCtxCookie() || pRCW->IsFreeThreaded())
     {
@@ -270,7 +273,7 @@ FORCEINLINE static IUnknown *GetCOMIPFromRCW_GetIUnknownFromRCWCache_NoIntercept
     // to compiled ML stubs. The idea is to aim for an efficient RCW cache hit.
     SOleTlsData *pOleTlsData = GetOrCreateOleTlsData();
     MethodTable *pItfMT = pComInfo->m_pInterfaceMT;
-    
+
     // test for free-threaded after testing for context match to optimize for apartment-bound objects
     if (pOleTlsData->pCurrentCtx == pRCW->GetWrapperCtxCookie() || pRCW->IsFreeThreaded())
     {
@@ -291,7 +294,7 @@ FORCEINLINE static IUnknown *GetCOMIPFromRCW_GetIUnknownFromRCWCache_NoIntercept
     if (pAuxData != NULL)
     {
         LPVOID pCtxCookie = (pRCW->IsFreeThreaded() ? NULL : pOleTlsData->pCurrentCtx);
-        
+
         IUnknown *pUnk = pAuxData->FindInterfacePointer(pItfMT, pCtxCookie);
         if (pUnk != NULL)
         {
@@ -340,7 +343,7 @@ NOINLINE static IUnknown* GetCOMIPFromRCWHelper(LPVOID pFCall, OBJECTREF pSrc, M
     GetCOMIPFromRCW_ClearFP();
 
     pIntf = pRetUnk.Extract();
-    
+
     // No exception will be thrown here (including thread abort as it is delayed in IL stubs)
     HELPER_METHOD_FRAME_END();
 
@@ -485,7 +488,7 @@ NOINLINE static FC_BOOL_RET ShouldCallWinRTInterfaceHelper(RCW *pRCW, MethodTabl
     FC_INNER_PROLOG(StubHelpers::ShouldCallWinRTInterface);
 
     bool result = false;
-    
+
     HELPER_METHOD_FRAME_BEGIN_RET_ATTRIB(Frame::FRAME_ATTR_EXACT_DEPTH|Frame::FRAME_ATTR_CAPTURE_DEPTH_2);
 
     // call the GC-triggering version
@@ -528,7 +531,7 @@ NOINLINE static DelegateObject *GetTargetForAmbiguousVariantCallHelper(RCW *pRCW
     FC_INNER_PROLOG(StubHelpers::GetTargetForAmbiguousVariantCall);
 
     DelegateObject *pRetVal = NULL;
-    
+
     HELPER_METHOD_FRAME_BEGIN_RET_ATTRIB(Frame::FRAME_ATTR_EXACT_DEPTH|Frame::FRAME_ATTR_CAPTURE_DEPTH_2);
 
     // Note that if the call succeeds, it will set the right OBJECTHANDLE/flags on the RCW so we won't have to do this
@@ -561,7 +564,7 @@ FCIMPL3(DelegateObject*, StubHelpers::GetTargetForAmbiguousVariantCall, Object *
     RCW *pRCW = pSrc->PassiveGetSyncBlock()->GetInteropInfoNoCreate()->GetRawRCW();
     if (pRCW == NULL)
     {
-        // ignore this - the call we'll attempt to make later will throw the right exception 
+        // ignore this - the call we'll attempt to make later will throw the right exception
         *pfUseString = false;
         return NULL;
     }
@@ -611,8 +614,8 @@ FCIMPL1(Object*, StubHelpers::ObjectMarshaler__ConvertToManaged, VARIANT* pSrc)
 
     OBJECTREF retVal = NULL;
     HELPER_METHOD_FRAME_BEGIN_RET_1(retVal);
-    // The IL stub is going to call ObjectMarshaler__ClearNative() afterwards.  
-    // If it doesn't it's a bug in ILObjectMarshaler.    
+    // The IL stub is going to call ObjectMarshaler__ClearNative() afterwards.
+    // If it doesn't it's a bug in ILObjectMarshaler.
     OleVariant::MarshalObjectForOleVariant(pSrc, &retVal);
     HELPER_METHOD_FRAME_END();
 
@@ -666,10 +669,10 @@ FCIMPL4(Object*, StubHelpers::InterfaceMarshaler__ConvertToManaged, IUnknown **p
     {
         return NULL;
     }
-    
+
     OBJECTREF pObj = NULL;
     HELPER_METHOD_FRAME_BEGIN_RET_1(pObj);
-    
+
     // We're going to be making some COM calls, better initialize COM.
     EnsureComStarted();
 
@@ -677,7 +680,7 @@ FCIMPL4(Object*, StubHelpers::InterfaceMarshaler__ConvertToManaged, IUnknown **p
 
     HELPER_METHOD_FRAME_END();
 
-    return OBJECTREFToObject(pObj);  
+    return OBJECTREFToObject(pObj);
 }
 FCIMPLEND
 
@@ -764,9 +767,9 @@ FCIMPL1(Object *, StubHelpers::InterfaceMarshaler__ConvertToManagedWithoutUnboxi
     //
     // Get a wrapper for pNative
     // Note that we need to skip WinRT unboxing at this point because
-    // 1. We never know whether GetObjectRefFromComIP went through unboxing path. 
+    // 1. We never know whether GetObjectRefFromComIP went through unboxing path.
     // For example, user could just pass a IUnknown * to T and we'll happily convert that to T
-    // 2. If for some reason we end up getting something that does not implement IReference<T>, 
+    // 2. If for some reason we end up getting something that does not implement IReference<T>,
     // we'll get a nice message later when we do the cast in CLRIReferenceImpl.UnboxHelper
     //
     GetObjectRefFromComIP(
@@ -774,20 +777,20 @@ FCIMPL1(Object *, StubHelpers::InterfaceMarshaler__ConvertToManagedWithoutUnboxi
         pNative,                                        // pUnk
         g_pBaseCOMObject,                               // Use __ComObject
         NULL,                                           // pItfMT
-        ObjFromComIP::CLASS_IS_HINT |                   // No cast check - we'll do cast later 
+        ObjFromComIP::CLASS_IS_HINT |                   // No cast check - we'll do cast later
         ObjFromComIP::UNIQUE_OBJECT |                   // Do not cache the object - To ensure that the unboxing code is called on this object always
                                                         // and the object is not retrieved from the cache as an __ComObject.
                                                         // Don't call GetRuntimeClassName - I just want a RCW of __ComObject
         ObjFromComIP::IGNORE_WINRT_AND_SKIP_UNBOXING    // Skip unboxing
         );
-        
+
     HELPER_METHOD_FRAME_END();
 
     return OBJECTREFToObject(oref);
 }
 FCIMPLEND
 
-FCIMPL2(StringObject *, StubHelpers::WinRTTypeNameConverter__ConvertToWinRTTypeName, 
+FCIMPL2(StringObject *, StubHelpers::WinRTTypeNameConverter__ConvertToWinRTTypeName,
     ReflectClassBaseObject *pTypeUNSAFE, CLR_BOOL *pbIsWinRTPrimitive)
 {
     CONTRACTL
@@ -802,7 +805,7 @@ FCIMPL2(StringObject *, StubHelpers::WinRTTypeNameConverter__ConvertToWinRTTypeN
     STRINGREF refString= NULL;
     HELPER_METHOD_FRAME_BEGIN_RET_2(refClass, refString);
 
-    SString strWinRTTypeName;    
+    SString strWinRTTypeName;
     bool bIsPrimitive;
     if (WinRTTypeNameConverter::AppendWinRTTypeNameForManagedType(
         refClass->GetType(),    // thManagedType
@@ -842,12 +845,12 @@ FCIMPL2(ReflectClassBaseObject *, StubHelpers::WinRTTypeNameConverter__GetTypeFr
     bool isPrimitive;
     TypeHandle th = WinRTTypeNameConverter::LoadManagedTypeForWinRTTypeName(refString->GetBuffer(), /* pLoadBinder */ nullptr, &isPrimitive);
     *pbIsPrimitive = isPrimitive;
-    
+
     refClass = th.GetManagedClassObject();
-    
+
     HELPER_METHOD_FRAME_END();
 
-    return (ReflectClassBaseObject *)OBJECTREFToObject(refClass);    
+    return (ReflectClassBaseObject *)OBJECTREFToObject(refClass);
 }
 FCIMPLEND
 
@@ -856,7 +859,7 @@ FCIMPL1(MethodDesc*, StubHelpers::GetDelegateInvokeMethod, DelegateObject *pThis
     FCALL_CONTRACT;
 
     MethodDesc *pMD = NULL;
-    
+
     OBJECTREF pThis = ObjectToOBJECTREF(pThisUNSAFE);
     HELPER_METHOD_FRAME_BEGIN_RET_1(pThis);
 
@@ -897,8 +900,8 @@ FCIMPL2(IInspectable *, StubHelpers::GetWinRTFactoryReturnValue, Object *pThisUN
 
     MethodTable *pDefaultItf = pClassMT->GetDefaultWinRTInterface();
     const IID &riid = (pDefaultItf == NULL ? IID_IInspectable : IID_NULL);
-    
-    pInsp = static_cast<IInspectable *>(ComCallWrapper::GetComIPFromCCW(pWrap, riid, pDefaultItf, 
+
+    pInsp = static_cast<IInspectable *>(ComCallWrapper::GetComIPFromCCW(pWrap, riid, pDefaultItf,
         GetComIPFromCCW::CheckVisibility));
 
     HELPER_METHOD_FRAME_END();
@@ -1089,7 +1092,7 @@ public :
 
         _ASSERTE(pThread != NULL);
         _ASSERTE(pCtxCookie != NULL);
-        
+
         m_bIsFreeThreaded = false;
         m_pThread = pThread;
         m_pCtxCookie = pCtxCookie;
@@ -1102,7 +1105,7 @@ public :
         LIMITED_METHOD_CONTRACT;
 
         _ASSERTE(pRCW != NULL);
-        
+
         if (pRCW->IsFreeThreaded())
             m_bIsFreeThreaded = true;
 
@@ -1116,11 +1119,11 @@ public :
     virtual bool ShouldUseThisRCW(RCW *pRCW)
     {
         LIMITED_METHOD_CONTRACT;
-        
+
         _ASSERTE(pRCW->SupportsIInspectable());
 
         // Is this a free threaded RCW or a context-bound RCW created in the same context
-        if (pRCW->IsFreeThreaded() || 
+        if (pRCW->IsFreeThreaded() ||
             pRCW->GetWrapperCtxCookie() == m_pCtxCookie)
         {
             return true;
@@ -1129,11 +1132,11 @@ public :
         {
             //
             // Now we get back a WinRT factory RCW created in a different context. This means the
-            // factory is a singleton, and the returned IActivationFactory could be either one of 
+            // factory is a singleton, and the returned IActivationFactory could be either one of
             // the following:
             // 1) A raw pointer, and it acts like a free threaded object
             // 2) A proxy that is used across different contexts. It might maintain a list of contexts
-            // that it is marshaled to, and will fail to be called if it is not marshaled to this 
+            // that it is marshaled to, and will fail to be called if it is not marshaled to this
             // context yet.
             //
             // In this case, it is unsafe to use this RCW in this context and we should proceed
@@ -1143,13 +1146,13 @@ public :
             return false;
         }
     }
-    
+
     virtual void OnRCWCacheHit(RCW *pRCW)
     {
-        LIMITED_METHOD_CONTRACT;    
+        LIMITED_METHOD_CONTRACT;
 
         if (pRCW->IsFreeThreaded())
-            m_bIsFreeThreaded = true;        
+            m_bIsFreeThreaded = true;
 
         if (pRCW->IsDCOMProxy())
             m_bIsDCOMProxy = true;
@@ -1161,7 +1164,7 @@ public :
 
         return m_bIsFreeThreaded;
     }
-    
+
     bool IsDCOMProxy()
     {
         LIMITED_METHOD_CONTRACT;
@@ -1186,14 +1189,14 @@ FCIMPL1(Object*, StubHelpers::GetWinRTFactoryObject, MethodDesc *pCMD)
     OBJECTREF refFactory = NULL;
 
     HELPER_METHOD_FRAME_BEGIN_RET_1(refFactory);
-    
+
     MethodTable *pMTOfTypeToCreate = pCMD->GetMethodTable();
     AppDomain   *pDomain = GetAppDomain();
 
     //
     // Look up cached WinRT factory according to type to create + current context cookie
-    // For each type in AppDomain, we cache only the last WinRT factory object 
-    // We don't cache factory per context in order to avoid explosion of objects if there are 
+    // For each type in AppDomain, we cache only the last WinRT factory object
+    // We don't cache factory per context in order to avoid explosion of objects if there are
     // multiple STA apartments
     //
     // Note that if cached WinRT factory is FTM, we'll get it back regardless of the supplied cookie
@@ -1201,11 +1204,11 @@ FCIMPL1(Object*, StubHelpers::GetWinRTFactoryObject, MethodDesc *pCMD)
     LPVOID lpCtxCookie = GetCurrentCtxCookie();
     refFactory = pDomain->LookupWinRTFactoryObject(pMTOfTypeToCreate, lpCtxCookie);
     if (refFactory == NULL)
-    {   
+    {
         //
         // Didn't find a cached factory that matches the context
         // Time to create a new factory and wrap it in a RCW
-        // 
+        //
 
         //
         // Creates a callback to checks for singleton WinRT factory during RCW creation
@@ -1239,7 +1242,7 @@ FCIMPL1(Object*, StubHelpers::GetWinRTFactoryObject, MethodDesc *pCMD)
         //
         if (callback.IsFreeThreaded())
             lpCtxCookie = NULL;
-        
+
         // Cache the result in the AD-wide cache, unless this is a proxy to a DCOM object.
         // Out of process WinRT servers can have lifetimes independent of the application,
         // and the cache may wind up with stale pointers if we save proxies to OOP factories.
@@ -1263,7 +1266,7 @@ FCIMPL3(SIZE_T, StubHelpers::ProfilerBeginTransitionCallback, SIZE_T pSecretPara
 {
     FCALL_CONTRACT;
 
-    // We can get here with an ngen image generated with "/prof", 
+    // We can get here with an ngen image generated with "/prof",
     // even if the profiler doesn't want to track transitions.
     if (!CORProfilerTrackTransitions())
     {
@@ -1274,7 +1277,7 @@ FCIMPL3(SIZE_T, StubHelpers::ProfilerBeginTransitionCallback, SIZE_T pSecretPara
 
     BEGIN_PRESERVE_LAST_ERROR;
 
-    // We must transition to preemptive GC mode before calling out to the profiler, 
+    // We must transition to preemptive GC mode before calling out to the profiler,
     // and the transition requires us to set up a HMF.
     DELEGATEREF dref = (DELEGATEREF)ObjectToOBJECTREF(unsafe_pThis);
     HELPER_METHOD_FRAME_BEGIN_RET_1(dref);
@@ -1292,7 +1295,7 @@ FCIMPL3(SIZE_T, StubHelpers::ProfilerBeginTransitionCallback, SIZE_T pSecretPara
     else
     if (pSecretParam == 0)
     {
-        // Secret param is null.  This is the calli pinvoke case or the unmanaged delegate case.  
+        // Secret param is null.  This is the calli pinvoke case or the unmanaged delegate case.
         // We have an unmanaged target address but no MD.  For the unmanaged delegate case, we can
         // still retrieve the MD by looking at the "this" object.
 
@@ -1343,7 +1346,7 @@ FCIMPL2(void, StubHelpers::ProfilerEndTransitionCallback, MethodDesc* pRealMD, T
 {
     FCALL_CONTRACT;
 
-    // We can get here with an ngen image generated with "/prof", 
+    // We can get here with an ngen image generated with "/prof",
     // even if the profiler doesn't want to track transitions.
     if (!CORProfilerTrackTransitions())
     {
@@ -1352,7 +1355,7 @@ FCIMPL2(void, StubHelpers::ProfilerEndTransitionCallback, MethodDesc* pRealMD, T
 
     BEGIN_PRESERVE_LAST_ERROR;
 
-    // We must transition to preemptive GC mode before calling out to the profiler, 
+    // We must transition to preemptive GC mode before calling out to the profiler,
     // and the transition requires us to set up a HMF.
     HELPER_METHOD_FRAME_BEGIN_0();
     {
@@ -1364,7 +1367,7 @@ FCIMPL2(void, StubHelpers::ProfilerEndTransitionCallback, MethodDesc* pRealMD, T
             pThread = GET_THREAD();
             fReverseInterop = true;
         }
-        
+
         GCX_PREEMP_THREAD_EXISTS(pThread);
 
         if (fReverseInterop)
@@ -1388,13 +1391,13 @@ FCIMPL1(Object*, StubHelpers::GetHRExceptionObject, HRESULT hr)
     FCALL_CONTRACT;
 
     OBJECTREF oThrowable = NULL;
-    
+
     HELPER_METHOD_FRAME_BEGIN_RET_1(oThrowable);
     {
         // GetExceptionForHR uses equivalant logic as COMPlusThrowHR
         GetExceptionForHR(hr, &oThrowable);
     }
-    HELPER_METHOD_FRAME_END();    
+    HELPER_METHOD_FRAME_END();
 
     return OBJECTREFToObject(oThrowable);
 }
@@ -1409,7 +1412,7 @@ FCIMPL4(Object*, StubHelpers::GetCOMHRExceptionObject, HRESULT hr, MethodDesc *p
 
     // get 'this'
     OBJECTREF oref = ObjectToOBJECTREF(unsafe_pThis);
-    
+
     HELPER_METHOD_FRAME_BEGIN_RET_2(oref, oThrowable);
     {
         IErrorInfo *pErrInfo = NULL;
@@ -1442,7 +1445,7 @@ FCIMPL4(Object*, StubHelpers::GetCOMHRExceptionObject, HRESULT hr, MethodDesc *p
                 IID ItfIID;
                 pItfMT->GetGuid(&ItfIID, TRUE);
                 pErrInfo = GetSupportedErrorInfo(pUnk, ItfIID, !fForWinRT);
-            
+
                 DWORD cbRef = SafeRelease(pUnk);
                 LogInteropRelease(pUnk, cbRef, "IUnk to QI for ISupportsErrorInfo");
             }
@@ -1450,7 +1453,7 @@ FCIMPL4(Object*, StubHelpers::GetCOMHRExceptionObject, HRESULT hr, MethodDesc *p
 
         GetExceptionForHR(hr, pErrInfo, !fForWinRT, &oThrowable, pResErrorInfo, bHasNonCLRLanguageErrorObject);
     }
-    HELPER_METHOD_FRAME_END();    
+    HELPER_METHOD_FRAME_END();
 
     return OBJECTREFToObject(oThrowable);
 }
@@ -1549,7 +1552,7 @@ FCIMPL1(Object*, StubHelpers::AllocateInternal, EnregisteredTypeHandle pRegister
 
     MethodTable* pMT = typeHnd.GetMethodTable();
     objRet = pMT->Allocate();
-    
+
     HELPER_METHOD_FRAME_END();
 
     return OBJECTREFToObject(objRet);
@@ -1719,7 +1722,7 @@ NOINLINE static void ArrayTypeCheckSlow(Object* element, PtrArray* arr)
 
     if (!ObjIsInstanceOf(element, arr->GetArrayElementTypeHandle()))
         COMPlusThrow(kArrayTypeMismatchException);
-    
+
     HELPER_METHOD_FRAME_END();
 
     FC_INNER_EPILOG();
@@ -1731,7 +1734,7 @@ FCIMPL2(void, StubHelpers::ArrayTypeCheck, Object* element, PtrArray* arr)
 
     if (ObjIsInstanceOfCached(element, arr->GetArrayElementTypeHandle()) == TypeHandle::CanCast)
         return;
-    
+
     FC_INNER_RETURN_VOID(ArrayTypeCheckSlow(element, arr));
 }
 FCIMPLEND

--- a/src/vm/syncblk.cpp
+++ b/src/vm/syncblk.cpp
@@ -548,12 +548,12 @@ SyncBlockCache::~SyncBlockCache()
 }
 
 
-// When the GC determines that an object is dead the low bit of the 
-// m_Object field of SyncTableEntry is set, however it is not 
+// When the GC determines that an object is dead the low bit of the
+// m_Object field of SyncTableEntry is set, however it is not
 // cleaned up because we cant do the COM interop cleanup at GC time.
 // It is put on a cleanup list and at a later time (typically during
-// finalization, this list is cleaned up. 
-// 
+// finalization, this list is cleaned up.
+//
 void SyncBlockCache::CleanupSyncBlocks()
 {
     STATIC_CONTRACT_THROWS;
@@ -616,7 +616,7 @@ void SyncBlockCache::CleanupSyncBlocks()
                 FinalizerThread::GetFinalizerThread()->PulseGCMode();
             }
         }
-        
+
 #ifdef FEATURE_COMINTEROP
         // Now clean up the rcw's sorted by context
         if (g_pRCWCleanupList != NULL)
@@ -631,7 +631,7 @@ void SyncBlockCache::CleanupSyncBlocks()
 #ifdef FEATURE_COMINTEROP
         if (param.pRCW)
             param.pRCW->Cleanup();
-#endif        
+#endif
 
         if (param.psb)
             DeleteSyncBlock(param.psb);
@@ -667,7 +667,7 @@ void SyncBlockCache::Start()
     for (int i=0; i<SYNC_TABLE_INITIAL_SIZE+1; i++) {
         SyncTableEntry::GetSyncTableEntry()[i].m_SyncBlock = NULL;
     }
-#endif    
+#endif
 
     SyncTableEntry::GetSyncTableEntry()[0].m_SyncBlock = 0;
     SyncBlockCache::GetSyncBlockCache() = new (&g_SyncBlockCacheInstance) SyncBlockCache;
@@ -834,7 +834,7 @@ void SyncBlockCache::Grow()
     CONTRACTL_END;
 
     STRESS_LOG0(LF_SYNC, LL_INFO10000, "SyncBlockCache::NewSyncBlockSlot growing SyncBlockCache \n");
-        
+
     NewArrayHolder<SyncTableEntry> newSyncTable (NULL);
     NewArrayHolder<DWORD>          newBitMap    (NULL);
     DWORD *                        oldBitMap;
@@ -926,7 +926,7 @@ DWORD SyncBlockCache::NewSyncBlockSlot(Object *obj)
         INJECT_FAULT(COMPlusThrowOM(););
     }
     CONTRACTL_END;
-    _ASSERTE(m_CacheLock.OwnedByCurrentThread()); // GetSyncBlock takes the lock, make sure no one else does.  
+    _ASSERTE(m_CacheLock.OwnedByCurrentThread()); // GetSyncBlock takes the lock, make sure no one else does.
 
     DWORD indexNewEntry;
     if (m_FreeSyncTableList)
@@ -937,7 +937,7 @@ DWORD SyncBlockCache::NewSyncBlockSlot(Object *obj)
     }
     else if ((indexNewEntry = (DWORD)(m_FreeSyncTableIndex)) >= m_SyncTableSize)
     {
-        // This is kept out of line to keep stuff like the C++ EH prolog (needed for holders) off 
+        // This is kept out of line to keep stuff like the C++ EH prolog (needed for holders) off
         // of the common path.
         Grow();
     }
@@ -961,8 +961,8 @@ DWORD SyncBlockCache::NewSyncBlockSlot(Object *obj)
 
     CardTableSetBit (indexNewEntry);
 
-    // In debug builds the m_SyncBlock at indexNewEntry should already be null, since we should 
-    // start out with a null table and always null it out on delete. 
+    // In debug builds the m_SyncBlock at indexNewEntry should already be null, since we should
+    // start out with a null table and always null it out on delete.
     _ASSERTE(SyncTableEntry::GetSyncTableEntry() [indexNewEntry].m_SyncBlock == NULL);
     SyncTableEntry::GetSyncTableEntry() [indexNewEntry].m_SyncBlock = NULL;
     SyncTableEntry::GetSyncTableEntry() [indexNewEntry].m_Object = obj;
@@ -973,7 +973,7 @@ DWORD SyncBlockCache::NewSyncBlockSlot(Object *obj)
 }
 
 
-// free a used sync block, only called from CleanupSyncBlocks.  
+// free a used sync block, only called from CleanupSyncBlocks.
 void SyncBlockCache::DeleteSyncBlock(SyncBlock *psb)
 {
     CONTRACTL
@@ -1106,9 +1106,9 @@ void SyncBlockCache::GCWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintp
    if (GCHeapUtilities::GetGCHeap()->GetCondemnedGeneration() < GCHeapUtilities::GetGCHeap()->GetMaxGeneration())
    {
 #ifdef VERIFY_HEAP
-        //for VSW 294550: we saw stale obeject reference in SyncBlkCache, so we want to make sure the card 
-        //table logic above works correctly so that every ephemeral entry is promoted. 
-        //For verification, we make a copy of the sync table in relocation phase and promote it use the 
+        //for VSW 294550: we saw stale obeject reference in SyncBlkCache, so we want to make sure the card
+        //table logic above works correctly so that every ephemeral entry is promoted.
+        //For verification, we make a copy of the sync table in relocation phase and promote it use the
         //slow approach and compare the result with the original one
         DWORD freeSyncTalbeIndexCopy = m_FreeSyncTableIndex;
         SyncTableEntry * syncTableShadow = NULL;
@@ -1117,7 +1117,7 @@ void SyncBlockCache::GCWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintp
             syncTableShadow = new(nothrow) SyncTableEntry [m_FreeSyncTableIndex];
             if (syncTableShadow)
             {
-                memcpy (syncTableShadow, SyncTableEntry::GetSyncTableEntry(), m_FreeSyncTableIndex * sizeof (SyncTableEntry));                
+                memcpy (syncTableShadow, SyncTableEntry::GetSyncTableEntry(), m_FreeSyncTableIndex * sizeof (SyncTableEntry));
             }
         }
 #endif //VERIFY_HEAP
@@ -1166,10 +1166,10 @@ void SyncBlockCache::GCWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintp
             else
                 break;
         }
-        
+
 #ifdef VERIFY_HEAP
-        //for VSW 294550: we saw stale obeject reference in SyncBlkCache, so we want to make sure the card 
-        //table logic above works correctly so that every ephemeral entry is promoted. To verify, we make a 
+        //for VSW 294550: we saw stale obeject reference in SyncBlkCache, so we want to make sure the card
+        //table logic above works correctly so that every ephemeral entry is promoted. To verify, we make a
         //copy of the sync table and promote it use the slow approach and compare the result with the real one
         if (g_pConfig->GetHeapVerifyLevel()& EEConfig::HEAPVERIFY_SYNCBLK)
         {
@@ -1189,7 +1189,7 @@ void SyncBlockCache::GCWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintp
                                 DebugBreak ();
                         }
                     }
-                } 
+                }
                 delete []syncTableShadow;
                 syncTableShadow = NULL;
             }
@@ -1225,7 +1225,7 @@ void SyncBlockCache::GCWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintp
             for (int nb = 1; nb < (int)m_FreeSyncTableIndex; nb++)
             {
                 Object* o = SyncTableEntry::GetSyncTableEntry()[nb].m_Object;
-                if (((size_t)o & 1) == 0)
+                if (o && ((size_t)o & 1) == 0)
                 {
                     o->Validate();
                 }
@@ -1345,15 +1345,15 @@ void SyncBlockCache::GCDone(BOOL demoting, int max_gen)
     }
     CONTRACTL_END;
 
-    if (demoting && 
-        (GCHeapUtilities::GetGCHeap()->GetCondemnedGeneration() == 
+    if (demoting &&
+        (GCHeapUtilities::GetGCHeap()->GetCondemnedGeneration() ==
          GCHeapUtilities::GetGCHeap()->GetMaxGeneration()))
     {
         //scan the bitmap
         size_t dw = 0;
         while (1)
         {
-            while (dw < BitMapSize (m_SyncTableSize) && 
+            while (dw < BitMapSize (m_SyncTableSize) &&
                    (m_EphemeralBitmap[dw]==(DWORD)~0))
             {
                 dw++;
@@ -1418,7 +1418,7 @@ void SyncBlockCache::VerifySyncTableEntry()
     {
         Object* o = SyncTableEntry::GetSyncTableEntry()[nb].m_Object;
         // if the slot was just allocated, the object may still be null
-        if (o && (((size_t)o & 1) == 0)) 
+        if (o && (((size_t)o & 1) == 0))
         {
             //there is no need to verify next object's header because this is called
             //from verify_heap, which will verify every object anyway
@@ -1431,7 +1431,7 @@ void SyncBlockCache::VerifySyncTableEntry()
             //
             static const DWORD max_iterations = 100;
             DWORD loop = 0;
-            
+
             for (; loop < max_iterations; loop++)
             {
                 // The syncblock index may be updating by another thread.
@@ -1441,7 +1441,7 @@ void SyncBlockCache::VerifySyncTableEntry()
                 }
                 __SwitchToThread(0, CALLER_LIMITS_SPINNING);
             }
-            
+
             DWORD idx = o->GetHeader()->GetHeaderSyncBlockIndex();
             _ASSERTE(idx == nb || ((0 == idx) && (loop == max_iterations)));
             _ASSERTE(!GCHeapUtilities::GetGCHeap()->IsEphemeral(o) || CardSetP(CardOf(nb)));
@@ -1744,7 +1744,7 @@ BOOL ObjHeader::LeaveObjMonitor()
     }
 }
 
-// The only difference between LeaveObjMonitor and LeaveObjMonitorAtException is switch 
+// The only difference between LeaveObjMonitor and LeaveObjMonitorAtException is switch
 // to preemptive mode around __SwitchToThread
 BOOL ObjHeader::LeaveObjMonitorAtException()
 {
@@ -1781,7 +1781,7 @@ BOOL ObjHeader::LeaveObjMonitorAtException()
         case AwareLock::LeaveHelperAction_Contention:
             // Some thread is updating the syncblock value.
             //
-            // We never toggle GC mode while holding the spinlock (BeginNoTriggerGC/EndNoTriggerGC 
+            // We never toggle GC mode while holding the spinlock (BeginNoTriggerGC/EndNoTriggerGC
             // in EnterSpinLock/ReleaseSpinLock ensures it). Thus we do not need to switch to preemptive
             // while waiting on the spinlock.
             //
@@ -1905,11 +1905,11 @@ DEBUG_NOINLINE void ObjHeader::EnterSpinLock()
 #ifdef _DEBUG
 #ifdef BIT64
         // Give 64bit more time because there isn't a remoting fast path now, and we've hit this assert
-        // needlessly in CLRSTRESS. 
+        // needlessly in CLRSTRESS.
         if (i++ > 30000)
-#else            
+#else
         if (i++ > 10000)
-#endif // BIT64            
+#endif // BIT64
             _ASSERTE(!"ObjHeader::EnterLock timed out");
 #endif
         // get the value so that it doesn't get changed under us.
@@ -2081,18 +2081,18 @@ BOOL ObjHeader::Validate (BOOL bVerifySyncBlkIndex)
     }
 
     //Don't know how to verify BIT_SBLK_SPIN_LOCK (0x10000000)
-    
+
     //BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX (0x08000000)
     if (bits & BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX)
     {
-        //if BIT_SBLK_IS_HASHCODE (0x04000000) is not set, 
+        //if BIT_SBLK_IS_HASHCODE (0x04000000) is not set,
         //rest of the DWORD is SyncBlk Index
         if (!(bits & BIT_SBLK_IS_HASHCODE))
         {
             if (bVerifySyncBlkIndex  && GCHeapUtilities::GetGCHeap()->RuntimeStructuresValid ())
             {
                 DWORD sbIndex = bits & MASK_SYNCBLOCKINDEX;
-                ASSERT_AND_CHECK(SyncTableEntry::GetSyncTableEntry()[sbIndex].m_Object == obj);             
+                ASSERT_AND_CHECK(SyncTableEntry::GetSyncTableEntry()[sbIndex].m_Object == obj);
             }
         }
         else
@@ -2102,15 +2102,15 @@ BOOL ObjHeader::Validate (BOOL bVerifySyncBlkIndex)
     }
     else
     {
-        //if BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX is clear, rest of DWORD is thin lock thread ID, 
+        //if BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX is clear, rest of DWORD is thin lock thread ID,
         //thin lock recursion level and appdomain index
         DWORD lockThreadId = bits & SBLK_MASK_LOCK_THREADID;
         DWORD recursionLevel = (bits & SBLK_MASK_LOCK_RECLEVEL) >> SBLK_RECLEVEL_SHIFT;
         //if thread ID is 0, recursionLeve got to be zero
         //but thread ID doesn't have to be valid because the lock could be orphanend
-        ASSERT_AND_CHECK (lockThreadId != 0 || recursionLevel == 0 );     
+        ASSERT_AND_CHECK (lockThreadId != 0 || recursionLevel == 0 );
     }
-    
+
     return TRUE;
 }
 
@@ -2155,7 +2155,7 @@ SyncBlock *ObjHeader::GetSyncBlock()
 
     if (syncBlock)
     {
-#ifdef _DEBUG 
+#ifdef _DEBUG
         // Has our backpointer been correctly updated through every GC?
         PTR_SyncTableEntry pEntries(SyncTableEntry::GetSyncTableEntry());
         _ASSERTE(pEntries[GetHeaderSyncBlockIndex()].m_Object == GetBaseObject());
@@ -2941,8 +2941,8 @@ bool SyncBlock::SetInteropInfo(InteropSyncBlockInfo* pInteropInfo)
     // We could be agile, but not have noticed yet.  We can't assert here
     //  that we live in any given domain, nor is this an appropriate place
     //  to re-parent the syncblock.
-/*    _ASSERTE (m_dwAppDomainIndex.m_dwIndex == 0 || 
-              m_dwAppDomainIndex == SystemDomain::System()->DefaultDomain()->GetIndex() || 
+/*    _ASSERTE (m_dwAppDomainIndex.m_dwIndex == 0 ||
+              m_dwAppDomainIndex == SystemDomain::System()->DefaultDomain()->GetIndex() ||
               m_dwAppDomainIndex == GetAppDomain()->GetIndex());
     m_dwAppDomainIndex = GetAppDomain()->GetIndex();
 */
@@ -2954,7 +2954,7 @@ bool SyncBlock::SetInteropInfo(InteropSyncBlockInfo* pInteropInfo)
 #ifdef EnC_SUPPORTED
 // Store information about fields added to this object by EnC
 // This must be called from a thread in the AppDomain of this object instance
-void SyncBlock::SetEnCInfo(EnCSyncBlockInfo *pEnCInfo) 
+void SyncBlock::SetEnCInfo(EnCSyncBlockInfo *pEnCInfo)
 {
     WRAPPER_NO_CONTRACT;
 

--- a/src/vm/typehash.cpp
+++ b/src/vm/typehash.cpp
@@ -103,9 +103,9 @@ void EETypeHashTable::Iterator::Init()
 
 EETypeHashTable::Iterator::Iterator()
 {
-    WRAPPER_NO_CONTRACT; 
+    WRAPPER_NO_CONTRACT;
     m_pTable = NULL;
-    Init(); 
+    Init();
 }
 
 EETypeHashTable::Iterator::Iterator(EETypeHashTable * pTable)
@@ -162,13 +162,13 @@ static DWORD HashPossiblyInstantiatedType(DWORD level, mdTypeDef token, Instanti
     CONTRACTL_END
 
     INT_PTR dwHash = 5381;
-    
+
     dwHash = ((dwHash << 5) + dwHash) ^ token;
     if (!inst.IsEmpty())
     {
         dwHash = ((dwHash << 5) + dwHash) ^ inst.GetNumArgs();
 
-        // Hash two levels of the hiearchy. A simple nesting of generics instantiations is 
+        // Hash two levels of the hiearchy. A simple nesting of generics instantiations is
         // pretty common in generic collections, e.g.: ICollection<KeyValuePair<TKey, TValue>>
         if (level < 2)
         {
@@ -189,7 +189,7 @@ static DWORD HashFnPtrType(DWORD level, BYTE callConv, DWORD numArgs, TypeHandle
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
     INT_PTR dwHash = 5381;
-    
+
     dwHash = ((dwHash << 5) + dwHash) ^ ELEMENT_TYPE_FNPTR;
     dwHash = ((dwHash << 5) + dwHash) ^ callConv;
     dwHash = ((dwHash << 5) + dwHash) ^ numArgs;
@@ -209,7 +209,7 @@ static DWORD HashParamType(DWORD level, CorElementType kind, TypeHandle typePara
 {
     WRAPPER_NO_CONTRACT;
     INT_PTR dwHash = 5381;
-    
+
     dwHash = ((dwHash << 5) + dwHash) ^ kind;
     dwHash = ((dwHash << 5) + dwHash) ^ HashTypeHandle(level, typeParam);
 
@@ -231,7 +231,7 @@ static DWORD HashTypeHandle(DWORD level, TypeHandle t)
     CONTRACTL_END;
 
     DWORD retVal = 0;
-    
+
     if (t.HasTypeParam())
     {
         retVal =  HashParamType(level, t.GetInternalCorElementType(), t.GetTypeParam());
@@ -251,7 +251,7 @@ static DWORD HashTypeHandle(DWORD level, TypeHandle t)
     }
     else
         retVal = HashPossiblyInstantiatedType(level, t.GetCl(), Instantiation());
-    
+
     return retVal;
 }
 
@@ -282,13 +282,13 @@ static DWORD HashTypeKey(TypeKey* pKey)
     }
 }
 
-// Look up a value in the hash table 
+// Look up a value in the hash table
 //
 // The logic is subtle: type handles in the hash table may not be
 // restored, but we need to compare components of the types (rank and
 // element type for arrays, generic type and instantiation for
 // instantiated types) against pKey
-// 
+//
 // We avoid restoring types during search by cracking the signature
 // encoding used by the zapper for out-of-module types e.g. in the
 // instantiation of an instantiated type.
@@ -326,7 +326,7 @@ EETypeHashEntry_t *EETypeHashTable::FindItem(TypeKey* pKey)
             pSearch = BaseFindNextEntryByHash(&sContext);
         }
     }
-    else if (kind == ELEMENT_TYPE_FNPTR) 
+    else if (kind == ELEMENT_TYPE_FNPTR)
     {
         BYTE callConv = pKey->GetCallConv();
         DWORD numArgs = pKey->GetNumArgs();
@@ -362,7 +362,7 @@ EETypeHashEntry_t *EETypeHashTable::FindItem(TypeKey* pKey)
                 // accessed when unrestored.  Also they are accessed in that
                 // manner at startup when we're loading the global types
                 // (i.e. System.Object).
-                
+
                 if (!pSearch->GetTypeHandle().IsTypeDesc())
                 {
                     // Not a match
@@ -392,10 +392,10 @@ EETypeHashEntry_t *EETypeHashTable::FindItem(TypeKey* pKey)
                 }
                 else
                 {
-                    ArrayTypeDesc *pATD = pSearch->GetTypeHandle().AsArray();   
+                    ArrayTypeDesc *pATD = pSearch->GetTypeHandle().AsArray();
 #ifdef FEATURE_PREJIT
                     // This ensures that GetAssemblyIfLoaded operations that may be triggered by signature walks will succeed if at all possible.
-                    ClrFlsThreadTypeSwitch genericInstantionCompareHolder(ThreadType_GenericInstantiationCompare); 
+                    ClrFlsThreadTypeSwitch genericInstantionCompareHolder(ThreadType_GenericInstantiationCompare);
 
                     TADDR fixup = pATD->GetTemplateMethodTableMaybeTagged();
                     if (!CORCOMPILE_IS_POINTER_TAGGED(fixup))
@@ -423,7 +423,7 @@ EETypeHashEntry_t *EETypeHashTable::FindItem(TypeKey* pKey)
                         ULONG data;
                         if (FAILED(sp.GetData(&data)))
                             break; // return NULL;
-                        
+
                         if (data != pKey->GetRank())
                             continue;
                     }
@@ -461,7 +461,7 @@ BOOL EETypeHashTable::CompareInstantiatedType(TypeHandle t, Module *pModule, mdT
 
     if (t.IsTypeDesc())
         return FALSE;
-    
+
     // Even the EEClass pointer might be encoded
     MethodTable * pMT = t.AsMethodTable();
 
@@ -470,11 +470,11 @@ BOOL EETypeHashTable::CompareInstantiatedType(TypeHandle t, Module *pModule, mdT
 
 #ifdef FEATURE_PREJIT
     // This ensures that GetAssemblyIfLoaded operations that may be triggered by signature walks will succeed if at all possible.
-    ClrFlsThreadTypeSwitch genericInstantionCompareHolder(ThreadType_GenericInstantiationCompare); 
+    ClrFlsThreadTypeSwitch genericInstantionCompareHolder(ThreadType_GenericInstantiationCompare);
 
     TADDR fixup = pMT->GetCanonicalMethodTableFixup();
-        
-    // The EEClass pointer is actually an encoding. 
+
+    // The EEClass pointer is actually an encoding.
     if (CORCOMPILE_IS_POINTER_TAGGED(fixup))
     {
         Module *pDefiningModule;
@@ -498,7 +498,7 @@ BOOL EETypeHashTable::CompareInstantiatedType(TypeHandle t, Module *pModule, mdT
     }
 
     // The EEClass pointer is a real pointer
-    else 
+    else
 #endif //FEATURE_PREJIT
     {
         // First check that the typedef tokens match
@@ -510,7 +510,7 @@ BOOL EETypeHashTable::CompareInstantiatedType(TypeHandle t, Module *pModule, mdT
         // is not loaded.
         Module *pGenericModuleIfLoaded = pMT->GetModuleIfLoaded();
 
-        // Now check that the modules match 
+        // Now check that the modules match
         if (!pGenericModuleIfLoaded ||
             dac_cast<TADDR>(pGenericModuleIfLoaded) !=
             dac_cast<TADDR>(pModule))
@@ -524,7 +524,7 @@ BOOL EETypeHashTable::CompareInstantiatedType(TypeHandle t, Module *pModule, mdT
     for (DWORD i = 0; i < inst.GetNumArgs(); i++)
     {
 #ifdef FEATURE_PREJIT
-        // Fetch the type handle as TADDR. It may be may be encoded fixup - TypeHandle debug-only validation 
+        // Fetch the type handle as TADDR. It may be may be encoded fixup - TypeHandle debug-only validation
         // asserts on encoded fixups.
         DACCOP_IGNORE(CastOfMarshalledType, "Dual mode DAC problem, but since the size is the same, the cast is safe");
         TADDR candidateArg = ((FixupPointer<TADDR> *)candidateInst.GetRawArgs())[i].GetValue();
@@ -537,7 +537,7 @@ BOOL EETypeHashTable::CompareInstantiatedType(TypeHandle t, Module *pModule, mdT
             return FALSE;
         }
     }
-    
+
     return TRUE;
 }
 
@@ -557,11 +557,11 @@ BOOL EETypeHashTable::CompareFnPtrType(TypeHandle t, BYTE callConv, DWORD numArg
 
     if (!t.IsFnPtrType())
         return FALSE;
-    
+
 #ifndef DACCESS_COMPILE
 #ifdef FEATURE_PREJIT
     // This ensures that GetAssemblyIfLoaded operations that may be triggered by signature walks will succeed if at all possible.
-    ClrFlsThreadTypeSwitch genericInstantionCompareHolder(ThreadType_GenericInstantiationCompare); 
+    ClrFlsThreadTypeSwitch genericInstantionCompareHolder(ThreadType_GenericInstantiationCompare);
 #endif
 
     FnPtrTypeDesc* pTD = t.AsFnPtrType();
@@ -583,7 +583,7 @@ BOOL EETypeHashTable::CompareFnPtrType(TypeHandle t, BYTE callConv, DWORD numArg
             return FALSE;
         }
     }
-    
+
     return TRUE;
 
 #else
@@ -684,22 +684,22 @@ void EETypeHashTable::Save(DataImage *image, Module *module, CorProfileData *pro
     // The base class will call us back for every entry to see if it's considered hot. To determine this we
     // have to walk through the profiling data. It's very inefficient for us to do this every time. Instead
     // we'll walk the data once just now and mark each hot entry as we find it.
-    CORBBTPROF_TOKEN_INFO * pTypeProfilingData = profileData->GetTokenFlagsData(TypeProfilingData);
-    DWORD                   cTypeProfilingData = profileData->GetTokenFlagsCount(TypeProfilingData);
+    CORBBTPROF_TOKEN_INFO * pTypeProfilingData = profileData ? profileData->GetTokenFlagsData(TypeProfilingData) : NULL;
+    DWORD                   cTypeProfilingData = profileData ? profileData->GetTokenFlagsCount(TypeProfilingData) : NULL;
 
     for (unsigned int i = 0; i < cTypeProfilingData; i++)
     {
         CORBBTPROF_TOKEN_INFO *entry = &pTypeProfilingData[i];
         mdToken token = entry->token;
         DWORD   flags = entry->flags;
-                
+
         if (TypeFromToken(token) != ibcTypeSpec)
             continue;
 
         if ((flags & (1 << ReadTypeHashTable)) == 0)
             continue;
 
-        CORBBTPROF_BLOB_ENTRY *pBlobEntry = profileData->GetBlobStream();
+        CORBBTPROF_BLOB_ENTRY *pBlobEntry = profileData ? profileData->GetBlobStream() : NULL;
         if (pBlobEntry)
         {
             while (pBlobEntry->TypeIsValid())
@@ -707,9 +707,9 @@ void EETypeHashTable::Save(DataImage *image, Module *module, CorProfileData *pro
                 if (TypeFromToken(pBlobEntry->token) == ibcTypeSpec)
                 {
                     _ASSERTE(pBlobEntry->type == ParamTypeSpec);
-                            
+
                     CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry = (CORBBTPROF_BLOB_PARAM_SIG_ENTRY *) pBlobEntry;
-                            
+
                     if (pBlobEntry->token == token)
                     {
                         if (flags & (1<<ReadTypeHashTable))
@@ -819,7 +819,7 @@ void
 EETypeHashTable::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 {
     SUPPORTS_DAC;
-    
+
     BaseEnumMemoryRegions(flags);
 }
 

--- a/src/vm/typeparse.cpp
+++ b/src/vm/typeparse.cpp
@@ -1510,7 +1510,7 @@ DomainAssembly * LoadDomainAssembly(
     DomainAssembly *pDomainAssembly = NULL;
 
     StackScratchBuffer buffer;
-    LPCUTF8 szAssemblySpec = psszAssemblySpec->GetUTF8(buffer);
+    LPCUTF8 szAssemblySpec = psszAssemblySpec ? psszAssemblySpec->GetUTF8(buffer) : NULL;
     IfFailThrow(spec.Init(szAssemblySpec));
 
     if (spec.IsContentType_WindowsRuntime())

--- a/src/zap/zapwriter.h
+++ b/src/zap/zapwriter.h
@@ -66,7 +66,14 @@ public:
     ZapNode()
     {
         // All ZapNodes are expected to be allocate from ZapWriter::GetHeap() that returns zero filled memory
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
         _ASSERTE(m_RVA == 0);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
     }
 
     // This constructor should be used to allocate temporary ZapNodes on the stack only
@@ -444,7 +451,7 @@ public:
         ZapVirtualSection * pSection = new (GetHeap()) ZapVirtualSection(dwAlignment);
         if (pInsertAfter != NULL)
         {
-            // pInsertAfter is workaround to get decent layout with the current scheme of virtual sections. It should not be necessary 
+            // pInsertAfter is workaround to get decent layout with the current scheme of virtual sections. It should not be necessary
             // once we have better layout algorithms in place.
             for (COUNT_T iSection = 0; iSection < pPhysicalSection->m_Sections.GetCount(); iSection++)
             {
@@ -452,7 +459,7 @@ public:
                 {
                     pPhysicalSection->m_Sections.Insert(pPhysicalSection->m_Sections+(iSection+1));
                     pPhysicalSection->m_Sections[iSection+1] = pSection;
-                    return pSection;                    
+                    return pSection;
                 }
             }
             _ASSERTE(false);


### PR DESCRIPTION
Remove gcc nonnull-compare suppression and impossible conditions.

> error: nonnull argument 'this' compared to NULL
> [-Werror=nonnull-compare]