### PR TITLE
Populate properties of AssemblyLoadStart/Stop events

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -209,7 +209,7 @@ namespace System.Runtime.Loader
             // Make sure ActivityTracker is enabled
             ActivityTracker.Instance.Enable();
 
-            // Don't use trace to TPL event source in ActivityTracker, as that could lead to recursive loading.
+            // Don't use trace to TPL event source in ActivityTracker - that event source is a singleton and its instantiation may have triggered the load.
             ActivityTracker.Instance.OnStart(NativeRuntimeEventSource.Log.Name, AssemblyLoadName, 0, ref activityId, ref relatedActivityId, EventActivityOptions.Recursive, useTplSource: false);
         }
 
@@ -218,7 +218,7 @@ namespace System.Runtime.Loader
         /// </summary>
         private static void StopAssemblyLoad(ref Guid activityId)
         {
-            // Don't use trace to TPL event source in ActivityTracker, as that could lead to recursive loading.
+            // Don't use trace to TPL event source in ActivityTracker - that event source is a singleton and its instantiation may have triggered the load.
             ActivityTracker.Instance.OnStop(NativeRuntimeEventSource.Log.Name, AssemblyLoadName, 0, ref activityId, useTplSource: false);
         }
     }

--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -206,7 +206,11 @@ namespace System.Runtime.Loader
         /// </summary>
         private static void StartAssemblyLoad(ref Guid activityId, ref Guid relatedActivityId)
         {
-            ActivityTracker.Instance.OnStart(NativeRuntimeEventSource.Log.Name, AssemblyLoadName, 0, ref activityId, ref relatedActivityId, EventActivityOptions.Recursive);
+            // Make sure ActivityTracker is enabled
+            ActivityTracker.Instance.Enable();
+
+            // Don't use trace to TPL event source in ActivityTracker, as that could lead to recursive loading.
+            ActivityTracker.Instance.OnStart(NativeRuntimeEventSource.Log.Name, AssemblyLoadName, 0, ref activityId, ref relatedActivityId, EventActivityOptions.Recursive, useTplSource: false);
         }
 
         /// <summary>
@@ -214,7 +218,8 @@ namespace System.Runtime.Loader
         /// </summary>
         private static void StopAssemblyLoad(ref Guid activityId)
         {
-            ActivityTracker.Instance.OnStop(NativeRuntimeEventSource.Log.Name, AssemblyLoadName, 0, ref activityId);
+            // Don't use trace to TPL event source in ActivityTracker, as that could lead to recursive loading.
+            ActivityTracker.Instance.OnStop(NativeRuntimeEventSource.Log.Name, AssemblyLoadName, 0, ref activityId, useTplSource: false);
         }
     }
 }

--- a/src/binder/activitytracker.cpp
+++ b/src/binder/activitytracker.cpp
@@ -19,6 +19,8 @@ void ActivityTracker::Start(/*out*/ GUID *activityId, /*out*/ GUID *relatedActiv
 {
     GCX_COOP();
 
+    OVERRIDE_TYPE_LOAD_LEVEL_LIMIT(CLASS_LOADED);
+
     PREPARE_NONVIRTUAL_CALLSITE(METHOD__ASSEMBLYLOADCONTEXT__START_ASSEMBLY_LOAD);
     DECLARE_ARGHOLDER_ARRAY(args, 2);
     args[ARGNUM_0] = PTR_TO_ARGHOLDER(activityId);
@@ -30,6 +32,8 @@ void ActivityTracker::Start(/*out*/ GUID *activityId, /*out*/ GUID *relatedActiv
 void ActivityTracker::Stop(/*out*/ GUID *activityId)
 {
     GCX_COOP();
+
+    OVERRIDE_TYPE_LOAD_LEVEL_LIMIT(CLASS_LOADED);
 
     PREPARE_NONVIRTUAL_CALLSITE(METHOD__ASSEMBLYLOADCONTEXT__STOP_ASSEMBLY_LOAD);
     DECLARE_ARGHOLDER_ARRAY(args, 1);

--- a/src/binder/bindertracing.cpp
+++ b/src/binder/bindertracing.cpp
@@ -85,9 +85,10 @@ namespace
         AppDomain *domain = spec->GetAppDomain();
         ICLRPrivBinder* bindContext = spec->GetBindingContext();
         if (bindContext == nullptr)
+        {
             bindContext = spec->GetBindingContextFromParentAssembly(domain);
-
-        _ASSERTE(bindContext != nullptr);
+            _ASSERTE(bindContext != nullptr);
+        }
 
         UINT_PTR binderID = 0;
         HRESULT hr = bindContext->GetBinderID(&binderID);
@@ -106,7 +107,9 @@ namespace
         }
         else
         {
-#if !defined(CROSSGEN_COMPILE)
+#ifdef CROSSGEN_COMPILE
+            alcName.Set(W("Custom"));
+#else // CROSSGEN_COMPILE
             CLRPrivBinderAssemblyLoadContext * alcBinder = static_cast<CLRPrivBinderAssemblyLoadContext *>(binder);
             OBJECTREF *alc = reinterpret_cast<OBJECTREF *>(alcBinder->GetManagedAssemblyLoadContext());
 
@@ -125,9 +128,7 @@ namespace
             gc.alcName->GetSString(alcName);
 
             GCPROTECT_END();
-#else // !defined(CROSSGEN_COMPILE)
-            alcName.Set(W("Custom"));
-#endif // !defined(CROSSGEN_COMPILE)
+#endif // CROSSGEN_COMPILE
         }
     }
 

--- a/src/binder/bindertracing.cpp
+++ b/src/binder/bindertracing.cpp
@@ -46,7 +46,7 @@ namespace
 #endif // FEATURE_EVENT_TRACE
     }
 
-    void FireAssemblyLoadStop(const BinderTracing::AssemblyBindOperation::BindRequest &request, bool success, const WCHAR *resultName, const WCHAR *resultPath, bool cached)
+    void FireAssemblyLoadStop(const BinderTracing::AssemblyBindOperation::BindRequest &request, PEAssembly *resultAssembly, bool cached)
     {
 #ifdef FEATURE_EVENT_TRACE
         if (!EventEnabledAssemblyLoadStop())
@@ -54,6 +54,15 @@ namespace
 
         GUID activityId = GUID_NULL;
         ActivityTracker::Stop(&activityId);
+
+        SString resultName;
+        SString resultPath;
+        bool success = resultAssembly != nullptr;
+        if (success)
+        {
+            resultPath = resultAssembly->GetPath();
+            resultAssembly->GetDisplayName(resultName);
+        }
 
         FireEtwAssemblyLoadStop(
             GetClrInstanceId(),
@@ -68,6 +77,71 @@ namespace
             &activityId);
 #endif // FEATURE_EVENT_TRACE
     }
+
+    void PopulateBindRequest(/*inout*/ BinderTracing::AssemblyBindOperation::BindRequest &request)
+    {
+        AssemblySpec *spec = request.AssemblySpec;
+        _ASSERTE(spec != nullptr);
+
+        if (request.AssemblyPath.IsEmpty())
+            request.AssemblyPath = spec->GetCodeBase();
+
+        if (spec->GetName() != nullptr)
+            spec->GetDisplayName(ASM_DISPLAYF_VERSION | ASM_DISPLAYF_CULTURE | ASM_DISPLAYF_PUBLIC_KEY_TOKEN, request.AssemblyName);
+
+        DomainAssembly *parentAssembly = spec->GetParentAssembly();
+        if (parentAssembly != nullptr)
+            parentAssembly->GetFile()->GetDisplayName(request.RequestingAssembly);
+
+        AppDomain *domain = spec->GetAppDomain();
+        ICLRPrivBinder* bindContext = spec->GetBindingContext();
+        if (bindContext == nullptr)
+            bindContext = spec->GetBindingContextFromParentAssembly(domain);
+
+        _ASSERTE(bindContext != nullptr);
+
+        UINT_PTR binderID = 0;
+        HRESULT hr = bindContext->GetBinderID(&binderID);
+        if (SUCCEEDED(hr))
+        {
+            ICLRPrivBinder *binder = reinterpret_cast<ICLRPrivBinder *>(binderID);
+            if (AreSameBinderInstance(binder, domain->GetTPABinderContext()))
+            {
+                request.AssemblyLoadContext = W("Default");
+            }
+#ifdef FEATURE_COMINTEROP
+            else if (AreSameBinderInstance(binder, domain->GetWinRtBinder()))
+            {
+                request.AssemblyLoadContext = W("WinRT");
+            }
+#endif // FEATURE_COMINTEROP
+            else
+            {
+#if !defined(CROSSGEN_COMPILE)
+                CLRPrivBinderAssemblyLoadContext * alcBinder = static_cast<CLRPrivBinderAssemblyLoadContext *>(binder);
+                OBJECTREF *alc = reinterpret_cast<OBJECTREF *>(alcBinder->GetManagedAssemblyLoadContext());
+
+                GCX_COOP();
+                struct _gc {
+                    STRINGREF alcName;
+                } gc;
+                ZeroMemory(&gc, sizeof(gc));
+
+                GCPROTECT_BEGIN(gc);
+
+                PREPARE_VIRTUAL_CALLSITE(METHOD__OBJECT__TO_STRING, *alc);
+                DECLARE_ARGHOLDER_ARRAY(args, 1);
+                args[ARGNUM_0] = OBJECTREF_TO_ARGHOLDER(*alc);
+                CALL_MANAGED_METHOD_RETREF(gc.alcName, STRINGREF, args);
+                gc.alcName->GetSString(request.AssemblyLoadContext);
+
+                GCPROTECT_END();
+#else // !defined(CROSSGEN_COMPILE)
+                request.AssemblyLoadContext = W("Custom");
+#endif // !defined(CROSSGEN_COMPILE)
+            }
+        }
+    }
 }
 
 bool BinderTracing::IsEnabled()
@@ -81,31 +155,55 @@ bool BinderTracing::IsEnabled()
 
 namespace BinderTracing
 {
-    AssemblyBindOperation::AssemblyBindOperation(AssemblySpec *assemblySpec)
-        : m_bindRequest { assemblySpec }
-        , m_success { false }
+    AssemblyBindOperation::AssemblyBindOperation(AssemblySpec *assemblySpec, const WCHAR *assemblyPath)
+        : m_bindRequest { assemblySpec, nullptr, assemblyPath }
+        , m_populatedBindRequest { false }
+        , m_checkedIgnoreBind { false }
+        , m_ignoreBind { false }
+        , m_resultAssembly { nullptr }
         , m_cached { false }
     {
         _ASSERTE(assemblySpec != nullptr);
 
-        // ActivityTracker or EventSource may have triggered the system satellite load.
-        // Don't track system satellite binding to avoid potential infinite recursion.
-        m_trackingBind = BinderTracing::IsEnabled() && !m_bindRequest.AssemblySpec->IsMscorlibSatellite();
-        if (m_trackingBind)
-        {
-            m_bindRequest.AssemblySpec->GetFileOrDisplayName(ASM_DISPLAYF_VERSION | ASM_DISPLAYF_CULTURE | ASM_DISPLAYF_PUBLIC_KEY_TOKEN, m_bindRequest.AssemblyName);
-            FireAssemblyLoadStart(m_bindRequest);
-        }
+        if (!BinderTracing::IsEnabled() || ShouldIgnoreBind())
+            return;
+
+        PopulateBindRequest(m_bindRequest);
+        m_populatedBindRequest = true;
+        FireAssemblyLoadStart(m_bindRequest);
     }
 
     AssemblyBindOperation::~AssemblyBindOperation()
     {
-        if (m_trackingBind)
-            FireAssemblyLoadStop(m_bindRequest, m_success, m_resultName.GetUnicode(), m_resultPath.GetUnicode(), m_cached);
+        if (!BinderTracing::IsEnabled() || ShouldIgnoreBind())
+            return;
+
+        // Make sure the bind request is populated. Tracing may have been enabled mid-bind.
+        if (!m_populatedBindRequest)
+            PopulateBindRequest(m_bindRequest);
+
+        FireAssemblyLoadStop(m_bindRequest, m_resultAssembly, m_cached);
     }
 
-    void AssemblyBindOperation::SetResult(PEAssembly *assembly)
+    void AssemblyBindOperation::SetResult(PEAssembly *assembly, bool cached)
     {
-        m_success = assembly != nullptr;
+        _ASSERTE(m_resultAssembly == nullptr);
+        m_resultAssembly = assembly;
+        if (m_resultAssembly != nullptr)
+            m_resultAssembly->AddRef();
+
+        m_cached = cached;
+    }
+
+    bool AssemblyBindOperation::ShouldIgnoreBind()
+    {
+        if (m_checkedIgnoreBind)
+            return m_ignoreBind;
+
+        // ActivityTracker or EventSource may have triggered the system satellite load.
+        // Don't track system satellite binding to avoid potential infinite recursion.
+        m_ignoreBind = m_bindRequest.AssemblySpec->IsMscorlibSatellite();
+        m_checkedIgnoreBind = true;
+        return m_ignoreBind;
     }
 }

--- a/src/binder/bindertracing.cpp
+++ b/src/binder/bindertracing.cpp
@@ -96,16 +96,14 @@ namespace
             return;
 
         ICLRPrivBinder *binder = reinterpret_cast<ICLRPrivBinder *>(binderID);
+#ifdef FEATURE_COMINTEROP
+        if (AreSameBinderInstance(binder, domain->GetTPABinderContext()) || AreSameBinderInstance(binder, domain->GetWinRtBinder()))
+#else
         if (AreSameBinderInstance(binder, domain->GetTPABinderContext()))
+#endif // FEATURE_COMINTEROP
         {
             alcName.Set(W("Default"));
         }
-#ifdef FEATURE_COMINTEROP
-        else if (AreSameBinderInstance(binder, domain->GetWinRtBinder()))
-        {
-            alcName.Set(W("WinRT"));
-        }
-#endif // FEATURE_COMINTEROP
         else
         {
 #if !defined(CROSSGEN_COMPILE)

--- a/src/binder/inc/bindertracing.h
+++ b/src/binder/inc/bindertracing.h
@@ -33,6 +33,7 @@ namespace BinderTracing
             SString AssemblyPath;
             SString RequestingAssembly;
             SString AssemblyLoadContext;
+            SString RequestingAssemblyLoadContext;
         };
 
     private:

--- a/src/binder/inc/bindertracing.h
+++ b/src/binder/inc/bindertracing.h
@@ -21,10 +21,10 @@ namespace BinderTracing
     {
     public:
         // This class assumes the assembly spec will have a longer lifetime than itself
-        AssemblyBindOperation(AssemblySpec *assemblySpec);
+        AssemblyBindOperation(AssemblySpec *assemblySpec, const WCHAR *assemblyPath = nullptr);
         ~AssemblyBindOperation();
 
-        void SetResult(PEAssembly *assembly);
+        void SetResult(PEAssembly *assembly, bool cached = false);
 
         struct BindRequest
         {
@@ -36,13 +36,16 @@ namespace BinderTracing
         };
 
     private:
+        bool ShouldIgnoreBind();
+
+    private:
         BindRequest m_bindRequest;
+        bool m_populatedBindRequest;
 
-        bool m_trackingBind;
+        bool m_checkedIgnoreBind;
+        bool m_ignoreBind;
 
-        bool m_success;
-        SString m_resultName;
-        SString m_resultPath;
+        ReleaseHolder<PEAssembly> m_resultAssembly;
         bool m_cached;
     };
 };

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -1638,6 +1638,7 @@
                         <data name="AssemblyPath" inType="win:UnicodeString" />
                         <data name="RequestingAssembly" inType="win:UnicodeString" />
                         <data name="AssemblyLoadContext" inType="win:UnicodeString" />
+                        <data name="RequestingAssemblyLoadContext" inType="win:UnicodeString" />
                         <UserData>
                             <AssemblyLoadStart xmlns="myNs">
                                 <ClrInstanceID> %1 </ClrInstanceID>
@@ -1645,6 +1646,7 @@
                                 <AssemblyPath> %3 </AssemblyPath>
                                 <RequestingAssembly> %4 </RequestingAssembly>
                                 <AssemblyLoadContext> %5 </AssemblyLoadContext>
+                                <RequestingAssemblyLoadContext> %6 </RequestingAssemblyLoadContext>
                             </AssemblyLoadStart>
                         </UserData>
                     </template>
@@ -1655,6 +1657,7 @@
                         <data name="AssemblyPath" inType="win:UnicodeString" />
                         <data name="RequestingAssembly" inType="win:UnicodeString" />
                         <data name="AssemblyLoadContext" inType="win:UnicodeString" />
+                        <data name="RequestingAssemblyLoadContext" inType="win:UnicodeString" />
                         <data name="Success" inType="win:Boolean" />
                         <data name="ResultAssemblyName" inType="win:UnicodeString" />
                         <data name="ResultAssemblyPath" inType="win:UnicodeString" />
@@ -1666,10 +1669,11 @@
                                 <AssemblyPath> %3 </AssemblyPath>
                                 <RequestingAssembly> %4 </RequestingAssembly>
                                 <AssemblyLoadContext> %5 </AssemblyLoadContext>
-                                <Success> %6 </Success>
-                                <ResultAssemblyName> %7 </ResultAssemblyName>
-                                <ResultAssemblyPath> %8 </ResultAssemblyPath>
-                                <Cached> %9 </Cached>
+                                <RequestingAssemblyLoadContext> %6 </RequestingAssemblyLoadContext>
+                                <Success> %7 </Success>
+                                <ResultAssemblyName> %8 </ResultAssemblyName>
+                                <ResultAssemblyPath> %9 </ResultAssemblyPath>
+                                <Cached> %10 </Cached>
                             </AssemblyLoadStop>
                         </UserData>
                     </template>
@@ -6659,8 +6663,8 @@
                 <string id="RuntimePublisher.AppDomainLoad_V1EventMessage" value="AppDomainID=%1;%nAppDomainFlags=%2;%nAppDomainName=%3;%nAppDomainIndex=%4;%nClrInstanceID=%5" />
                 <string id="RuntimePublisher.AppDomainUnloadEventMessage" value="AppDomainID=%1;%nAppDomainFlags=%2;%nAppDomainName=%3" />
                 <string id="RuntimePublisher.AppDomainUnload_V1EventMessage" value="AppDomainID=%1;%nAppDomainFlags=%2;%nAppDomainName=%3;%nAppDomainIndex=%4;%nClrInstanceID=%5" />
-                <string id="RuntimePublisher.AssemblyLoadStartEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nAssemblyPath=%3;%nRequestingAssembly=%4;%nAssemblyLoadContext=%5" />
-                <string id="RuntimePublisher.AssemblyLoadStopEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nAssemblyPath=%3;%nRequestingAssembly=%4;%nAssemblyLoadContext=%5;%nSuccess=%6;%nResultAssemblyName=%7;%nResultAssemblyPath=%8;%nCached=%9" />
+                <string id="RuntimePublisher.AssemblyLoadStartEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nAssemblyPath=%3;%nRequestingAssembly=%4;%nAssemblyLoadContext=%5;%nRequestingAssemblyLoadContext=%6" />
+                <string id="RuntimePublisher.AssemblyLoadStopEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nAssemblyPath=%3;%nRequestingAssembly=%4;%nAssemblyLoadContext=%5;%nRequestingAssemblyLoadContext=%6;%nSuccess=%7;%nResultAssemblyName=%8;%nResultAssemblyPath=%9;%nCached=%10" />
                 <string id="RuntimePublisher.StackEventMessage" value="ClrInstanceID=%1;%nReserved1=%2;%nReserved2=%3;%nFrameCount=%4;%nStack=%5" />
                 <string id="RuntimePublisher.AppDomainMemAllocatedEventMessage" value="AppDomainID=%1;%nAllocated=%2;%nClrInstanceID=%3" />
                 <string id="RuntimePublisher.AppDomainMemSurvivedEventMessage" value="AppDomainID=%1;%nSurvived=%2;%nProcessSurvived=%3;%nClrInstanceID=%4" />

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -4983,10 +4983,12 @@ EndTry2:;
     {
         HRESULT hrBindResult = S_OK;
         PEAssemblyHolder result;
-
+        
+        bool isCached = false;
         EX_TRY
         {
-            if (!IsCached(pSpec))
+            isCached = IsCached(pSpec);
+            if (!isCached)
             {
 
                 {
@@ -5147,7 +5149,7 @@ EndTry2:;
                 result->AddRef();
         }
 
-        bindOperation.SetResult(result.GetValue());
+        bindOperation.SetResult(result.GetValue(), isCached);
         return result.Extract();
     }
     else

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -188,7 +188,7 @@ Assembly* AssemblyNative::LoadFromPEImage(ICLRPrivBinder* pBinderContext, PEImag
     AssemblySpec spec;
     spec.InitializeSpec(TokenFromRid(1, mdtAssembly), pImage->GetMDImport(), pCallersAssembly);
     spec.SetBindingContext(pBinderContext);
-    
+
     BinderTracing::AssemblyBindOperation bindOperation(&spec, pImage->GetPath());
 
     HRESULT hr = S_OK;

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -188,8 +188,8 @@ Assembly* AssemblyNative::LoadFromPEImage(ICLRPrivBinder* pBinderContext, PEImag
     AssemblySpec spec;
     spec.InitializeSpec(TokenFromRid(1, mdtAssembly), pImage->GetMDImport(), pCallersAssembly);
     spec.SetBindingContext(pBinderContext);
-
-    BinderTracing::AssemblyBindOperation bindOperation(&spec);
+    
+    BinderTracing::AssemblyBindOperation bindOperation(&spec, pImage->GetPath());
 
     HRESULT hr = S_OK;
     PTR_AppDomain pCurDomain = GetAppDomain();

--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -29,6 +29,8 @@
 #include "winrthelpers.h"
 #endif
 
+#include "../binder/inc/bindertracing.h"
+
 #ifdef _DEBUG
 // This debug-only wrapper for LookupAssembly is solely for the use of postconditions and
 // assertions. The problem is that the real LookupAssembly can throw an OOM
@@ -917,6 +919,9 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
 
     if (pAssembly)
     {
+        BinderTracing::AssemblyBindOperation bindOperation(this);
+        bindOperation.SetResult(pAssembly->GetFile(), true /*cached*/);
+
         pDomain->LoadDomainFile(pAssembly, targetLevel);
         RETURN pAssembly;
     }

--- a/src/vm/baseassemblyspec.h
+++ b/src/vm/baseassemblyspec.h
@@ -217,6 +217,9 @@ public:
 
 protected:
     static BOOL CompareRefToDef(const BaseAssemblySpec *pRef, const BaseAssemblySpec *pDef);
+
+private:
+    void GetDisplayNameInternal(DWORD flags, SString &result) const;
 };
 
 #endif // __BASE_ASSEMBLY_SPEC_H__

--- a/src/vm/baseassemblyspec.h
+++ b/src/vm/baseassemblyspec.h
@@ -175,6 +175,7 @@ public:
     static BOOL VerifyBindingString(LPCWSTR pwStr);
 
     void GetFileOrDisplayName(DWORD flags, SString &result) const;
+    void GetDisplayName(DWORD flags, SString &result) const;
 
     inline void GetPublicKey(
         PBYTE * ppbPublicKey,
@@ -213,7 +214,6 @@ public:
         LIMITED_METHOD_CONTRACT;
         return IsAfRetargetable(m_dwFlags);
     }
-
 
 protected:
     static BOOL CompareRefToDef(const BaseAssemblySpec *pRef, const BaseAssemblySpec *pDef);

--- a/src/vm/coreassemblyspec.cpp
+++ b/src/vm/coreassemblyspec.cpp
@@ -102,7 +102,7 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
 
     if (m_wszCodeBase == NULL)
     {
-        GetFileOrDisplayName(0, assemblyDisplayName);
+        GetDisplayName(0, assemblyDisplayName);
     }
 
     // Have a default binding context setup
@@ -460,6 +460,21 @@ VOID BaseAssemblySpec::GetFileOrDisplayName(DWORD flags, SString &result) const
         result.Set(m_wszCodeBase);
         return;
     }
+
+    return GetDisplayName(flags, result);
+}
+
+VOID BaseAssemblySpec::GetDisplayName(DWORD flags, SString &result) const
+{
+    CONTRACTL
+    {
+        INSTANCE_CHECK;
+        THROWS;
+        INJECT_FAULT(ThrowOutOfMemory());
+        PRECONDITION(CheckValue(result));
+        PRECONDITION(result.IsEmpty());
+    }
+    CONTRACTL_END;
 
     if (flags==0)
         flags=ASM_DISPLAYF_FULL;

--- a/src/vm/coreassemblyspec.cpp
+++ b/src/vm/coreassemblyspec.cpp
@@ -461,7 +461,7 @@ VOID BaseAssemblySpec::GetFileOrDisplayName(DWORD flags, SString &result) const
         return;
     }
 
-    return GetDisplayName(flags, result);
+    GetDisplayNameInternal(flags, result);
 }
 
 VOID BaseAssemblySpec::GetDisplayName(DWORD flags, SString &result) const
@@ -476,6 +476,11 @@ VOID BaseAssemblySpec::GetDisplayName(DWORD flags, SString &result) const
     }
     CONTRACTL_END;
 
+    GetDisplayNameInternal(flags, result);
+}
+
+VOID BaseAssemblySpec::GetDisplayNameInternal(DWORD flags, SString &result) const
+{
     if (flags==0)
         flags=ASM_DISPLAYF_FULL;
 

--- a/tests/src/Loader/binding/tracing/AssemblyToLoad.cs
+++ b/tests/src/Loader/binding/tracing/AssemblyToLoad.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace AssemblyToLoad
+{
+    public class Program
+    { }
+}

--- a/tests/src/Loader/binding/tracing/AssemblyToLoad.csproj
+++ b/tests/src/Loader/binding/tracing/AssemblyToLoad.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyToLoad.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/src/Loader/binding/tracing/BinderEventListener.cs
+++ b/tests/src/Loader/binding/tracing/BinderEventListener.cs
@@ -19,6 +19,7 @@ namespace BinderTracingTests
         internal string AssemblyPath;
         internal AssemblyName RequestingAssembly;
         internal string AssemblyLoadContext;
+        internal string RequestingAssemblyLoadContext;
 
         internal bool Success;
         internal AssemblyName ResultAssemblyName;
@@ -93,6 +94,7 @@ namespace BinderTracingTests
                             AssemblyName = new AssemblyName(GetDataString("AssemblyName")),
                             AssemblyPath = GetDataString("AssemblyPath"),
                             AssemblyLoadContext = GetDataString("AssemblyLoadContext"),
+                            RequestingAssemblyLoadContext = GetDataString("RequestingAssemblyLoadContext"),
                             ActivityId = data.ActivityId,
                             ParentActivityId = data.RelatedActivityId,
                             Nested = bindOperations.ContainsKey(data.RelatedActivityId)

--- a/tests/src/Loader/binding/tracing/BinderEventListener.cs
+++ b/tests/src/Loader/binding/tracing/BinderEventListener.cs
@@ -122,17 +122,6 @@ namespace BinderTracingTests
                     }
                     break;
             }
-
-            // System.Text.StringBuilder sb = new System.Text.StringBuilder($"  {data.EventName}{Environment.NewLine}");
-            // sb.AppendLine("    Payload:");
-            // for (int i = 0; i < data.Payload.Count; i++)
-            // {
-            //     string payloadString = data.Payload[i] != null ? data.Payload[i].ToString() : string.Empty;
-            //     sb.AppendLine($"      {data.PayloadNames[i]} = {payloadString}");
-            // }
-            // sb.AppendLine($"    Activity: {data.ActivityId}");
-            // sb.AppendLine($"    Related Activity: {data.RelatedActivityId}");
-            // Console.WriteLine(sb.ToString());
         }
     }
 }

--- a/tests/src/Loader/binding/tracing/BinderTracingTest.cs
+++ b/tests/src/Loader/binding/tracing/BinderTracingTest.cs
@@ -3,56 +3,238 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
 
-using Assert = Xunit.Assert;
+using TestLibrary;
 
 namespace BinderTracingTests
 {
+    [AttributeUsage(System.AttributeTargets.Method)]
+    class BinderTestAttribute : Attribute
+    {
+        public bool Isolate { get; private set; }
+        public BinderTestAttribute(bool isolate = false)
+        {
+            Isolate = isolate;
+        }
+    }
+
     class BinderTracingTest
     {
-        public static void PlatformAssembly_DefaultALC()
+        public class CustomALC : AssemblyLoadContext
         {
-            Console.WriteLine($"Running {nameof(PlatformAssembly_DefaultALC)}...");
-            using (var listener = new BinderEventListener())
-            {
-                string assemblyName = "System.Xml";
-                Assembly asm = Assembly.Load(assemblyName);
-
-                BindOperation[] binds = listener.WaitAndGetEventsForAssembly(assemblyName);
-                Assert.True(binds.Length == 1, $"Bind count for {assemblyName} - expected: 1, actual: {binds.Length}");
-                BindOperation bind = binds[0];
-                Assert.True(bind.Success, $"Expected bind for {assemblyName} to succeed");
-            }
+            public CustomALC(string name) : base(name)
+            { }
         }
 
-        public static void NonExistentAssembly_DefaultALC()
-        {
-            Console.WriteLine($"Running {nameof(NonExistentAssembly_DefaultALC)}...");
-            using (var listener = new BinderEventListener())
-            {
-                string assemblyName = "DoesNotExist";
-                try
-                {
-                    Assembly.Load(assemblyName);
-                }
-                catch { }
+        private const string DefaultALC = "Default";
 
-                BindOperation[] binds = listener.WaitAndGetEventsForAssembly(assemblyName);
-                Assert.True(binds.Length == 1, $"Bind event count for {assemblyName} - expected: 1, actual: {binds.Length}");
-                BindOperation bind = binds[0];
-                Assert.False(bind.Success, $"Expected bind for {assemblyName} to fail");
-            }
+        [BinderTest]
+        public static BindOperation LoadFile()
+        {
+            var executingAssembly = Assembly.GetExecutingAssembly();
+            Assembly asm = Assembly.LoadFile(executingAssembly.Location);
+
+            return new BindOperation()
+            {
+                AssemblyName = executingAssembly.GetName(),
+                AssemblyPath = executingAssembly.Location,
+                AssemblyLoadContext = AssemblyLoadContext.GetLoadContext(asm).ToString(),
+                Success = true,
+                ResultAssemblyName = asm.GetName(),
+                ResultAssemblyPath = asm.Location,
+                Cached = false
+            };
         }
 
-        public static int Main(string[] unused)
+        [BinderTest]
+        public static BindOperation LoadBytes()
         {
+            var executingAssembly = Assembly.GetExecutingAssembly();
+            Byte[] bytes = File.ReadAllBytes(executingAssembly.Location);
+            Assembly asm = Assembly.Load(bytes);
+
+            return new BindOperation()
+            {
+                AssemblyName = executingAssembly.GetName(),
+                AssemblyLoadContext = AssemblyLoadContext.GetLoadContext(asm).ToString(),
+                Success = true,
+                ResultAssemblyName = asm.GetName(),
+                ResultAssemblyPath = asm.Location,
+                Cached = false
+            };
+        }
+
+        [BinderTest]
+        public static BindOperation LoadFromStream()
+        {
+            var executingAssembly = Assembly.GetExecutingAssembly();
+            Stream stream = File.OpenRead(executingAssembly.Location);
+            CustomALC alc = new CustomALC(nameof(LoadFromStream));
+            Assembly asm = alc.LoadFromStream(stream);
+
+            return new BindOperation()
+            {
+                AssemblyName = executingAssembly.GetName(),
+                AssemblyLoadContext = alc.ToString(),
+                Success = true,
+                ResultAssemblyName = asm.GetName(),
+                ResultAssemblyPath = asm.Location,
+                Cached = false
+            };
+        }
+
+        [BinderTest]
+        public static BindOperation LoadFromAssemblyPath()
+        {
+            CustomALC alc = new CustomALC(nameof(LoadFromAssemblyPath));
+            var executingAssembly = Assembly.GetExecutingAssembly();
+            Assembly asm = alc.LoadFromAssemblyPath(executingAssembly.Location);
+
+            return new BindOperation()
+            {
+                AssemblyName = executingAssembly.GetName(),
+                AssemblyPath = executingAssembly.Location,
+                AssemblyLoadContext = alc.ToString(),
+                Success = true,
+                ResultAssemblyName = asm.GetName(),
+                ResultAssemblyPath = asm.Location,
+                Cached = false
+            };
+        }
+
+        [BinderTest(isolate: true)]
+        public static BindOperation LoadFrom()
+        {
+            var executingAssembly = Assembly.GetExecutingAssembly();
+            Assembly asm = Assembly.LoadFrom(executingAssembly.Location);
+
+            return new BindOperation()
+            {
+                AssemblyName = executingAssembly.GetName(),
+                AssemblyPath = executingAssembly.Location,
+                AssemblyLoadContext = DefaultALC,
+                Success = true,
+                ResultAssemblyName = asm.GetName(),
+                ResultAssemblyPath = asm.Location,
+                Cached = false
+            };
+        }
+
+        [BinderTest(isolate: true)]
+        public static BindOperation PlatformAssembly()
+        {
+            string assemblyName = "System.Xml";
+            Assembly asm = Assembly.Load(assemblyName);
+            
+            return new BindOperation()
+            {
+                AssemblyName = new AssemblyName(assemblyName),
+                AssemblyLoadContext = DefaultALC,
+                Success = true,
+                ResultAssemblyName = asm.GetName(),
+                ResultAssemblyPath = asm.Location,
+                Cached = false
+            };
+        }
+
+        [BinderTest]
+        public static BindOperation NonExistentAssembly()
+        {
+            string assemblyName = "DoesNotExist";
             try
             {
-                PlatformAssembly_DefaultALC();
-                NonExistentAssembly_DefaultALC();
+                Assembly.Load(assemblyName);
+            }
+            catch { }
+
+            return new BindOperation()
+            {
+                AssemblyName = new AssemblyName(assemblyName),
+                AssemblyLoadContext = DefaultALC,
+                Success = false,
+                Cached = false
+            };
+        }
+
+        [BinderTest(isolate: true)]
+        public static BindOperation Reflection()
+        {
+            string assemblyName = "AssemblyToLoad";
+            var t = Type.GetType($"AssemblyToLoad.Program, {assemblyName}");
+
+            return new BindOperation()
+            {
+                AssemblyName = new AssemblyName(assemblyName),
+                AssemblyLoadContext = DefaultALC,
+                RequestingAssembly = Assembly.GetExecutingAssembly().GetName(),
+                Success = true,
+                ResultAssemblyName = t.Assembly.GetName(),
+                ResultAssemblyPath = t.Assembly.Location,
+                Cached = false,
+            };
+        }
+
+        [BinderTest(isolate: true)]
+        public static BindOperation JITLoad()
+        {
+            Assembly asm = UseDependentAssembly();
+
+            return new BindOperation()
+            {
+                AssemblyName = asm.GetName(),
+                AssemblyLoadContext = DefaultALC,
+                RequestingAssembly = Assembly.GetExecutingAssembly().GetName(),
+                Success = true,
+                ResultAssemblyName = asm.GetName(),
+                ResultAssemblyPath = asm.Location,
+                Cached = false,
+            };
+        }
+
+        public static bool RunAllTests()
+        {
+            MethodInfo[] methods = typeof(BinderTracingTest)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(m => m.GetCustomAttributes(typeof(BinderTestAttribute), false).Length > 0 && m.ReturnType == typeof(BindOperation))
+                .ToArray();
+
+            foreach (var method in methods)
+            {
+                BinderTestAttribute attribute = (BinderTestAttribute)method.GetCustomAttributes(typeof(BinderTestAttribute)).First();
+                bool success = attribute.Isolate
+                    ? RunTestInSeparateProcess(method)
+                    : RunSingleTest(method);
+                if (!success)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static int Main(string[] args)
+        {
+            bool success;
+            try
+            {
+                if (args.Length == 0)
+                {
+                    success = RunAllTests();
+                }
+                else
+                {
+                    // Run specific test - first argument should be the test method name
+                    MethodInfo method = typeof(BinderTracingTest)
+                        .GetMethod(args[0], BindingFlags.Public | BindingFlags.Static);
+                    Assert.IsTrue(method.GetCustomAttributes(typeof(BinderTestAttribute), false).Length > 0 && method.ReturnType == typeof(BindOperation));
+                    success = RunSingleTest(method);
+                }
             }
             catch (Exception e)
             {
@@ -60,7 +242,93 @@ namespace BinderTracingTests
                 return 101;
             }
 
-            return 100;
+            return success ? 100 : 101;
+        }
+
+        private static Assembly UseDependentAssembly()
+        {
+            var p = new AssemblyToLoad.Program();
+            return Assembly.GetAssembly(p.GetType());
+        }
+
+        private static bool RunSingleTest(MethodInfo method)
+        {
+            Console.WriteLine($"Running {method.Name}...");
+            try
+            {
+                Func<BindOperation> func = (Func<BindOperation>)method.CreateDelegate(typeof(Func<BindOperation>));
+                using (var listener = new BinderEventListener())
+                {
+                    BindOperation expected = func();
+                    ValidateSingleBind(listener, expected.AssemblyName.Name, expected);
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Test {method.Name} failed: {e}");
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool RunTestInSeparateProcess(MethodInfo method)
+        {
+            var startInfo = new ProcessStartInfo()
+            {
+                FileName = Process.GetCurrentProcess().MainModule.FileName,
+                Arguments = $"{Assembly.GetExecutingAssembly().Location} {method.Name}",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            Console.WriteLine($"Launching process for {method.Name}...");
+            using (Process p = Process.Start(startInfo))
+            {
+                p.OutputDataReceived += (_, args) => Console.WriteLine(args.Data);
+                p.BeginOutputReadLine();
+
+                p.ErrorDataReceived += (_, args) => Console.Error.WriteLine(args.Data);
+                p.BeginErrorReadLine();
+
+                p.WaitForExit();
+                return p.ExitCode == 100;
+            }
+        }
+
+        private static void ValidateSingleBind(BinderEventListener listener, string assemblyName, BindOperation expected)
+        {
+            BindOperation[] binds = listener.WaitAndGetEventsForAssembly(assemblyName);
+            Assert.IsTrue(binds.Length == 1, $"Bind event count for {assemblyName} - expected: 1, actual: {binds.Length}");
+            BindOperation actual = binds[0];
+            
+            ValidateAssemblyName(expected.AssemblyName, actual.AssemblyName, nameof(BindOperation.AssemblyName));
+            Assert.AreEqual(expected.AssemblyPath ?? string.Empty, actual.AssemblyPath, $"Unexpected value for {nameof(BindOperation.AssemblyPath)} on event");
+            Assert.AreEqual(expected.AssemblyLoadContext, actual.AssemblyLoadContext, $"Unexpected value for {nameof(BindOperation.AssemblyLoadContext)} on event");
+            ValidateAssemblyName(expected.RequestingAssembly, actual.RequestingAssembly, nameof(BindOperation.RequestingAssembly));
+
+            Assert.AreEqual(expected.Success, actual.Success, $"Unexpected value for {nameof(BindOperation.Success)} on event");
+            Assert.AreEqual(expected.ResultAssemblyPath ?? string.Empty, actual.ResultAssemblyPath, $"Unexpected value for {nameof(BindOperation.ResultAssemblyPath)} on event");
+            Assert.AreEqual(expected.Cached, actual.Cached, $"Unexpected value for {nameof(BindOperation.Cached)} on event");
+            ValidateAssemblyName(expected.ResultAssemblyName, actual.ResultAssemblyName, nameof(BindOperation.ResultAssemblyName));
+        }
+
+        private static void ValidateAssemblyName(AssemblyName expected, AssemblyName actual, string propertyName)
+        {
+            if (expected == null)
+            {
+                return;
+            }
+            
+            if (expected.Version != null)
+            {
+                Assert.AreEqual(expected.FullName, actual.FullName, $"Unexpected value for {propertyName} on event");
+            }
+            else 
+            {
+                Assert.AreEqual(expected.Name, actual.Name, $"Unexpected value for {propertyName} on event");
+            }
         }
     }
 }

--- a/tests/src/Loader/binding/tracing/BinderTracingTest.csproj
+++ b/tests/src/Loader/binding/tracing/BinderTracingTest.csproj
@@ -8,5 +8,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="AssemblyToLoad.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Populate properties for `AssemblyLoadStart` and `AssemblyLoadStop` binder tracing events
- Fire event when assembly is retrieved from the binding cache
- Add tests to validate single start/stop assembly load events. Some tests launch the test process again to run in order to avoid polluting the default ALC
- Avoid using the `TplEventSource` (which can lead to an attempt to use itself during its load) when using the `ActivityTracker` for tracking assembly loads