### PR TITLE
Enable a faster mod/GetCurrentProcessorId

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/Timer.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Timer.cs
@@ -41,6 +41,14 @@ namespace System.Threading
 
         public static TimerQueue[] Instances { get; } = CreateTimerQueues();
 
+        public static TimerQueue GetQueueForProcessor()
+        {
+            int index = Thread.GetCurrentProcessorId();
+            Debug.Assert(Environment.ProcessorCount == Instances.Length);
+            Debug.Assert(index >= 0 && index < Instances.Length);
+            return Instances[index];
+        }
+
         private static TimerQueue[] CreateTimerQueues()
         {
             var queues = new TimerQueue[Environment.ProcessorCount];
@@ -437,7 +445,7 @@ namespace System.Threading
             {
                 _executionContext = ExecutionContext.Capture();
             }
-            _associatedTimerQueue = TimerQueue.Instances[Thread.GetCurrentProcessorId() % TimerQueue.Instances.Length];
+            _associatedTimerQueue = TimerQueue.GetQueueForProcessor();
 
             // After the following statement, the timer may fire.  No more manipulation of timer state outside of
             // the lock is permitted beyond this point!

--- a/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -487,52 +487,6 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern int GetCurrentProcessorNumber();
 
-        // The upper bits of t_currentProcessorIdCache are the currentProcessorId. The lower bits of
-        // the t_currentProcessorIdCache are counting down to get it periodically refreshed.
-        // TODO: Consider flushing the currentProcessorIdCache on Wait operations or similar
-        // actions that are likely to result in changing the executing core
-        [ThreadStatic]
-        private static int t_currentProcessorIdCache;
-
-        private const int ProcessorIdCacheShift = 16;
-        private const int ProcessorIdCacheCountDownMask = (1 << ProcessorIdCacheShift) - 1;
-        private const int ProcessorIdRefreshRate = 5000;
-
-        private static int RefreshCurrentProcessorId()
-        {
-            int currentProcessorId = GetCurrentProcessorNumber();
-
-            // On Unix, GetCurrentProcessorNumber() is implemented in terms of sched_getcpu, which
-            // doesn't exist on all platforms.  On those it doesn't exist on, GetCurrentProcessorNumber()
-            // returns -1.  As a fallback in that case and to spread the threads across the buckets
-            // by default, we use the current managed thread ID as a proxy.
-            if (currentProcessorId < 0) currentProcessorId = Environment.CurrentManagedThreadId;
-
-            // Add offset to make it clear that it is not guaranteed to be 0-based processor number
-            currentProcessorId += 100;
-
-            Debug.Assert(ProcessorIdRefreshRate <= ProcessorIdCacheCountDownMask);
-
-            // Mask with int.MaxValue to ensure the execution Id is not negative
-            t_currentProcessorIdCache = ((currentProcessorId << ProcessorIdCacheShift) & int.MaxValue) | ProcessorIdRefreshRate;
-
-            return currentProcessorId;
-        }
-
-        // Cached processor id used as a hint for which per-core stack to access. It is periodically
-        // refreshed to trail the actual thread core affinity.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int GetCurrentProcessorId()
-        {
-            int currentProcessorIdCache = t_currentProcessorIdCache--;
-            if ((currentProcessorIdCache & ProcessorIdCacheCountDownMask) == 0)
-            {
-                return RefreshCurrentProcessorId();
-            }
-
-            return currentProcessorIdCache >> ProcessorIdCacheShift;
-        }
-
         internal void ResetThreadPoolThread()
         {
             // Currently implemented in unmanaged method Thread::InternalReset and


### PR DESCRIPTION
Ensure `GetCurrentProcessorId()` is in range 0 - ProcCount as with https://github.com/dotnet/coreclr/pull/27543 ProcCount is now a stable value.

In `TimerQueueTimer` use `GetCurrentProcessorId()` directly as it no longer needs mod.

In `TlsOverPerCoreLockedStacksArrayPool` use a pattern that can be elided by Tier1 Jitting and skip mod if ProcCount < 64

Originally I was aiming to use `FastMod`; however I realised the Jit would do it itself at Tier1 as the `readonly static`s would become `const`s

/cc @stephentoub @jkotas @VSadov 