### PR TITLE
Arm64: Add S.P.CoreLib instrinsics for AddAcross

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.PlatformNotSupported.cs
@@ -47,6 +47,66 @@ namespace System.Runtime.Intrinsics.Arm
             public static Vector128<double> Add(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
+            /// uint8_t vaddv_u8(uint8x8_t a)
+            ///   A64: ADDV Bd, Vn.8B
+            /// </summary>
+            public static byte AddAcross(Vector64<byte> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// int16_t vaddv_s16(int16x4_t a)
+            ///   A64: ADDV Hd, Vn.4H
+            /// </summary>
+            public static short AddAcross(Vector64<short> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// int8_t vaddv_s8(int8x8_t a)
+            ///   A64: ADDV Bd, Vn.8B
+            /// </summary>
+            public static sbyte AddAcross(Vector64<sbyte> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// uint16_t vaddv_u16(uint16x4_t a)
+            ///   A64: ADDV Hd, Vn.4H
+            /// </summary>
+            public static ushort AddAcross(Vector64<ushort> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// uint8_t vaddvq_u8(uint8x16_t a)
+            ///   A64: ADDV Bd, Vn.16B
+            /// </summary>
+            public static byte AddAcross(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// int16_t vaddvq_s16(int16x8_t a)
+            ///   A64: ADDV Hd, Vn.8H
+            /// </summary>
+            public static short AddAcross(Vector128<short> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// int32_t vaddvq_s32(int32x4_t a)
+            ///   A64: ADDV Sd, Vn.4S
+            /// </summary>
+            public static int AddAcross(Vector128<int> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// int8_t vaddvq_s8(int8x16_t a)
+            ///   A64: ADDV Bd, Vn.16B
+            /// </summary>
+            public static sbyte AddAcross(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// uint16_t vaddvq_u16(uint16x8_t a)
+            ///   A64: ADDV Hd, Vn.8H
+            /// </summary>
+            public static ushort AddAcross(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// uint32_t vaddvq_u32(uint32x4_t a)
+            ///   A64: ADDV Sd, Vn.4S
+            /// </summary>
+            public static uint AddAcross(Vector128<uint> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
             /// float64x2_t vsubq_f64 (float64x2_t a, float64x2_t b)
             ///   A64: FSUB Vd.2D, Vn.2D, Vm.2D
             /// </summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.cs
@@ -49,6 +49,66 @@ namespace System.Runtime.Intrinsics.Arm
             public static Vector128<double> Add(Vector128<double> left, Vector128<double> right) => Add(left, right);
 
             /// <summary>
+            /// uint8_t vaddv_u8(uint8x8_t a)
+            ///   A64: ADDV Bd, Vn.8B
+            /// </summary>
+            public static byte AddAcross(Vector64<byte> value) => AddAcross(value);
+
+            /// <summary>
+            /// int16_t vaddv_s16(int16x4_t a)
+            ///   A64: ADDV Hd, Vn.4H
+            /// </summary>
+            public static short AddAcross(Vector64<short> value) => AddAcross(value);
+
+            /// <summary>
+            /// int8_t vaddv_s8(int8x8_t a)
+            ///   A64: ADDV Bd, Vn.8B
+            /// </summary>
+            public static sbyte AddAcross(Vector64<sbyte> value) => AddAcross(value);
+
+            /// <summary>
+            /// uint16_t vaddv_u16(uint16x4_t a)
+            ///   A64: ADDV Hd, Vn.4H
+            /// </summary>
+            public static ushort AddAcross(Vector64<ushort> value) => AddAcross(value);
+
+            /// <summary>
+            /// uint8_t vaddvq_u8(uint8x16_t a)
+            ///   A64: ADDV Bd, Vn.16B
+            /// </summary>
+            public static byte AddAcross(Vector128<byte> value) => AddAcross(value);
+
+            /// <summary>
+            /// int16_t vaddvq_s16(int16x8_t a)
+            ///   A64: ADDV Hd, Vn.8H
+            /// </summary>
+            public static short AddAcross(Vector128<short> value) => AddAcross(value);
+
+            /// <summary>
+            /// int32_t vaddvq_s32(int32x4_t a)
+            ///   A64: ADDV Sd, Vn.4S
+            /// </summary>
+            public static int AddAcross(Vector128<int> value) => AddAcross(value);
+
+            /// <summary>
+            /// int8_t vaddvq_s8(int8x16_t a)
+            ///   A64: ADDV Bd, Vn.16B
+            /// </summary>
+            public static sbyte AddAcross(Vector128<sbyte> value) => AddAcross(value);
+
+            /// <summary>
+            /// uint16_t vaddvq_u16(uint16x8_t a)
+            ///   A64: ADDV Hd, Vn.8H
+            /// </summary>
+            public static ushort AddAcross(Vector128<ushort> value) => AddAcross(value);
+
+            /// <summary>
+            /// uint32_t vaddvq_u32(uint32x4_t a)
+            ///   A64: ADDV Sd, Vn.4S
+            /// </summary>
+            public static uint AddAcross(Vector128<uint> value) => AddAcross(value);
+
+            /// <summary>
             /// float64x2_t vsubq_f64 (float64x2_t a, float64x2_t b)
             ///   A64: FSUB Vd.2D, Vn.2D, Vm.2D
             /// </summary>


### PR DESCRIPTION
This implements the AddAcross intrinsics for Arm64.

`AddAcross` is a sum reduction operation.

See dotnet/corefx#26581 and is split of #26769
CoreFX reference assembly update at https://github.com/dotnet/corefx/pull/42359

/CC @tannergooding @CarolEidt @echesakovMSFT

Thanks,
Tamar