### PR TITLE
[test] Improve diagnostics for failures in IPC/EventPipe tests

### DIFF
--- a/tests/src/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/tests/src/tracing/eventpipe/common/IpcTraceTest.cs
@@ -207,7 +207,7 @@ namespace Tracing.Tests.Common
                     }
                     Logger.logger.Log($"Connected to EventPipe with sessionID '0x{sessionId:x}'");
 
-                    lock(threadSync)
+                    lock (threadSync)
                     {
                         eventpipeSessionId = sessionId;
                     }
@@ -280,7 +280,7 @@ namespace Tracing.Tests.Common
             var stopTask = Task.Run(() => 
             {
                 Logger.logger.Log("Sending StopTracing command...");
-                lock(threadSync) // eventpipeSessionId
+                lock (threadSync) // eventpipeSessionId
                 {
                     EventPipeClient.StopTracing(processId, eventpipeSessionId);
                 }

--- a/tests/src/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/tests/src/tracing/eventpipe/common/IpcTraceTest.cs
@@ -175,7 +175,7 @@ namespace Tracing.Tests.Common
         {
             var isClean = EnsureCleanEnvironment();
             if (!isClean)
-            return -1;
+                return -1;
             // CollectTracing returns before EventPipe::Enable has returned, so the
             // the sources we want to listen for may not have been enabled yet.
             // We'll use this sentinel EventSource to check if Enable has finished

--- a/tests/src/tracing/eventpipe/common/StreamProxy.cs
+++ b/tests/src/tracing/eventpipe/common/StreamProxy.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using System.IO;
+
+namespace Tracing.Tests.Common
+{
+    // This Stream implementation takes one stream
+    // and proxies the Stream API to it while
+    // saving any read bytes to an internal stream.
+    // Should an error occur, the internal stream
+    // is dumped to disk for reproducing the error.
+    public class StreamProxy : Stream
+    {
+        private Stream ProxiedStream { get; }
+        private MemoryStream InternalStream => new MemoryStream();
+        public override bool CanRead => ProxiedStream.CanRead;
+
+        public override bool CanSeek => ProxiedStream.CanSeek;
+
+        public override bool CanWrite => ProxiedStream.CanWrite;
+
+        public override long Length => ProxiedStream.Length;
+
+        public override long Position { get => ProxiedStream.Position; set => ProxiedStream.Position = value; }
+
+        public StreamProxy(Stream streamToProxy)
+        {
+            ProxiedStream = streamToProxy;
+        }
+
+        public override void Flush() => ProxiedStream.Flush();
+
+        // Read the actual desired amount of bytes into an empty buffer
+        // copy those bytes into an internal MemoryStream THEN
+        // forward those bytes to the caller. If the caller
+        // would have thrown an exception with its Read, copy
+        // the bytes to the internal MemoryStream and then throw
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null || offset < 0 || count < 0)
+                throw new ArgumentException("Invalid input into Read");
+
+            byte[] localBuffer = ArrayPool<byte>.Shared.Rent(count);
+            var readCount = ProxiedStream.Read(localBuffer, 0, count);
+            if (readCount == 0)
+                return readCount;
+
+            InternalStream.Write(localBuffer, 0, readCount);
+
+            if (buffer.Length - offset < count)
+            {
+                // This is the error that EventPipeEventSource is causing,
+                // so this is when we should throw an exception, just like
+                // System.IO.PipeStream, but dump the InternalStream
+                // to a file first!
+                Logger.logger.Log($"[Error] Attempted to read {count} bytes into a buffer of length {buffer.Length} at offset {offset}");
+                DumpStreamToDisk();
+
+                // Throw the exception like what would have happened in System.IO.PipeStream
+                throw new ArgumentException($"Attempted to read {count} bytes into a buffer of length {buffer.Length} at offset {offset}");
+            }
+
+            // copy the data into the caller's buffer
+            Array.Copy(localBuffer, 0, buffer, offset, readCount);
+
+            ArrayPool<byte>.Shared.Return(localBuffer, true);
+            return readCount;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => ProxiedStream.Seek(offset, origin);
+
+        public override void SetLength(long value) => ProxiedStream.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            // This stream is only for "reading" from. No need for this method.
+            throw new System.NotImplementedException();
+        }
+
+        protected bool disposed = false;
+        protected override void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+                    ProxiedStream.Dispose();
+                    InternalStream.Dispose();
+                }
+
+                disposed = true;
+            }
+        }
+
+        private void DumpStreamToDisk()
+        {
+            var helixDumpDirectory = System.Environment.GetEnvironmentVariable("HELIX_DUMP_FOLDER");
+            if (helixDumpDirectory != null && Directory.Exists(helixDumpDirectory))
+            {
+                using (var streamDumpFile = File.Create(Path.Combine(helixDumpDirectory, "streamdump.nettrace")))
+                {
+                    Logger.logger.Log($"\t Writing stream read to this point to file");
+                    InternalStream.Seek(0, SeekOrigin.Begin);
+                    InternalStream.CopyTo(streamDumpFile);
+                }
+            }
+        }
+    }
+}

--- a/tests/src/tracing/eventpipe/common/StreamProxy.cs
+++ b/tests/src/tracing/eventpipe/common/StreamProxy.cs
@@ -100,9 +100,11 @@ namespace Tracing.Tests.Common
             var helixWorkItemDirectory = System.Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT");
             if (helixWorkItemDirectory != null && Directory.Exists(helixWorkItemDirectory))
             {
-                using (var streamDumpFile = File.Create(Path.Combine(helixWorkItemDirectory, "streamdump.nettrace")))
+                Logger.logger.Log($"\t HELIX_WORKITEM_UPLOAD_ROOT = {helixWorkItemDirectory}");
+                var filePath = Path.Combine(helixWorkItemDirectory, "streamdump.nettrace");
+                using (var streamDumpFile = File.Create(filePath))
                 {
-                    Logger.logger.Log($"\t Writing stream read to this point to file");
+                    Logger.logger.Log($"\t Writing stream to {filePath}");
                     InternalStream.Seek(0, SeekOrigin.Begin);
                     InternalStream.CopyTo(streamDumpFile);
                 }

--- a/tests/src/tracing/eventpipe/common/StreamProxy.cs
+++ b/tests/src/tracing/eventpipe/common/StreamProxy.cs
@@ -55,10 +55,9 @@ namespace Tracing.Tests.Common
             {
                 // This is the error that EventPipeEventSource is causing,
                 // so this is when we should throw an exception, just like
-                // System.IO.PipeStream, but dump the InternalStream
-                // to a file first!
+                // System.IO.PipeStream. This will result in the dispose method
+                // being called and the culprit stream data being dumped to disk
                 Logger.logger.Log($"[Error] Attempted to read {count} bytes into a buffer of length {buffer.Length} at offset {offset}");
-                DumpStreamToDisk();
 
                 // Throw the exception like what would have happened in System.IO.PipeStream
                 throw new ArgumentException($"Attempted to read {count} bytes into a buffer of length {buffer.Length} at offset {offset}");
@@ -96,12 +95,12 @@ namespace Tracing.Tests.Common
             }
         }
 
-        private void DumpStreamToDisk()
+        public void DumpStreamToDisk()
         {
-            var helixDumpDirectory = System.Environment.GetEnvironmentVariable("HELIX_DUMP_FOLDER");
-            if (helixDumpDirectory != null && Directory.Exists(helixDumpDirectory))
+            var helixWorkItemDirectory = System.Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT");
+            if (helixWorkItemDirectory != null && Directory.Exists(helixWorkItemDirectory))
             {
-                using (var streamDumpFile = File.Create(Path.Combine(helixDumpDirectory, "streamdump.nettrace")))
+                using (var streamDumpFile = File.Create(Path.Combine(helixWorkItemDirectory, "streamdump.nettrace")))
                 {
                     Logger.logger.Log($"\t Writing stream read to this point to file");
                     InternalStream.Seek(0, SeekOrigin.Begin);

--- a/tests/src/tracing/eventpipe/common/common.csproj
+++ b/tests/src/tracing/eventpipe/common/common.csproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="IpcTraceTest.cs" />
+    <Compile Include="StreamProxy.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Add ProxyStream for diagnosing issues with EventPipeEventSource StreamReading
* Harden IpcTraceTest.cs against errors where the reader throws an exception before we await the task

---

This should prevent the timeout mentioned in #26241.  Also adds a `Stream` proxy that will allow us to dump the contents of the stream in the event that a failure does occur.  

I believe I have narrowed down the issue to an exception happening inside `EventPipeEventSource` that causes the reader thread to die before we `.Wait()` on it, so we deadlock on the `StopTracing()` call because that won't return until writing has stopped.  Since the reader thread has died, the kernel buffer for the OS transport (Named Pipes on Windows; Sockets on Linux) has filled up and the runtime's event flushing thread is blocked on a call to `EventPipeFile::Write()`, therefore `StopTracing` can't return and we are deadlocked.

The additional `using` statements are meant to harden against this case by ensuring that the OS level structs for the `Stream` are cleaned up when an exception inside a `Task` is thrown.  This should close the EventPipe connection once the exception has been thrown and prevent the writer thread from being blocked, allowing the `StopTracing` call to complete.  This means we will now hit whatever exception has been causing the reader thread to die at the `.Wait()` call.  In this case, I have observed the culprit to be an `ArgumentException` thrown from System.IO.PipeStream.Read from inside `EventPipeEventSource`. 

The proxied `Read` call on `ProxyStream` checks for the case when this is happening and dumps the whole stream to a `.nettrace` file in order to have a file that should ostensibly reproduce the issue in `EventPipeEventSource` when streamed through it later.

CC - @tommcdon 