### PR TITLE
Remove unsigned overloads of LeadingSignCount

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.PlatformNotSupported.cs
@@ -557,27 +557,11 @@ namespace System.Runtime.Intrinsics.Arm
         public static Vector64<sbyte> LeadingSignCount(Vector64<sbyte> value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        /// uint8x8_t vcls_u8 (uint8x8_t a)
-        ///   A32: VCLS Dd, Dm
-        ///   A64: CLS Vd, Vn
-        /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-        /// </summary>
-        public static Vector64<byte> LeadingSignCount(Vector64<byte> value) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
         /// int16x4_t vcls_s16 (int16x4_t a)
         ///   A32: VCLS Dd, Dm
         ///   A64: CLS Vd, Vn
         /// </summary>
         public static Vector64<short> LeadingSignCount(Vector64<short> value) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
-        /// uint16x4_t vcls_u16 (uint16x4_t a)
-        ///   A32: VCLS Dd, Dm
-        ///   A64: CLS Vd, Vn
-        /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-        /// </summary>
-        public static Vector64<ushort> LeadingSignCount(Vector64<ushort> value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int32x2_t vcls_s32 (int32x2_t a)
@@ -587,27 +571,11 @@ namespace System.Runtime.Intrinsics.Arm
         public static Vector64<int> LeadingSignCount(Vector64<int> value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        /// uint32x2_t vcls_u32 (uint32x2_t a)
-        ///   A32: VCLS Dd, Dm
-        ///   A64: CLS Vd, Vn
-        /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-        /// </summary>
-        public static Vector64<uint> LeadingSignCount(Vector64<uint> value) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
         /// int8x16_t vclsq_s8 (int8x16_t a)
         ///   A32: VCLS Qd, Qm
         ///   A64: CLS Vd, Vn
         /// </summary>
         public static Vector128<sbyte> LeadingSignCount(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
-        /// uint8x16_t vclsq_u8 (uint8x16_t a)
-        ///   A32: VCLS Qd, Qm
-        ///   A64: CLS Vd, Vn
-        /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-        /// </summary>
-        public static Vector128<byte> LeadingSignCount(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int16x8_t vclsq_s16 (int16x8_t a)
@@ -617,27 +585,11 @@ namespace System.Runtime.Intrinsics.Arm
         public static Vector128<short> LeadingSignCount(Vector128<short> value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        /// uint16x8_t vclsq_u16 (uint16x8_t a)
-        ///   A32: VCLS Qd, Qm
-        ///   A64: CLS Vd, Vn
-        /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-        /// </summary>
-        public static Vector128<ushort> LeadingSignCount(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
         /// int32x4_t vclsq_s32 (int32x4_t a)
         ///   A32: VCLS Qd, Qm
         ///   A64: CLS Vd, Vn
         /// </summary>
         public static Vector128<int> LeadingSignCount(Vector128<int> value) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
-        /// uint32x4_t vclsq_u32 (uint32x4_t a)
-        ///   A32: VCLS Qd, Qm
-        ///   A64: CLS Vd, Vn
-        /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-        /// </summary>
-        public static Vector128<uint> LeadingSignCount(Vector128<uint> value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int8x8_t vclz_s8 (int8x8_t a)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.cs
@@ -559,27 +559,11 @@ namespace System.Runtime.Intrinsics.Arm
         public static Vector64<sbyte> LeadingSignCount(Vector64<sbyte> value) => LeadingSignCount(value);
 
         /// <summary>
-        /// uint8x8_t vcls_u8 (uint8x8_t a)
-        ///   A32: VCLS Dd, Dm
-        ///   A64: CLS Vd, Vn
-        /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-        /// </summary>
-        public static Vector64<byte> LeadingSignCount(Vector64<byte> value) => LeadingSignCount(value);
-
-        /// <summary>
         /// int16x4_t vcls_s16 (int16x4_t a)
         ///   A32: VCLS Dd, Dm
         ///   A64: CLS Vd, Vn
         /// </summary>
         public static Vector64<short> LeadingSignCount(Vector64<short> value) => LeadingSignCount(value);
-
-        /// <summary>
-        /// uint16x4_t vcls_u16 (uint16x4_t a)
-        ///   A32: VCLS Dd, Dm
-        ///   A64: CLS Vd, Vn
-        /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-        /// </summary>
-        public static Vector64<ushort> LeadingSignCount(Vector64<ushort> value) => LeadingSignCount(value);
 
         /// <summary>
         /// int32x2_t vcls_s32 (int32x2_t a)
@@ -589,27 +573,11 @@ namespace System.Runtime.Intrinsics.Arm
         public static Vector64<int> LeadingSignCount(Vector64<int> value) => LeadingSignCount(value);
 
         /// <summary>
-        /// uint32x2_t vcls_u32 (uint32x2_t a)
-        ///   A32: VCLS Dd, Dm
-        ///   A64: CLS Vd, Vn
-        /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-        /// </summary>
-        public static Vector64<uint> LeadingSignCount(Vector64<uint> value) => LeadingSignCount(value);
-
-        /// <summary>
         /// int8x16_t vclsq_s8 (int8x16_t a)
         ///   A32: VCLS Qd, Qm
         ///   A64: CLS Vd, Vn
         /// </summary>
         public static Vector128<sbyte> LeadingSignCount(Vector128<sbyte> value) => LeadingSignCount(value);
-
-        /// <summary>
-        /// uint8x16_t vclsq_u8 (uint8x16_t a)
-        ///   A32: VCLS Qd, Qm
-        ///   A64: CLS Vd, Vn
-        /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-        /// </summary>
-        public static Vector128<byte> LeadingSignCount(Vector128<byte> value) => LeadingSignCount(value);
 
         /// <summary>
         /// int16x8_t vclsq_s16 (int16x8_t a)
@@ -619,27 +587,11 @@ namespace System.Runtime.Intrinsics.Arm
         public static Vector128<short> LeadingSignCount(Vector128<short> value) => LeadingSignCount(value);
 
         /// <summary>
-        /// uint16x8_t vclsq_u16 (uint16x8_t a)
-        ///   A32: VCLS Qd, Qm
-        ///   A64: CLS Vd, Vn
-        /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-        /// </summary>
-        public static Vector128<ushort> LeadingSignCount(Vector128<ushort> value) => LeadingSignCount(value);
-
-        /// <summary>
         /// int32x4_t vclsq_s32 (int32x4_t a)
         ///   A32: VCLS Qd, Qm
         ///   A64: CLS Vd, Vn
         /// </summary>
         public static Vector128<int> LeadingSignCount(Vector128<int> value) => LeadingSignCount(value);
-
-        /// <summary>
-        /// uint32x4_t vclsq_u32 (uint32x4_t a)
-        ///   A32: VCLS Qd, Qm
-        ///   A64: CLS Vd, Vn
-        /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-        /// </summary>
-        public static Vector128<uint> LeadingSignCount(Vector128<uint> value) => LeadingSignCount(value);
 
         /// <summary>
         /// int8x8_t vclz_s8 (int8x8_t a)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/ArmBase.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/ArmBase.PlatformNotSupported.cs
@@ -34,18 +34,6 @@ namespace System.Runtime.Intrinsics.Arm
             public static int LeadingSignCount(long value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
-            ///   A64: CLS Wd, Wn
-            /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-            /// </summary>
-            public static int LeadingSignCount(uint value) { throw new PlatformNotSupportedException(); }
-
-            /// <summary>
-            ///   A64: CLS Xd, Xn
-            /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-            /// </summary>
-            public static int LeadingSignCount(ulong value) { throw new PlatformNotSupportedException(); }
-
-            /// <summary>
             ///   A64: CLZ Xd, Xn
             /// </summary>
             public static int LeadingZeroCount(long value) { throw new PlatformNotSupportedException(); }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/ArmBase.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/ArmBase.cs
@@ -35,18 +35,6 @@ namespace System.Runtime.Intrinsics.Arm
             public static int LeadingSignCount(long value) => LeadingSignCount(value);
 
             /// <summary>
-            ///   A64: CLS Wd, Wn
-            /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-            /// </summary>
-            public static int LeadingSignCount(uint value) => LeadingSignCount(value);
-
-            /// <summary>
-            ///   A64: CLS Xd, Xn
-            /// The above native signature does not exist. We provide this additional overload for consistency with the other scalar APIs.
-            /// </summary>
-            public static int LeadingSignCount(ulong value) => LeadingSignCount(value);
-
-            /// <summary>
             ///   A64: CLZ Xd, Xn
             /// </summary>
             public static int LeadingZeroCount(long value) => LeadingZeroCount(value);


### PR DESCRIPTION
In API Review this morning it was decided to remove unsigned overloads of `LeadingSignCount`