### PR TITLE
Restore Helix SDK with toolset to work around race in msbuild

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -11,5 +11,7 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingVersion)" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsVersion)" />
     <PackageReference Include="Microsoft.DotNet.VersionTools.Tasks" Version="$(MicrosoftDotNetVersionToolsTasksVersion)" />
+    <!-- Download the SDK in the initial restore step to work around race conditions when restoring in MSBuild -->
+    <PackageReference Include="Microsoft.DotNet.Helix.Sdk" Version="[$(MicrosoftDotNetHelixSdkVersion)]" />
   </ItemGroup>
 </Project>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -12,6 +12,6 @@
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsVersion)" />
     <PackageReference Include="Microsoft.DotNet.VersionTools.Tasks" Version="$(MicrosoftDotNetVersionToolsTasksVersion)" />
     <!-- Download the SDK in the initial restore step to work around race conditions when restoring in MSBuild -->
-    <PackageReference Include="Microsoft.DotNet.Helix.Sdk" Version="[$(MicrosoftDotNetHelixSdkVersion)]" />
+    <PackageDownload Include="Microsoft.DotNet.Helix.Sdk" Version="[$(MicrosoftDotNetHelixSdkVersion)]" />
   </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,6 +19,7 @@
     <MicrosoftDotNetBuildTasksPackagingVersion>1.0.0-beta.19463.3</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.19278.1</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>1.0.0-beta.19463.3</MicrosoftDotNetVersionToolsTasksVersion>
+    <MicrosoftDotNetHelixSdkVersion>2.0.0-beta.19463.3</MicrosoftDotNetHelixSdkVersion>
     <!-- corefx -->
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>5.0.0-alpha.1.19531.1</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftNETCorePlatformsVersion>5.0.0-alpha.1.19531.1</MicrosoftNETCorePlatformsVersion>


### PR DESCRIPTION
Works around #26057 by having toolset restore pre-fetch the package for the send to helix steps.

cc: @dotnet/coreclr-infra 