### PR TITLE
Prevent DivideByZeroException in EventCounter.ToString()

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
@@ -56,7 +56,13 @@ namespace System.Diagnostics.Tracing
             Enqueue(value);
         }
 
-        public override string ToString() => $"EventCounter '{Name}' Count {_count} Mean {{(_count == 0 ? "" : (_sum / _count).ToString("n3"))}}";
+        public override string ToString()
+        {
+            int count = Volatile.Read(ref _count);
+            return count == 0 ?
+                $"EventCounter '{Name}' Count 0" :
+                $"EventCounter '{Name}' Count {count} Mean {(_sum / count).ToString("n3")}";
+        }
 
         #region Statistics Calculation
 

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
@@ -56,7 +56,7 @@ namespace System.Diagnostics.Tracing
             Enqueue(value);
         }
 
-        public override string ToString() => $"EventCounter '{Name}' Count {_count} Mean {(_sum / _count).ToString("n3")}";
+        public override string ToString() => $"EventCounter '{Name}' Count {_count} Mean {{(_count == 0 ? "" : (_sum / _count).ToString("n3"))}}";
 
         #region Statistics Calculation
 


### PR DESCRIPTION
Maybe it should print something other than 0. Maybe "Mean" should be excluded. But at least with this it doesn't divide by zero. Ternary operator in interpolated string is not super readable; didn't know if making the code more descriptive would have performance implications.