### PR TITLE
Avoid instantiating abstract class

### DIFF
--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -758,6 +758,11 @@ namespace Internal.JitInterface
         private CorInfoHelpFunc getNewHelper(ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, byte* pHasSideEffects = null)
         {
             TypeDesc type = HandleToObject(pResolvedToken.hClass);
+            MetadataType metadataType = type as MetadataType;
+            if (metadataType != null && metadataType.IsAbstract)
+            {
+                ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramSpecific, HandleToObject(callerHandle));
+            }
 
             if (pHasSideEffects != null)
             {


### PR DESCRIPTION
It is possible for `crossgen2` to encounter code trying to instantiate an abstract class, and we should refuse to generate code in those cases so that the JIT will throw `InvalidOperationException` at runtime.

This is not possible in C#, but it is possible to in `IL`, for example, the code is instantiating the abstract class `Gen<T>` [here](https://github.com/dotnet/coreclr/blob/01d2c1316843648d496d0530be3236efd2114e53/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract01.il#L76)  and the assembler produced the IL for it.

@dotnet/crossgen-contrib 