### PR TITLE
Fix Buggy code in TimeZoneInfo

### DIFF
--- a/src/System.Private.CoreLib/shared/System/TimeZoneInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeZoneInfo.cs
@@ -1459,7 +1459,7 @@ namespace System
                     {
                         ambiguousStartModified = ambiguousStart.AddYears(1);
                         ambiguousEndModified = ambiguousEnd.AddYears(1);
-                        isAmbiguousLocalDst = (time >= ambiguousStart && time < ambiguousEnd);
+                        isAmbiguousLocalDst = (time >= ambiguousStartModified && time < ambiguousEndModified);
                     }
                     catch (ArgumentOutOfRangeException) { }
 
@@ -1469,7 +1469,7 @@ namespace System
                         {
                             ambiguousStartModified = ambiguousStart.AddYears(-1);
                             ambiguousEndModified = ambiguousEnd.AddYears(-1);
-                            isAmbiguousLocalDst = (time >= ambiguousStart && time < ambiguousEnd);
+                            isAmbiguousLocalDst = (time >= ambiguousStartModified && time < ambiguousEndModified);
                         }
                         catch (ArgumentOutOfRangeException) { }
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/26995

Although couldn’t reach the corner case cause executing the buggy code, the fix here is done according to the similar code in TimeZoneInfo which show the intention of the change

https://github.com/dotnet/coreclr/blob/97c582975eed3260ef21e0bcc55c8c86d1e3bec8/src/System.Private.CoreLib/shared/System/TimeZoneInfo.cs#L1638
https://github.com/dotnet/coreclr/blob/97c582975eed3260ef21e0bcc55c8c86d1e3bec8/src/System.Private.CoreLib/shared/System/TimeZoneInfo.cs#L1568