### PR TITLE
[release/3.1] Fix minidumps not loading in VS issue

### DIFF
--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -1238,12 +1238,6 @@ bool DacDbiInterfaceImpl::GetMetaDataFileInfoFromPEFile(VMPTR_PEFile vmPEFile,
                                                         bool  &isNGEN,
                                                         IStringHolder* pStrFilename)
 {
-#if !defined(FEATURE_PREJIT)
-
-    return false;
-
-#else // defined(FEATURE_PREJIT)
-
     DD_ENTER_MAY_THROW;
 
     DWORD dwDataSize;
@@ -1266,7 +1260,6 @@ bool DacDbiInterfaceImpl::GetMetaDataFileInfoFromPEFile(VMPTR_PEFile vmPEFile,
 
     pStrFilename->AssignCopy(wszFilePath);
     return ret;
-#endif // !defined(FEATURE_PREJIT)
 }
 
 

--- a/src/debug/daccess/request_svr.cpp
+++ b/src/debug/daccess/request_svr.cpp
@@ -227,7 +227,9 @@ ClrDataAccess::EnumSvrGlobalMemoryRegions(CLRDataEnumMemoryFlags flags)
         size_t gen_table_size = g_gcDacGlobals->generation_size * (*g_gcDacGlobals->max_gen + 2);
         DacEnumMemoryRegion(dac_cast<TADDR>(pHeap), sizeof(dac_gc_heap));
         DacEnumMemoryRegion(dac_cast<TADDR>(pHeap->finalize_queue), sizeof(dac_finalize_queue));
-        DacEnumMemoryRegion(dac_cast<TADDR>(pHeap->generation_table), gen_table_size);
+
+        TADDR taddrTable = dac_cast<TADDR>(pHeap) + offsetof(dac_gc_heap, generation_table);
+        DacEnumMemoryRegion(taddrTable, gen_table_size);
 
         // enumerating the generations from max (which is normally gen2) to max+1 gives you
         // the segment list for all the normal segements plus the large heap segment (max+1)

--- a/src/vm/typedesc.cpp
+++ b/src/vm/typedesc.cpp
@@ -229,9 +229,9 @@ void TypeDesc::GetName(SString &ssBuf)
         th = TypeHandle(this);
 
     if (kind == ELEMENT_TYPE_ARRAY)
-        rank = ((ArrayTypeDesc*) this)->GetRank();
+        rank = dac_cast<PTR_ArrayTypeDesc>(this)->GetRank();
     else if (CorTypeInfo::IsGenericVariable(kind))
-        rank = ((TypeVarTypeDesc*) this)->GetIndex();
+        rank = dac_cast<PTR_TypeVarTypeDesc>(this)->GetIndex();
     else
         rank = 0;
 


### PR DESCRIPTION
Fix a function that was ifdef'ed needed for the metadata locator callbacks to work.

Fix some not properly DAC'ized code in the type desc and server GC code. Caused an exception during dump generation.

Issue: https://github.com/dotnet/coreclr/issues/26907