### PR TITLE
Use simple Array.Copy overload where possible

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/ArrayList.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ArrayList.cs
@@ -106,7 +106,7 @@ namespace System.Collections
                         object[] newItems = new object[value];
                         if (_size > 0)
                         {
-                            Array.Copy(_items, 0, newItems, 0, _size);
+                            Array.Copy(_items, newItems, _size);
                         }
                         _items = newItems;
                     }
@@ -248,7 +248,7 @@ namespace System.Collections
             ArrayList la = new ArrayList(_size);
             la._size = _size;
             la._version = _version;
-            Array.Copy(_items, 0, la._items, 0, _size);
+            Array.Copy(_items, la._items, _size);
             return la;
         }
 
@@ -714,7 +714,7 @@ namespace System.Collections
                 return Array.Empty<object>();
 
             object?[] array = new object[_size];
-            Array.Copy(_items, 0, array, 0, _size);
+            Array.Copy(_items, array, _size);
             return array;
         }
 
@@ -729,7 +729,7 @@ namespace System.Collections
                 throw new ArgumentNullException(nameof(type));
 
             Array array = Array.CreateInstance(type, _size);
-            Array.Copy(_items, 0, array, 0, _size);
+            Array.Copy(_items, array, _size);
             return array;
         }
 

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -727,7 +727,7 @@ namespace System.Collections.Generic
             Entry[] entries = new Entry[newSize];
 
             int count = _count;
-            Array.Copy(_entries, 0, entries, 0, count);
+            Array.Copy(_entries, entries, count);
 
             if (default(TKey)! == null && forceNewHashCodes) // TODO-NULLABLE: default(T) == null warning (https://github.com/dotnet/roslyn/issues/34757)
             {

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/List.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/List.cs
@@ -113,7 +113,7 @@ namespace System.Collections.Generic
                         T[] newItems = new T[value];
                         if (_size > 0)
                         {
-                            Array.Copy(_items, 0, newItems, 0, _size);
+                            Array.Copy(_items, newItems, _size);
                         }
                         _items = newItems;
                     }
@@ -1035,7 +1035,7 @@ namespace System.Collections.Generic
             }
 
             T[] array = new T[_size];
-            Array.Copy(_items, 0, array, 0, _size);
+            Array.Copy(_items, array, _size);
             return array;
         }
 

--- a/src/System.Private.CoreLib/shared/System/DefaultBinder.cs
+++ b/src/System.Private.CoreLib/shared/System/DefaultBinder.cs
@@ -304,7 +304,7 @@ namespace System
                     {
                         object[] objs = new object[parms.Length];
                         int lastPos = parms.Length - 1;
-                        Array.Copy(args, 0, objs, 0, lastPos);
+                        Array.Copy(args, objs, lastPos);
                         objs[lastPos] = Array.CreateInstance(paramArrayTypes[0], 1);
                         ((Array)objs[lastPos]).SetValue(args[lastPos], 0);
                         args = objs;
@@ -334,7 +334,7 @@ namespace System
                     {
                         object[] objs = new object[parms.Length];
                         int paramArrayPos = parms.Length - 1;
-                        Array.Copy(args, 0, objs, 0, paramArrayPos);
+                        Array.Copy(args, objs, paramArrayPos);
                         objs[paramArrayPos] = Array.CreateInstance(paramArrayTypes[0], args.Length - paramArrayPos);
                         Array.Copy(args, paramArrayPos, (System.Array)objs[paramArrayPos], 0, args.Length - paramArrayPos);
                         args = objs;
@@ -384,7 +384,7 @@ namespace System
                 {
                     object[] objs = new object[parameters.Length];
                     int lastPos = parameters.Length - 1;
-                    Array.Copy(args, 0, objs, 0, lastPos);
+                    Array.Copy(args, objs, lastPos);
                     objs[lastPos] = Array.CreateInstance(paramArrayTypes[currentMin], 1);
                     ((Array)objs[lastPos]).SetValue(args[lastPos], 0);
                     args = objs;
@@ -417,7 +417,7 @@ namespace System
                 {
                     object[] objs = new object[parameters.Length];
                     int paramArrayPos = parameters.Length - 1;
-                    Array.Copy(args, 0, objs, 0, paramArrayPos);
+                    Array.Copy(args, objs, paramArrayPos);
                     objs[paramArrayPos] = Array.CreateInstance(paramArrayTypes[currentMin], args.Length - paramArrayPos);
                     Array.Copy(args, paramArrayPos, (System.Array)objs[paramArrayPos], 0, args.Length - paramArrayPos);
                     args = objs;
@@ -750,7 +750,7 @@ namespace System
                 {
                     // must be args.Length < state.originalSize
                     object[] newArgs = new object[args.Length];
-                    Array.Copy(args, 0, newArgs, 0, paramArrayPos);
+                    Array.Copy(args, newArgs, paramArrayPos);
                     for (int i = paramArrayPos, j = 0; i < newArgs.Length; i++, j++)
                     {
                         newArgs[i] = ((object[])args[paramArrayPos]!)[j];
@@ -763,7 +763,7 @@ namespace System
                 if (args.Length > binderState._originalSize)
                 {
                     object[] newArgs = new object[binderState._originalSize];
-                    Array.Copy(args, 0, newArgs, 0, binderState._originalSize);
+                    Array.Copy(args, newArgs, binderState._originalSize);
                     args = newArgs;
                 }
             }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
@@ -89,7 +89,7 @@ namespace System.Diagnostics.Tracing
             else if (eventSourceIndex >= CounterGroup.s_counterGroups.Length)
             {
                 WeakReference<CounterGroup>[] newCounterGroups = new WeakReference<CounterGroup>[eventSourceIndex + 1];
-                Array.Copy(CounterGroup.s_counterGroups, 0, newCounterGroups, 0, CounterGroup.s_counterGroups.Length);
+                Array.Copy(CounterGroup.s_counterGroups, newCounterGroups, CounterGroup.s_counterGroups.Length);
                 CounterGroup.s_counterGroups = newCounterGroups;
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -3502,7 +3502,7 @@ namespace System.Diagnostics.Tracing
             if (eventData.Length <= eventAttribute.EventId)
             {
                 EventMetadata[] newValues = new EventMetadata[Math.Max(eventData.Length + 16, eventAttribute.EventId + 1)];
-                Array.Copy(eventData, 0, newValues, 0, eventData.Length);
+                Array.Copy(eventData, newValues, eventData.Length);
                 eventData = newValues;
             }
 
@@ -3542,7 +3542,7 @@ namespace System.Diagnostics.Tracing
             if (eventData.Length - idx > 2)      // allow one wasted slot.
             {
                 EventMetadata[] newValues = new EventMetadata[idx + 1];
-                Array.Copy(eventData, 0, newValues, 0, newValues.Length);
+                Array.Copy(eventData, newValues, newValues.Length);
                 eventData = newValues;
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/ConcurrentSet.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/ConcurrentSet.cs
@@ -107,7 +107,7 @@ namespace System.Diagnostics.Tracing
 
                 int oldLength = oldItems.Length;
                 newItems = new ItemType[oldLength + 1];
-                Array.Copy(oldItems, 0, newItems, 0, lo);
+                Array.Copy(oldItems, newItems, lo);
                 newItems[lo] = newItem;
                 Array.Copy(oldItems, lo, newItems, lo + 1, oldLength - lo);
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureData.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureData.cs
@@ -1567,7 +1567,7 @@ namespace System.Globalization
 
                         // It worked, remember the list
                         CalendarId[] temp = new CalendarId[count];
-                        Array.Copy(calendars, 0, temp, 0, count);
+                        Array.Copy(calendars, temp, count);
 
                         // Want 1st calendar to be default
                         // Prior to Vista the enumeration didn't have default calendar first

--- a/src/System.Private.CoreLib/shared/System/Globalization/StringInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/StringInfo.cs
@@ -287,7 +287,7 @@ namespace System.Globalization
             if (resultCount < len)
             {
                 int[] returnArray = new int[resultCount];
-                Array.Copy(result, 0, returnArray, 0, resultCount);
+                Array.Copy(result, returnArray, resultCount);
                 return returnArray;
             }
             return result;

--- a/src/System.Private.CoreLib/shared/System/Runtime/Serialization/SerializationInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Serialization/SerializationInfo.cs
@@ -264,9 +264,9 @@ namespace System.Runtime.Serialization
             object[] newData = new object[newSize];
             Type[] newTypes = new Type[newSize];
 
-            Array.Copy(_names, 0, newMembers, 0, _count);
-            Array.Copy(_values, 0, newData, 0, _count);
-            Array.Copy(_types, 0, newTypes, 0, _count);
+            Array.Copy(_names, newMembers, _count);
+            Array.Copy(_values, newData, _count);
+            Array.Copy(_types, newTypes, _count);
 
             // Assign the new arrays back to the member vars.
             _names = newMembers;

--- a/src/System.Private.CoreLib/shared/System/Text/EncodingProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/EncodingProvider.cs
@@ -56,7 +56,7 @@ namespace System.Text
                 }
 
                 EncodingProvider[] providers = new EncodingProvider[s_providers.Length + 1];
-                Array.Copy(s_providers, 0, providers, 0, s_providers.Length);
+                Array.Copy(s_providers, providers, s_providers.Length);
                 providers[^1] = provider;
                 s_providers = providers;
             }

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -315,7 +315,7 @@ namespace System.Text
                 {
                     int newLen = value - m_ChunkOffset;
                     char[] newArray = GC.AllocateUninitializedArray<char>(newLen);
-                    Array.Copy(m_ChunkChars, 0, newArray, 0, m_ChunkLength);
+                    Array.Copy(m_ChunkChars, newArray, m_ChunkLength);
                     m_ChunkChars = newArray;
                 }
             }
@@ -480,7 +480,7 @@ namespace System.Text
                             // We crossed a chunk boundary when reducing the Length. We must replace this middle-chunk with a new larger chunk,
                             // to ensure the capacity we want is preserved.
                             char[] newArray = GC.AllocateUninitializedArray<char>(newLen);
-                            Array.Copy(chunk.m_ChunkChars, 0, newArray, 0, chunk.m_ChunkLength);
+                            Array.Copy(chunk.m_ChunkChars, newArray, chunk.m_ChunkLength);
                             m_ChunkChars = newArray;
                         }
                         else

--- a/src/System.Private.CoreLib/shared/System/Threading/AsyncLocal.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/AsyncLocal.cs
@@ -358,7 +358,7 @@ namespace System.Threading
                             // Create a new map of the same size that has all of the same pairs, with this new key/value pair
                             // overwriting the old.
                             var multi = new MultiElementAsyncLocalValueMap(_keyValues.Length);
-                            Array.Copy(_keyValues, 0, multi._keyValues, 0, _keyValues.Length);
+                            Array.Copy(_keyValues, multi._keyValues, _keyValues.Length);
                             multi._keyValues[i] = new KeyValuePair<IAsyncLocal, object?>(key, value);
                             return multi;
                         }
@@ -377,7 +377,7 @@ namespace System.Threading
                             // We have enough elements remaining to warrant a multi map.  Create a new one and copy all of the
                             // elements from this one, except the one to be removed.
                             var multi = new MultiElementAsyncLocalValueMap(_keyValues.Length - 1);
-                            if (i != 0) Array.Copy(_keyValues, 0, multi._keyValues, 0, i);
+                            if (i != 0) Array.Copy(_keyValues, multi._keyValues, i);
                             if (i != _keyValues.Length - 1) Array.Copy(_keyValues, i + 1, multi._keyValues, i, _keyValues.Length - i - 1);
                             return multi;
                         }
@@ -397,7 +397,7 @@ namespace System.Threading
                 if (_keyValues.Length < MaxMultiElements)
                 {
                     var multi = new MultiElementAsyncLocalValueMap(_keyValues.Length + 1);
-                    Array.Copy(_keyValues, 0, multi._keyValues, 0, _keyValues.Length);
+                    Array.Copy(_keyValues, multi._keyValues, _keyValues.Length);
                     multi._keyValues[_keyValues.Length] = new KeyValuePair<IAsyncLocal, object?>(key, value);
                     return multi;
                 }

--- a/src/System.Private.CoreLib/shared/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ThreadPool.cs
@@ -63,7 +63,7 @@ namespace System.Threading
                     Debug.Assert(Array.IndexOf(oldQueues, queue) == -1);
 
                     var newQueues = new WorkStealingQueue[oldQueues.Length + 1];
-                    Array.Copy(oldQueues, 0, newQueues, 0, oldQueues.Length);
+                    Array.Copy(oldQueues, newQueues, oldQueues.Length);
                     newQueues[^1] = queue;
                     if (Interlocked.CompareExchange(ref _queues, newQueues, oldQueues) == oldQueues)
                     {
@@ -97,11 +97,11 @@ namespace System.Threading
                     }
                     else if (pos == oldQueues.Length - 1)
                     {
-                        Array.Copy(oldQueues, 0, newQueues, 0, newQueues.Length);
+                        Array.Copy(oldQueues, newQueues, newQueues.Length);
                     }
                     else
                     {
-                        Array.Copy(oldQueues, 0, newQueues, 0, pos);
+                        Array.Copy(oldQueues, newQueues, pos);
                         Array.Copy(oldQueues, pos + 1, newQueues, pos, newQueues.Length - pos);
                     }
 

--- a/src/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
@@ -297,7 +297,7 @@ namespace System
 
                 Attribute[] temp = ret;
                 ret = CreateAttributeArrayHelper(type, temp.Length + count);
-                Array.Copy(temp, 0, ret, 0, temp.Length);
+                Array.Copy(temp, ret, temp.Length);
 
                 int offset = temp.Length;
 

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingEventHandleTable.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingEventHandleTable.cs
@@ -50,7 +50,7 @@ namespace System.Diagnostics.Tracing
                 }
 
                 IntPtr[] newTable = new IntPtr[newSize];
-                Array.Copy(m_innerTable, 0, newTable, 0, m_innerTable.Length);
+                Array.Copy(m_innerTable, newTable, m_innerTable.Length);
                 Volatile.Write(ref m_innerTable, newTable);
             }
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
@@ -127,7 +127,7 @@ namespace System.Reflection.Emit
             // Cache information used elsewhere.
             m_con = con;
             m_constructorArgs = new object?[constructorArgs.Length];
-            Array.Copy(constructorArgs, 0, m_constructorArgs, 0, constructorArgs.Length);
+            Array.Copy(constructorArgs, m_constructorArgs, constructorArgs.Length);
 
             Type[] paramTypes;
             int i;

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -613,7 +613,7 @@ namespace System.Reflection.Emit
             {
                 ParameterInfo[] privateParameters = LoadParameters();
                 ParameterInfo[] parameters = new ParameterInfo[privateParameters.Length];
-                Array.Copy(privateParameters, 0, parameters, 0, privateParameters.Length);
+                Array.Copy(privateParameters, parameters, privateParameters.Length);
                 return parameters;
             }
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
@@ -30,7 +30,7 @@ namespace System.Reflection.Emit
             Debug.Assert(incoming != null);
 
             T[] temp = new T[requiredSize];
-            Array.Copy(incoming, 0, temp, 0, incoming.Length);
+            Array.Copy(incoming, temp, incoming.Length);
             return temp;
         }
 
@@ -208,7 +208,7 @@ namespace System.Reflection.Emit
             byte[] newBytes = new byte[m_length];
 
             // Copy the data from the old array
-            Array.Copy(m_ILStream, 0, newBytes, 0, m_length);
+            Array.Copy(m_ILStream, newBytes, m_length);
 
             // Do the fixups.
             // This involves iterating over all of the labels and
@@ -253,7 +253,7 @@ namespace System.Reflection.Emit
             }
 
             var temp = new __ExceptionInfo[m_exceptionCount];
-            Array.Copy(m_exceptions, 0, temp, 0, m_exceptionCount);
+            Array.Copy(m_exceptions, temp, m_exceptionCount);
             SortExceptions(temp);
             return temp;
         }
@@ -270,7 +270,7 @@ namespace System.Reflection.Emit
         private void IncreaseCapacity(int size)
         {
             byte[] temp = new byte[Math.Max(m_ILStream.Length * 2, m_length + size)];
-            Array.Copy(m_ILStream, 0, temp, 0, m_ILStream.Length);
+            Array.Copy(m_ILStream, temp, m_ILStream.Length);
             m_ILStream = temp;
         }
 
@@ -355,7 +355,7 @@ namespace System.Reflection.Emit
             }
 
             int[] narrowTokens = new int[m_RelocFixupCount];
-            Array.Copy(m_RelocFixupList, 0, narrowTokens, 0, m_RelocFixupCount);
+            Array.Copy(m_RelocFixupList, narrowTokens, m_RelocFixupCount);
             return narrowTokens;
         }
         #endregion
@@ -1593,15 +1593,15 @@ namespace System.Reflection.Emit
                 // It would probably be simpler to just use Lists here.
                 int newSize = checked(m_iCount * 2);
                 int[] temp = new int[newSize];
-                Array.Copy(m_iOffsets, 0, temp, 0, m_iCount);
+                Array.Copy(m_iOffsets, temp, m_iCount);
                 m_iOffsets = temp;
 
                 ScopeAction[] tempSA = new ScopeAction[newSize];
-                Array.Copy(m_ScopeActions, 0, tempSA, 0, m_iCount);
+                Array.Copy(m_ScopeActions, tempSA, m_iCount);
                 m_ScopeActions = tempSA;
 
                 LocalSymInfo[] tempLSI = new LocalSymInfo[newSize];
-                Array.Copy(m_localSymInfos, 0, tempLSI, 0, m_iCount);
+                Array.Copy(m_localSymInfos, tempLSI, m_iCount);
                 m_localSymInfos = tempLSI;
             }
         }
@@ -1700,7 +1700,7 @@ namespace System.Reflection.Emit
             {
                 // the arrays are full. Enlarge the arrays
                 REDocument[] temp = new REDocument[m_DocumentCount * 2];
-                Array.Copy(m_Documents, 0, temp, 0, m_DocumentCount);
+                Array.Copy(m_Documents, temp, m_DocumentCount);
                 m_Documents = temp;
             }
         }
@@ -1770,23 +1770,23 @@ namespace System.Reflection.Emit
                 // It would probably be simpler to just use Lists here
                 int newSize = checked(m_iLineNumberCount * 2);
                 int[] temp = new int[newSize];
-                Array.Copy(m_iOffsets, 0, temp, 0, m_iLineNumberCount);
+                Array.Copy(m_iOffsets, temp, m_iLineNumberCount);
                 m_iOffsets = temp;
 
                 temp = new int[newSize];
-                Array.Copy(m_iLines, 0, temp, 0, m_iLineNumberCount);
+                Array.Copy(m_iLines, temp, m_iLineNumberCount);
                 m_iLines = temp;
 
                 temp = new int[newSize];
-                Array.Copy(m_iColumns, 0, temp, 0, m_iLineNumberCount);
+                Array.Copy(m_iColumns, temp, m_iLineNumberCount);
                 m_iColumns = temp;
 
                 temp = new int[newSize];
-                Array.Copy(m_iEndLines, 0, temp, 0, m_iLineNumberCount);
+                Array.Copy(m_iEndLines, temp, m_iLineNumberCount);
                 m_iEndLines = temp;
 
                 temp = new int[newSize];
-                Array.Copy(m_iEndColumns, 0, temp, 0, m_iLineNumberCount);
+                Array.Copy(m_iEndColumns, temp, m_iLineNumberCount);
                 m_iEndColumns = temp;
             }
         }
@@ -1797,19 +1797,19 @@ namespace System.Reflection.Emit
                 return;
             // reduce the array size to be exact
             int[] iOffsetsTemp = new int[m_iLineNumberCount];
-            Array.Copy(m_iOffsets, 0, iOffsetsTemp, 0, m_iLineNumberCount);
+            Array.Copy(m_iOffsets, iOffsetsTemp, m_iLineNumberCount);
 
             int[] iLinesTemp = new int[m_iLineNumberCount];
-            Array.Copy(m_iLines, 0, iLinesTemp, 0, m_iLineNumberCount);
+            Array.Copy(m_iLines, iLinesTemp, m_iLineNumberCount);
 
             int[] iColumnsTemp = new int[m_iLineNumberCount];
-            Array.Copy(m_iColumns, 0, iColumnsTemp, 0, m_iLineNumberCount);
+            Array.Copy(m_iColumns, iColumnsTemp, m_iLineNumberCount);
 
             int[] iEndLinesTemp = new int[m_iLineNumberCount];
-            Array.Copy(m_iEndLines, 0, iEndLinesTemp, 0, m_iLineNumberCount);
+            Array.Copy(m_iEndLines, iEndLinesTemp, m_iLineNumberCount);
 
             int[] iEndColumnsTemp = new int[m_iLineNumberCount];
-            Array.Copy(m_iEndColumns, 0, iEndColumnsTemp, 0, m_iLineNumberCount);
+            Array.Copy(m_iEndColumns, iEndColumnsTemp, m_iLineNumberCount);
 
             symWriter.DefineSequencePoints(m_document, iOffsetsTemp, iLinesTemp, iColumnsTemp, iEndLinesTemp, iEndColumnsTemp);
         }

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -118,7 +118,7 @@ namespace System.Reflection.Emit
             if (parameterTypes != null)
             {
                 m_parameterTypes = new Type[parameterTypes.Length];
-                Array.Copy(parameterTypes, 0, m_parameterTypes, 0, parameterTypes.Length);
+                Array.Copy(parameterTypes, m_parameterTypes, parameterTypes.Length);
             }
             else
             {
@@ -718,7 +718,7 @@ namespace System.Reflection.Emit
             if (parameterTypes != null)
             {
                 m_parameterTypes = new Type[parameterTypes.Length];
-                Array.Copy(parameterTypes, 0, m_parameterTypes, 0, parameterTypes.Length);
+                Array.Copy(parameterTypes, m_parameterTypes, parameterTypes.Length);
             }
 
             m_returnTypeRequiredCustomModifiers = returnTypeRequiredCustomModifiers;
@@ -906,7 +906,7 @@ namespace System.Reflection.Emit
             else if (m_iNameSpaceCount == m_namespace.Length)
             {
                 string[] strTemp = new string[checked(m_iNameSpaceCount * 2)];
-                Array.Copy(m_namespace, 0, strTemp, 0, m_iNameSpaceCount);
+                Array.Copy(m_namespace, strTemp, m_iNameSpaceCount);
                 m_namespace = strTemp;
             }
         }
@@ -928,23 +928,23 @@ namespace System.Reflection.Emit
                 // why aren't we just using lists here?
                 int newSize = checked(m_iLocalSymCount * 2);
                 int[] temp = new int[newSize];
-                Array.Copy(m_iLocalSlot, 0, temp, 0, m_iLocalSymCount);
+                Array.Copy(m_iLocalSlot, temp, m_iLocalSymCount);
                 m_iLocalSlot = temp;
 
                 temp = new int[newSize];
-                Array.Copy(m_iStartOffset, 0, temp, 0, m_iLocalSymCount);
+                Array.Copy(m_iStartOffset, temp, m_iLocalSymCount);
                 m_iStartOffset = temp;
 
                 temp = new int[newSize];
-                Array.Copy(m_iEndOffset, 0, temp, 0, m_iLocalSymCount);
+                Array.Copy(m_iEndOffset, temp, m_iLocalSymCount);
                 m_iEndOffset = temp;
 
                 string[] strTemp = new string[newSize];
-                Array.Copy(m_strName, 0, strTemp, 0, m_iLocalSymCount);
+                Array.Copy(m_strName, strTemp, m_iLocalSymCount);
                 m_strName = strTemp;
 
                 byte[][] ubTemp = new byte[newSize][];
-                Array.Copy(m_ubSignature, 0, ubTemp, 0, m_iLocalSymCount);
+                Array.Copy(m_ubSignature, ubTemp, m_iLocalSymCount);
                 m_ubSignature = ubTemp;
             }
         }

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/SignatureHelper.cs
@@ -857,7 +857,7 @@ namespace System.Reflection.Emit
             if (m_signature.Length > m_currSig)
             {
                 byte[] temp = new byte[m_currSig];
-                Array.Copy(m_signature, 0, temp, 0, m_currSig);
+                Array.Copy(m_signature, temp, m_currSig);
                 m_signature = temp;
             }
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolMethod.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolMethod.cs
@@ -37,7 +37,7 @@ namespace System.Reflection.Emit
             if (parameterTypes != null)
             {
                 m_parameterTypes = new Type[parameterTypes.Length];
-                Array.Copy(parameterTypes, 0, m_parameterTypes, 0, parameterTypes.Length);
+                Array.Copy(parameterTypes, m_parameterTypes, parameterTypes.Length);
             }
             else
             {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolType.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolType.cs
@@ -243,9 +243,9 @@ namespace System.Reflection.Emit
             {
                 // resize the bound array
                 int[] iaTemp = new int[m_cRank * 2];
-                Array.Copy(m_iaLowerBound, 0, iaTemp, 0, m_cRank);
+                Array.Copy(m_iaLowerBound, iaTemp, m_cRank);
                 m_iaLowerBound = iaTemp;
-                Array.Copy(m_iaUpperBound, 0, iaTemp, 0, m_cRank);
+                Array.Copy(m_iaUpperBound, iaTemp, m_cRank);
                 m_iaUpperBound = iaTemp;
             }
 

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -206,7 +206,7 @@ namespace System.Reflection
                 return parameters;
 
             ParameterInfo[] ret = new ParameterInfo[parameters.Length];
-            Array.Copy(parameters, 0, ret, 0, parameters.Length);
+            Array.Copy(parameters, ret, parameters.Length);
             return ret;
         }
 

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -303,7 +303,7 @@ namespace System.Reflection
 
             ParameterInfo[] ret = new ParameterInfo[parameters.Length];
 
-            Array.Copy(parameters, 0, ret, 0, parameters.Length);
+            Array.Copy(parameters, ret, parameters.Length);
 
             return ret;
         }

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -268,7 +268,7 @@ namespace System.Reflection
 
             ParameterInfo[] ret = new ParameterInfo[numParams];
 
-            Array.Copy(indexParams, 0, ret, 0, numParams);
+            Array.Copy(indexParams, ret, numParams);
 
             return ret;
         }

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -687,7 +687,7 @@ namespace System.Runtime.InteropServices
             object?[] objects = GetObjectsForNativeVariants(aSrcNativeVariant, cVars);
 
             T[] result = new T[objects.Length];
-            Array.Copy(objects, 0, result, 0, objects.Length);
+            Array.Copy(objects, result, objects.Length);
 
             return result;
         }


### PR DESCRIPTION
The simple Array.Copy overload does not come with a performance penalty anymore.