### PR TITLE
Clean up package restoration in CoreCLR test build

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -289,6 +289,14 @@ powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -Command "%__ProjectDir%\e
   /p:UsePartialNGENOptimization=false /maxcpucount^
   !__Logging! %__CommonMSBuildArgs% %__PriorityArg% %__UnprocessedBuildArgs%
 
+if errorlevel 1 (
+    echo %__ErrMsgPrefix%%__MsgPrefix%Error: Package restoration failed. Refer to the build log files for details:
+    echo     %__BuildLog%
+    echo     %__BuildWrn%
+    echo     %__BuildErr%
+    exit /b 1
+)
+
 :SkipRestoreProduct
 
 REM =========================================================================================
@@ -334,7 +342,16 @@ for /l %%G in (1, 1, %__NumberOfTestGroups%) do (
 
     if not "%__CopyNativeTestBinaries%" == "1" (
         REM Disable warnAsError - coreclr issue 19922
-        set __MSBuildBuildArgs=!__ProjectDir!\tests\build.proj -warnAsError:0 /nodeReuse:false !__Logging! !TargetsWindowsMsbuildArg! !__msbuildArgs! !__PriorityArg! !__UnprocessedBuildArgs! /p:CopyNativeProjectBinaries=!__CopyNativeProjectsAfterCombinedTestBuild!
+        set __MSBuildBuildArgs=!__ProjectDir!\tests\build.proj
+        set __MSBuildBuildArgs=!__MSBuildBuildArgs! -warnAsError:0
+        set __MSBuildBuildArgs=!__MSBuildBuildArgs! /nodeReuse:false
+        set __MSBuildBuildArgs=!__MSBuildBuildArgs! !__Logging!
+        set __MSBuildBuildArgs=!__MSBuildBuildArgs! !TargetsWindowsMsbuildArg!
+        set __MSBuildBuildArgs=!__MSBuildBuildArgs! !__msbuildArgs!
+        set __MSBuildBuildArgs=!__MSBuildBuildArgs! !__PriorityArg!
+        set __MSBuildBuildArgs=!__MSBuildBuildArgs! !__UnprocessedBuildArgs!
+        set __MSBuildBuildArgs=!__MSBuildBuildArgs! /p:CopyNativeProjectBinaries=!__CopyNativeProjectsAfterCombinedTestBuild!
+        set __MSBuildBuildArgs=!__MSBuildBuildArgs! /p:__SkipPackageRestore=true
         echo Running: msbuild !__MSBuildBuildArgs!
         !__CommonMSBuildCmdPrefix! !__MSBuildBuildArgs!
 

--- a/build-test.sh
+++ b/build-test.sh
@@ -319,6 +319,11 @@ build_Tests()
 
     if [ ${__SkipRestorePackages} != 1 ]; then
         build_MSBuild_projects "Restore_Product" "${__ProjectDir}/tests/build.proj" "Restore product binaries (build tests)" "/t:BatchRestorePackages"
+
+        if [ $? -ne 0 ]; then
+            echo "${__ErrMsgPrefix}${__MsgPrefix}Error: package restoration failed. Refer to the build log files for details (above)"
+            exit 1
+        fi
     fi
 
     if [ $__SkipNative != 1 ]; then
@@ -423,6 +428,7 @@ build_MSBuild_projects()
             buildArgs+=("${__CommonMSBuildArgs[@]}")
             buildArgs+=("${__UnprocessedBuildArgs[@]}")
             buildArgs+=("\"/p:CopyNativeProjectBinaries=${__CopyNativeProjectsAfterCombinedTestBuild}\"");
+            buildArgs+=("/p:__SkipPackageRestore=true");
 
             # Disable warnAsError - coreclr issue 19922
             nextCommand="\"$__ProjectRoot/eng/common/msbuild.sh\" $__ArcadeScriptArgs --warnAsError false ${buildArgs[@]}"


### PR DESCRIPTION
During investigation of package version issues in consolidation
scouting I noticed that package restoration logic in the test build
script is quite silly: we first restore all packages but ignore the
exit code, subsequently we restore all packages again before
building each test chunk and fail if we're unable to.

I have simplified this so that we properly exit when we fail to
restore packages upfront; after that, we no longer need to restore
packages before building each test chunk.

Thanks

Tomas