### PR TITLE
Pass zero length array as null

### DIFF
--- a/src/tools/crossgen2/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1343,6 +1343,11 @@ namespace Internal.TypeSystem.Interop
                 ILLocalVariable vPinnedFirstElement = emitter.NewLocal(ManagedElementType.MakeByRefType(), true);
 
                 LoadManagedValue(codeStream);
+                codeStream.Emit(ILOpcode.ldlen);
+                codeStream.Emit(ILOpcode.conv_i4);
+                codeStream.Emit(ILOpcode.brfalse, lNullArray);
+
+                LoadManagedValue(codeStream);
                 codeStream.Emit(ILOpcode.call, emitter.NewToken(getRawSzArrayDataMethod));
                 codeStream.EmitStLoc(vPinnedFirstElement);
 


### PR DESCRIPTION
Turns out zero length arrays are passed as a pointer to the non-existing element only when the array is passed by reference. They are passed as null otherwise.