### PR TITLE
Enable faster mod ProcessorCount at tier1

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -47,11 +47,13 @@ namespace System.Buffers
 
         private int _callbackCreated;
 
+        private static readonly bool s_trimBuffers = PerCoreLockedStacksHelpers.s_trimBuffers;
+
         /// <summary>
         /// Used to keep track of all thread local buckets for trimming if needed
         /// </summary>
         private static readonly ConditionalWeakTable<T[]?[], object?>? s_allTlsBuckets =
-            PerCoreLockedStacksHelpers.s_trimBuffers ? new ConditionalWeakTable<T[]?[], object?>() : null;
+            s_trimBuffers ? new ConditionalWeakTable<T[]?[], object?>() : null;
 
         /// <summary>Initialize the pool.</summary>
         public TlsOverPerCoreLockedStacksArrayPool()

--- a/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
+++ b/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
@@ -684,6 +684,8 @@ namespace System
                     return "arrayIndex";
                 case ExceptionArgument.year:
                     return "year";
+                case ExceptionArgument.minimumLength:
+                    return "minimumLength";
                 default:
                     Debug.Fail("The enum value is not defined, please check the ExceptionArgument Enum.");
                     return "";
@@ -834,6 +836,8 @@ namespace System
                     return SR.Rank_MultiDimNotSupported;
                 case ExceptionResource.Arg_TypeNotSupported:
                     return SR.Arg_TypeNotSupported;
+                case ExceptionResource.ArgumentException_BufferNotFromPool:
+                    return SR.ArgumentException_BufferNotFromPool;
                 default:
                     Debug.Fail("The enum value is not defined, please check the ExceptionResource Enum.");
                     return "";
@@ -931,6 +935,7 @@ namespace System
         elementType,
         arrayIndex,
         year,
+        minimumLength,
     }
 
     //
@@ -1002,5 +1007,6 @@ namespace System
         NotSupported_FixedSizeCollection,
         Rank_MultiDimNotSupported,
         Arg_TypeNotSupported,
+        ArgumentException_BufferNotFromPool,
     }
 }


### PR DESCRIPTION
For `TimerQueueTimer` and `TlsOverPerCoreLockedStacksArrayPool`.

As with #27543 ProcCount is now a stable readonly static, using it will convert the mod into a faster version at tier1.

Just changes from https://github.com/dotnet/coreclr/pull/27588 to enable a faster mod vs ProcessorCount at the call sites rather than changing `GetCurrentProcessorId`


/cc @jkotas @VSadov