### PR TITLE
Reduce unneeded forcing to boolean

### DIFF
--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -177,19 +177,14 @@ bool GCToEEInterface::IsPreemptiveGCDisabled()
 
 bool GCToEEInterface::EnablePreemptiveGC()
 {
-    bool bToggleGC = false;
     Thread* pThread = ::GetThread();
-
-    if (pThread)
+    if (pThread && pThread->PreemptiveGCDisabled())
     {
-        bToggleGC = !!pThread->PreemptiveGCDisabled();
-        if (bToggleGC)
-        {
-            pThread->EnablePreemptiveGC();
-        }
+        pThread->EnablePreemptiveGC();
+        return true;
     }
 
-    return bToggleGC;
+    return false;
 }
 
 void GCToEEInterface::DisablePreemptiveGC()

--- a/src/gc/sample/gcenv.h
+++ b/src/gc/sample/gcenv.h
@@ -92,7 +92,7 @@ struct alloc_context;
 
 class Thread
 {
-    uint32_t m_fPreemptiveGCDisabled;
+    bool m_fPreemptiveGCDisabled;
     uintptr_t m_alloc_context[16]; // Reserve enough space to fix allocation context
 
     friend class ThreadStore;
@@ -105,7 +105,7 @@ public:
 
     bool PreemptiveGCDisabled()
     {
-        return !!m_fPreemptiveGCDisabled;
+        return m_fPreemptiveGCDisabled;
     }
 
     void EnablePreemptiveGC()

--- a/src/gc/unix/events.cpp
+++ b/src/gc/unix/events.cpp
@@ -146,7 +146,7 @@ public:
             TimeSpecAdd(&endTime, milliseconds);
         }
 #else
-#error "Don't know how to perfom timed wait on this platform"
+#error "Don't know how to perform timed wait on this platform"
 #endif
 
         int st = 0;

--- a/src/md/enc/metamodelrw.cpp
+++ b/src/md/enc/metamodelrw.cpp
@@ -1422,7 +1422,7 @@ CMiniMdRW::InitOnMem(
         int         iCol;
 
         // Look at all the tables, or until mixed sizes are discovered.
-        for (i=0; i<(int)m_TblCount && fMixed == false; i++)
+        for (i=0; i<(int)m_TblCount && !fMixed; i++)
         {   // Look at all the columns of the table.
             pCols = m_TableDefs[i].m_pColDefs;
             for (iCol = 0; iCol < m_TableDefs[i].m_cCols && !fMixed; iCol++)
@@ -1430,15 +1430,13 @@ CMiniMdRW::InitOnMem(
                 if (!IsFixedType(m_TableDefs[i].m_pColDefs[iCol].m_Type))
                 {   // If this is the first non-fixed size column...
                     if (iSize == 0)
-                    {   // remember it's size.
+                    {   // remember its size.
                         iSize = m_TableDefs[i].m_pColDefs[iCol].m_cbColumn;
                     }
-                    else
-                    {   // Not first non-fixed size, so if a different size...
-                        if (iSize != m_TableDefs[i].m_pColDefs[iCol].m_cbColumn)
-                        {   // ...the table has mixed column sizes.
-                            fMixed = true;
-                        }
+                    else if (iSize != m_TableDefs[i].m_pColDefs[iCol].m_cbColumn)
+                    {   // Not first non-fixed size, so if a different size
+                        //  the table has mixed column sizes.
+                        fMixed = true;
                     }
                 }
             }
@@ -1449,18 +1447,15 @@ CMiniMdRW::InitOnMem(
             IfFailGo(ExpandTables());
             ComputeGrowLimits(FALSE /* ! small*/);
         }
+        else if (iSize == 2)
+        {
+            // small schema
+            ComputeGrowLimits(TRUE /* small */);
+        }
         else
         {
-            if (iSize == 2)
-            {
-                // small schema
-                ComputeGrowLimits(TRUE /* small */);
-            }
-            else
-            {
-                // large schema
-                ComputeGrowLimits(FALSE /* ! small */);
-            }
+            // large schema
+            ComputeGrowLimits(FALSE /* ! small */);
         }
     }
     else

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -369,31 +369,23 @@ bool GCToEEInterface::IsPreemptiveGCDisabled()
     WRAPPER_NO_CONTRACT;
 
     Thread* pThread = ::GetThread();
-    if (pThread)
-    {
-        return !!pThread->PreemptiveGCDisabled();
-    }
-
-    return false;
+    
+    return (pThread && pThread->PreemptiveGCDisabled());
 }
 
 bool GCToEEInterface::EnablePreemptiveGC()
 {
     WRAPPER_NO_CONTRACT;
 
-    bool bToggleGC = false;
     Thread* pThread = ::GetThread();
 
-    if (pThread)
+    if (pThread && pThread->PreemptiveGCDisabled())
     {
-        bToggleGC = !!pThread->PreemptiveGCDisabled();
-        if (bToggleGC)
-        {
-            pThread->EnablePreemptiveGC();
-        }
+        pThread->EnablePreemptiveGC();
+        return true;
     }
 
-    return bToggleGC;
+    return false;
 }
 
 void GCToEEInterface::DisablePreemptiveGC()


### PR DESCRIPTION
In a couple of files related to GC, there is the problem in which whenever one runs the getter pThread->PreemptiveGCDisabled(), the getter checks to see if the member variable m_fPreemptiveGCDisabled is 0 or not, AND then the value of that expression is checked to be 1 or 0 AGAIN.

This is unnecessary and now only does this check when running the getter.