### PR TITLE
Don't needlessly refresh proc count

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Environment.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.cs
@@ -11,6 +11,16 @@ namespace System
 {
     public static partial class Environment
     {
+        public static int ProcessorCount { get; } = GetProcessorCount();
+
+        /// <summary>
+        /// Gets whether the current machine has only a single processor.
+        /// </summary>
+        internal static bool IsSingleProcessor => ProcessorCount == 1;
+
+        // Unconditionally return false since .NET Core does not support object finalization during shutdown.
+        public static bool HasShutdownStarted => false;
+
         public static string? GetEnvironmentVariable(string variable)
         {
             if (variable == null)

--- a/src/System.Private.CoreLib/shared/System/Threading/CancellationTokenSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/CancellationTokenSource.cs
@@ -726,7 +726,7 @@ namespace System.Threading
         /// <returns>A power of 2 representing the number of partitions to use.</returns>
         private static int GetPartitionCount()
         {
-            int procs = PlatformHelper.ProcessorCount;
+            int procs = Environment.ProcessorCount;
             int count =
                 procs > 8 ? 16 : // capped at 16 to limit memory usage on larger machines
                 procs > 4 ? 8 :

--- a/src/System.Private.CoreLib/shared/System/Threading/LowLevelLifoSemaphore.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/LowLevelLifoSemaphore.cs
@@ -88,7 +88,7 @@ namespace System.Threading
                 counts = countsBeforeUpdate;
             }
 
-            int processorCount = PlatformHelper.ProcessorCount;
+            int processorCount = Environment.ProcessorCount;
             int spinIndex = processorCount > 1 ? 0 : SpinSleep0Threshold;
             while (spinIndex < _spinCount)
             {

--- a/src/System.Private.CoreLib/shared/System/Threading/ManualResetEventSlim.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ManualResetEventSlim.cs
@@ -202,7 +202,7 @@ namespace System.Threading
             Debug.Assert(DEFAULT_SPIN_SP >= 0, "Internal error - DEFAULT_SPIN_SP is outside the legal range.");
             Debug.Assert(DEFAULT_SPIN_SP <= SpinCountState_MaxValue, "Internal error - DEFAULT_SPIN_SP is outside the legal range.");
 
-            SpinCount = PlatformHelper.IsSingleProcessor ? DEFAULT_SPIN_SP : spinCount;
+            SpinCount = Environment.IsSingleProcessor ? DEFAULT_SPIN_SP : spinCount;
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Threading/PortableThreadPool.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/PortableThreadPool.cs
@@ -68,7 +68,7 @@ namespace System.Threading
 
         private PortableThreadPool()
         {
-            _minThreads = s_forcedMinWorkerThreads > 0 ? s_forcedMinWorkerThreads : (short)ThreadPoolGlobals.processorCount;
+            _minThreads = s_forcedMinWorkerThreads > 0 ? s_forcedMinWorkerThreads : (short)Environment.ProcessorCount;
             if (_minThreads > MaxPossibleThreadCount)
             {
                 _minThreads = MaxPossibleThreadCount;

--- a/src/System.Private.CoreLib/shared/System/Threading/ReaderWriterLockSlim.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ReaderWriterLockSlim.cs
@@ -53,8 +53,6 @@ namespace System.Threading
     /// </summary>
     public class ReaderWriterLockSlim : IDisposable
     {
-        private static readonly int ProcessorCount = Environment.ProcessorCount;
-
         // Specifying if the lock can be reacquired recursively.
         private readonly bool _fIsReentrant;
 
@@ -1233,7 +1231,7 @@ namespace System.Threading
             const int LockSpinCycles = 20;
 
             // Exponential back-off
-            if ((spinCount < 5) && (ProcessorCount > 1))
+            if ((spinCount < 5) && (Environment.ProcessorCount > 1))
             {
                 Thread.SpinWait(LockSpinCycles * spinCount);
             }
@@ -1563,7 +1561,7 @@ namespace System.Threading
                     Interlocked.Add(ref _enterDeprioritizationState, deprioritizationStateChange);
                 }
 
-                int processorCount = ProcessorCount;
+                int processorCount = Environment.ProcessorCount;
                 for (int spinIndex = 0; ; spinIndex++)
                 {
                     if (spinIndex < LockSpinCount && processorCount > 1)

--- a/src/System.Private.CoreLib/shared/System/Threading/SpinLock.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SpinLock.cs
@@ -349,7 +349,7 @@ namespace System.Threading
 
             // *** Step 2, Spinning and Yielding
             var spinner = new SpinWait();
-            if (turn > PlatformHelper.ProcessorCount)
+            if (turn > Environment.ProcessorCount)
             {
                 spinner.Count = SpinWait.YieldThreshold;
             }

--- a/src/System.Private.CoreLib/shared/System/Threading/SpinWait.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SpinWait.cs
@@ -86,7 +86,7 @@ namespace System.Threading
         /// depends on the likelihood of the spin being successful and how long the wait would be but those are not accounted
         /// for here.
         /// </remarks>
-        internal static readonly int SpinCountforSpinBeforeWait = PlatformHelper.IsSingleProcessor ? 1 : 35;
+        internal static readonly int SpinCountforSpinBeforeWait = Environment.IsSingleProcessor ? 1 : 35;
 
         // The number of times we've spun already.
         private int _count;
@@ -114,7 +114,7 @@ namespace System.Threading
         /// On a single-CPU machine, <see cref="SpinOnce()"/> always yields the processor. On machines with
         /// multiple CPUs, <see cref="SpinOnce()"/> may yield after an unspecified number of calls.
         /// </remarks>
-        public bool NextSpinWillYield => _count >= YieldThreshold || PlatformHelper.IsSingleProcessor;
+        public bool NextSpinWillYield => _count >= YieldThreshold || Environment.IsSingleProcessor;
 
         /// <summary>
         /// Performs a single spin.
@@ -175,7 +175,7 @@ namespace System.Threading
                     _count >= YieldThreshold &&
                     ((_count >= sleep1Threshold && sleep1Threshold >= 0) || (_count - YieldThreshold) % 2 == 0)
                 ) ||
-                PlatformHelper.IsSingleProcessor)
+                Environment.IsSingleProcessor)
             {
                 //
                 // We must yield.
@@ -345,43 +345,5 @@ namespace System.Threading
             return true;
         }
         #endregion
-    }
-
-    /// <summary>
-    /// A helper class to get the number of processors, it updates the numbers of processors every sampling interval.
-    /// </summary>
-    internal static class PlatformHelper
-    {
-        private const int PROCESSOR_COUNT_REFRESH_INTERVAL_MS = 30000; // How often to refresh the count, in milliseconds.
-        private static volatile int s_processorCount; // The last count seen.
-        private static volatile int s_lastProcessorCountRefreshTicks; // The last time we refreshed.
-
-        /// <summary>
-        /// Gets the number of available processors
-        /// </summary>
-        internal static int ProcessorCount
-        {
-            get
-            {
-                int now = Environment.TickCount;
-                int procCount = s_processorCount;
-                if (procCount == 0 || (now - s_lastProcessorCountRefreshTicks) >= PROCESSOR_COUNT_REFRESH_INTERVAL_MS)
-                {
-                    s_processorCount = procCount = Environment.ProcessorCount;
-                    s_lastProcessorCountRefreshTicks = now;
-                }
-
-                Debug.Assert(procCount > 0,
-                    "Processor count should be greater than 0.");
-
-                return procCount;
-            }
-        }
-
-        /// <summary>
-        /// Gets whether the current machine has only a single processor.
-        /// </summary>
-        /// <remarks>This typically does not change on a machine, so it's checked only once.</remarks>
-        internal static readonly bool IsSingleProcessor = ProcessorCount == 1;
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ThreadPool.cs
@@ -25,8 +25,6 @@ namespace System.Threading
 {
     internal static class ThreadPoolGlobals
     {
-        public static readonly int processorCount = Environment.ProcessorCount;
-
         public static volatile bool threadPoolInitialized;
         public static bool enableWorkerTracking;
 
@@ -436,7 +434,7 @@ namespace System.Threading
             // by the VM by the time we reach this point.
             //
             int count = numOutstandingThreadRequests;
-            while (count < ThreadPoolGlobals.processorCount)
+            while (count < Environment.ProcessorCount)
             {
                 int prev = Interlocked.CompareExchange(ref numOutstandingThreadRequests, count + 1, count);
                 if (prev == count)

--- a/src/System.Private.CoreLib/src/System/Environment.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.CoreCLR.cs
@@ -80,11 +80,6 @@ namespace System
                 GetCommandLineArgsNative();
         }
 
-        // Unconditionally return false since .NET Core does not support object finalization during shutdown.
-        public static bool HasShutdownStarted => false;
-
-        public static int ProcessorCount => GetProcessorCount();
-
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         private static extern int GetProcessorCount();
 


### PR DESCRIPTION
Edit: Ah... my mistake, it isn't cached in the VM layer. How important is detecting changing proc count changes every 30 secs? (as used by `SpinWait`, `SpinLock` and `CancellationTokenSource`)

e.g. `IsSingleProcessor` is only ever set once and never refreshed

~Its cached in the vm layer after first access so never changes; so it can be a `static readonly`.~

~I looked at changing `Enviorment.ProcessorCount` to be `static readonly` backed and then changing all the individual `static readonly` procCount caches to just call it directly.~

~However, that's a bit more complicated as there are Jit tests that rely on it being non-inlinable due to the p/invoke and it would cause complications for the shared source as Mono's p/invoke its the get property not the method that the get property then calls; so loosing the caches would likely cause regressions there.~

/cc @jkotas @stephentoub 