### PR TITLE
Arm64: Add S.P.CoreLib instrinsics for ReverseBitOrder

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.PlatformNotSupported.cs
@@ -51,6 +51,30 @@ namespace System.Runtime.Intrinsics.Arm
             ///   A64: FSUB Vd.2D, Vn.2D, Vm.2D
             /// </summary>
             public static Vector128<double> Subtract(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// uint8x8_t vrbit_u8 (uint8x8_t a)
+            ///   A64: RBIT Vd.8B, Vn.8B
+            /// </summary>
+            public static Vector64<byte> ReverseElementBits(Vector64<byte> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// int8x8_t vrbit_s8 (int8x8_t a)
+            ///   A64: RBIT Vd.8B, Vn.8B
+            /// </summary>
+            public static Vector64<sbyte> ReverseElementBits(Vector64<sbyte> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// uint8x16_t vrbitq_u8 (uint8x16_t a)
+            ///   A64: RBIT Vd.16B, Vn.16B
+            /// </summary>
+            public static Vector128<byte> ReverseElementBits(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// int8x16_t vrbitq_s8 (int8x16_t a)
+            ///   A64: RBIT Vd.16B, Vn.16B
+            /// </summary>
+            public static Vector128<sbyte> ReverseElementBits(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.cs
@@ -53,6 +53,30 @@ namespace System.Runtime.Intrinsics.Arm
             ///   A64: FSUB Vd.2D, Vn.2D, Vm.2D
             /// </summary>
             public static Vector128<double> Subtract(Vector128<double> left, Vector128<double> right) => Add(left, right);
+
+            /// <summary>
+            /// uint8x8_t vrbit_u8 (uint8x8_t a)
+            ///   A64: RBIT Vd.8B, Vn.8B
+            /// </summary>
+            public static Vector64<byte> ReverseElementBits(Vector64<byte> value) => ReverseElementBits(value);
+
+            /// <summary>
+            /// int8x8_t vrbit_s8 (int8x8_t a)
+            ///   A64: RBIT Vd.8B, Vn.8B
+            /// </summary>
+            public static Vector64<sbyte> ReverseElementBits(Vector64<sbyte> value) => ReverseElementBits(value);
+
+            /// <summary>
+            /// uint8x16_t vrbitq_u8 (uint8x16_t a)
+            ///   A64: RBIT Vd.16B, Vn.16B
+            /// </summary>
+            public static Vector128<byte> ReverseElementBits(Vector128<byte> value) => ReverseElementBits(value);
+
+            /// <summary>
+            /// int8x16_t vrbitq_s8 (int8x16_t a)
+            ///   A64: RBIT Vd.16B, Vn.16B
+            /// </summary>
+            public static Vector128<sbyte> ReverseElementBits(Vector128<sbyte> value) => ReverseElementBits(value);
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/ArmBase.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/ArmBase.PlatformNotSupported.cs
@@ -42,6 +42,16 @@ namespace System.Runtime.Intrinsics.Arm
             ///   A64: CLZ Xd, Xn
             /// </summary>
             public static int LeadingZeroCount(ulong value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            ///   A64: RBIT Xd, Xn
+            /// </summary>
+            public static int ReverseElementBits(long value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            ///   A64: RBIT Xd, Xn
+            /// </summary>
+            public static int ReverseElementBits(ulong value) { throw new PlatformNotSupportedException(); }
         }
 
         /// <summary>
@@ -55,5 +65,17 @@ namespace System.Runtime.Intrinsics.Arm
         ///   A64: CLZ Wd, Wn
         /// </summary>
         public static int LeadingZeroCount(uint value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        ///   A32: RBIT Rd, Rm
+        ///   A64: RBIT Wd, Wn
+        /// </summary>
+        public static int ReverseElementBits(int value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        ///   A32: RBIT Rd, Rm
+        ///   A64: RBIT Wd, Wn
+        /// </summary>
+        public static int ReverseElementBits(uint value) { throw new PlatformNotSupportedException(); }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/ArmBase.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/ArmBase.cs
@@ -43,6 +43,16 @@ namespace System.Runtime.Intrinsics.Arm
             ///   A64: CLZ Xd, Xn
             /// </summary>
             public static int LeadingZeroCount(ulong value) => LeadingZeroCount(value);
+
+            /// <summary>
+            ///   A64: RBIT Xd, Xn
+            /// </summary>
+            public static long ReverseElementBits(long value) => ReverseElementBits(value);
+
+            /// <summary>
+            ///   A64: RBIT Xd, Xn
+            /// </summary>
+            public static ulong ReverseElementBits(ulong value) => ReverseElementBits(value);
         }
 
         /// <summary>
@@ -56,5 +66,17 @@ namespace System.Runtime.Intrinsics.Arm
         ///   A64: CLZ Wd, Wn
         /// </summary>
         public static int LeadingZeroCount(uint value) => LeadingZeroCount(value);
+
+        /// <summary>
+        ///   A32: RBIT Rd, Rm
+        ///   A64: RBIT Wd, Wn
+        /// </summary>
+        public static int ReverseElementBits(int value) => ReverseElementBits(value);
+
+        /// <summary>
+        ///   A32: RBIT Rd, Rm
+        ///   A64: RBIT Wd, Wn
+        /// </summary>
+        public static uint ReverseElementBits(uint value) => ReverseElementBits(value);
     }
 }


### PR DESCRIPTION
This implements the `ReverseBitOrder` intrinsics for Arm64.

See https://github.com/dotnet/corefx/issues/26581 and if first split of #26769
CoreFX ref assembly update at https://github.com/dotnet/corefx/pull/42358

/CC @tannergooding @CarolEidt @echesakovMSFT 

Thanks,
Tamar