### PR TITLE
EnvironGetenv: use strncmp instead of strlen and memcmp

### DIFF
--- a/src/pal/src/misc/environ.cpp
+++ b/src/pal/src/misc/environ.cpp
@@ -927,12 +927,7 @@ char* EnvironGetenv(const char* name, BOOL copyValue)
     size_t nameLength = strlen(name);
     for (int i = 0; palEnvironment[i] != nullptr; ++i)
     {
-        if (strlen(palEnvironment[i]) < nameLength)
-        {
-            continue;
-        }
-
-        if (memcmp(palEnvironment[i], name, nameLength) == 0)
+        if (strncmp(palEnvironment[i], name, nameLength) == 0)
         {
             char *equalsSignPosition = palEnvironment[i] + nameLength;
 


### PR DESCRIPTION
Instead of iterating twice over the string, first for searching the
null-terminator and then to compare it to `name`, we only iterate
over it once.

Ref: https://github.com/dotnet/corefx/issues/42216