### PR TITLE
Introduce YAML variable coreClrRepoRoot

### DIFF
--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -126,18 +126,18 @@ jobs:
 
     # Build
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build.sh $(buildConfig) $(archType) $(crossArg) -ci -skipnuget $(clangArg) $(stripSymbolsArg) $(officialBuildIdArg)
+      - script: $(coreClrRepoRoot)/build$(scriptExt) $(buildConfig) $(archType) $(crossArg) -ci -skipnuget $(clangArg) $(stripSymbolsArg) $(officialBuildIdArg)
         displayName: Build product
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: set __TestIntermediateDir=int&&build.cmd $(buildConfig) $(archType) -ci -skiptests -skipbuildpackages $(officialBuildIdArg) $(ibcOptimizeArg) $(enforcePgoArg)
+      - script: set __TestIntermediateDir=int&&$(coreClrRepoRoot)\build$(scriptExt) $(buildConfig) $(archType) -ci -skiptests -skipbuildpackages $(officialBuildIdArg) $(ibcOptimizeArg) $(enforcePgoArg)
         displayName: Build product
 
     # Build native test components
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build-test.sh skipmanaged $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(clangArg)
+      - script: $(coreClrRepoRoot)/build-test$(scriptExt) skipmanaged $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(clangArg)
         displayName: Build native test components
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: build-test.cmd skipmanaged $(buildConfig) $(archType) $(priorityArg)
+      - script: $(coreClrRepoRoot)\build-test$(scriptExt) skipmanaged $(buildConfig) $(archType) $(priorityArg)
         displayName: Build native test components
 
     # Sign on Windows
@@ -197,10 +197,10 @@ jobs:
 
     # Build packages
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build-packages.sh -BuildArch=$(archType) -BuildType=$(_BuildConfig) $(crossPackagesArg) $(officialBuildIdArg) $(portableBuildArg) -ci
+      - script: $(coreClrRepoRoot)/build-packages$(scriptExt) -BuildArch=$(archType) -BuildType=$(_BuildConfig) $(crossPackagesArg) $(officialBuildIdArg) $(portableBuildArg) -ci
         displayName: Build packages
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: build-packages.cmd -BuildArch=$(archType) -BuildType=$(_BuildConfig) $(officialBuildIdArg) -ci
+      - script: $(coreClrRepoRoot)\build-packages$(scriptExt) -BuildArch=$(archType) -BuildType=$(_BuildConfig) $(officialBuildIdArg) -ci
         displayName: Build packages
 
     # Publish official build

--- a/eng/build-test-job.yml
+++ b/eng/build-test-job.yml
@@ -83,10 +83,10 @@ jobs:
 
     # Build managed test components
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build-test.sh skipnative skipgeneratelayout $(buildConfig) $(archType) $(crossArg) $(priorityArg) ci
+      - script: $(coreClrRepoRoot)/build-test$(scriptExt) skipnative skipgeneratelayout $(buildConfig) $(archType) $(crossArg) $(priorityArg) ci
         displayName: Build managed test components
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: build-test.cmd skipnative skipgeneratelayout $(buildConfig) $(archType) $(priorityArg) ci
+      - script: $(coreClrRepoRoot)\build-test$(scriptExt) skipnative skipgeneratelayout $(buildConfig) $(archType) $(priorityArg) ci
         displayName: Build managed test components
 
 

--- a/eng/run-test-job.yml
+++ b/eng/run-test-job.yml
@@ -152,10 +152,10 @@ jobs:
     # managed test artifacts.
     - ${{ if ne(parameters.corefxTests, true) }}:
       - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-        - script: ./build-test.sh copynativeonly $(buildConfig) $(archType) $(priorityArg)
+        - script: $(coreClrRepoRoot)/build-test$(scriptExt) copynativeonly $(buildConfig) $(archType) $(priorityArg)
           displayName: Copy native test components to test output folder
       - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-        - script: build-test.cmd copynativeonly $(buildConfig) $(archType) $(priorityArg)
+        - script: $(coreClrRepoRoot)\build-test$(scriptExt) copynativeonly $(buildConfig) $(archType) $(priorityArg)
           displayName: Copy native test components to test output folder
 
 

--- a/eng/xplat-pipeline-job.yml
+++ b/eng/xplat-pipeline-job.yml
@@ -55,8 +55,11 @@ jobs:
       - name: testArtifactRootName
         value: ${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}
 
+    - name: coreClrRepoRoot
+      value: $(Build.SourcesDirectory)
+
     - name: binTestsPath
-      value: $(Build.SourcesDirectory)/bin/tests
+      value: $(coreClrRepoRoot)/bin/tests
 
     - name: testRootFolderPath
       value: $(binTestsPath)/$(osGroup).$(archType).$(buildConfigUpper)
@@ -98,6 +101,8 @@ jobs:
         value: zip
       - name: tarCompression
         value: ''
+      - name: scriptExt
+        value: '.cmd'
 
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
       - name: archiveExtension
@@ -106,6 +111,8 @@ jobs:
         value: tar
       - name: tarCompression
         value: gz
+      - name: scriptExt
+        value: '.sh'
 
     - name: priorityArg
       value: ''


### PR DESCRIPTION
In the repo consolidation scouting exercises I keep stumbling
over sanitizing paths to build scripts. I have realized that, by
introducing a bunch of new variables I can unify Windows and Unix
script executions and make the subsequent transformations much
simpler.

Thanks

Tomas