### PR TITLE
Fix struct assignment where types differ

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1385,9 +1385,9 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
     if ((dest == nullptr) && (destAddr->OperGet() == GT_ADDR))
     {
         GenTree* destNode = destAddr->gtGetOp1();
-        // If the actual destination is a local, or already a block node, or is a node that
+        // If the actual destination is a local, a GT_INDEX or a block node, or is a node that
         // will be morphed, don't insert an OBJ(ADDR) if it already has the right type.
-        if ((destNode->gtOper == GT_INDEX) || destNode->OperIsBlk() || (destNode->OperGet() == GT_LCL_VAR))
+        if (destNode->OperIs(GT_LCL_VAR, GT_INDEX) || destNode->OperIsBlk())
         {
             var_types destType = destNode->TypeGet();
             // If one or both types are TYP_STRUCT (one may not yet be normalized), they are compatible

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1170,8 +1170,8 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
                                       BasicBlock*          block       /* = NULL */
                                       )
 {
-    GenTree*  dest      = nullptr;
-    unsigned  destFlags = 0;
+    GenTree* dest      = nullptr;
+    unsigned destFlags = 0;
 
     if (ilOffset == BAD_IL_OFFSET)
     {

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1393,9 +1393,10 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
             // If one or both types are TYP_STRUCT (one may not yet be normalized), they are compatible
             // iff their handles are the same.
             // Otherwise, they are compatible if their types are the same.
-            bool typesAreCompatible = ((destType == TYP_STRUCT) || (asgType == TYP_STRUCT))
-                                          ? ((gtGetStructHandleIfPresent(destNode) == structHnd) && varTypeIsStruct(asgType))
-                                          : (destType == asgType);
+            bool typesAreCompatible =
+                ((destType == TYP_STRUCT) || (asgType == TYP_STRUCT))
+                    ? ((gtGetStructHandleIfPresent(destNode) == structHnd) && varTypeIsStruct(asgType))
+                    : (destType == asgType);
             if (typesAreCompatible)
             {
                 dest = destNode;

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1400,6 +1400,11 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
             if (typesAreCompatible)
             {
                 dest = destNode;
+                if (destType != TYP_STRUCT)
+                {
+                    // Use a normalized type if available. We know from above that they're equivalent.
+                    asgType = destType;
+                }
             }
         }
     }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_27551/GitHub_27551.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_27551/GitHub_27551.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.CompilerServices;
+
+public class GitHub_27551
+{
+    static int returnVal = 100;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static byte GetByte()
+    {
+        return 0xaa;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void ValidateResult(Byte[] resultElements, Byte[] valueElements)
+    {
+        bool succeeded = true;
+
+        if (resultElements.Length <= valueElements.Length)
+        {
+            for (var i = 0; i < resultElements.Length; i++)
+            {
+                if (resultElements[i] != valueElements[i])
+                {
+                    returnVal = -1;
+                    break;
+                }
+            }
+        }
+        else
+        {
+            for (var i = 0; i < valueElements.Length; i++)
+            {
+                if (resultElements[i] != valueElements[i])
+                {
+                    returnVal = -1;
+                    break;
+                }
+            }
+
+            for (var i = valueElements.Length; i < resultElements.Length; i++)
+            {
+                if (resultElements[i] != default)
+                {
+                    returnVal = -1;
+                    break;
+                }
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ValidateResult(Vector<Byte> result, Vector256<Byte> value)
+    {
+        Byte[] resultElements = new Byte[Vector<byte>.Count];
+        Unsafe.WriteUnaligned(ref Unsafe.As<Byte, byte>(ref resultElements[0]), result);
+
+        Byte[] valueElements = new Byte[Vector256<byte>.Count];
+        Unsafe.WriteUnaligned(ref Unsafe.As<Byte, byte>(ref valueElements[0]), value);
+
+        ValidateResult(resultElements, valueElements);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ValidateResult(Vector256<Byte> result, Vector<Byte> value)
+    {
+        Byte[] resultElements = new Byte[Vector256<byte>.Count];
+        Unsafe.WriteUnaligned(ref Unsafe.As<Byte, byte>(ref resultElements[0]), result);
+
+        Byte[] valueElements = new Byte[Vector<byte>.Count];
+        Unsafe.WriteUnaligned(ref Unsafe.As<Byte, byte>(ref valueElements[0]), value);
+
+        ValidateResult(resultElements, valueElements);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Test(Vector256<byte> value)
+    {
+        Vector<Byte> result = value.AsVector();
+        ValidateResult(result, value);
+
+        value = result.AsVector256();
+        ValidateResult(value, result);
+    }
+
+    public static int Main()
+    {
+        Vector256<Byte> value = Vector256.Create((byte)GetByte());
+        Test(value);
+
+        return returnVal;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_27551/GitHub_27551.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_27551/GitHub_27551.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType />
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix #27551 
The first commit adds a small repro test case. I verified that it fails on arm/linux without the fix: https://dev.azure.com/dnceng/public/_build/results?buildId=409199&view=logs
The second commit fixes `impAssignStructPtr` by moving the optimization to eliminate the indirection after the various cases have been handed, and adds a check that the handles are the same.