### PR TITLE
Move p/invoke pregeneration out of single-exe branch

### DIFF
--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.Intrinsics.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.Intrinsics.cs
@@ -139,7 +139,7 @@ namespace Internal.JitInterface
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_TypeEQ, "op_Equality", "System", "Type");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_TypeNEQ, "op_Inequality", "System", "Type");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_Object_GetType, "GetType", "System", "Object");
-            // table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_StubHelpers_GetStubContext, "GetStubContext", "System.StubHelpers", "StubHelpers"); // interop-specific
+            table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_StubHelpers_GetStubContext, "GetStubContext", "System.StubHelpers", "StubHelpers"); // interop-specific
             // table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_StubHelpers_GetStubContextAddr, "GetStubContextAddr", "System.StubHelpers", "StubHelpers"); // interop-specific
             // table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_StubHelpers_GetNDirectTarget, "GetNDirectTarget", "System.StubHelpers", "StubHelpers"); // interop-specific
             // table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_InterlockedAdd32, "Add", System.Threading", "Interlocked"); // unused

--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -764,6 +764,15 @@ namespace Internal.JitInterface
         {
             MethodDesc callerMethod = HandleToObject(callerHnd);
             MethodDesc calleeMethod = HandleToObject(calleeHnd);
+
+#if READYTORUN
+            // IL stubs don't inline well
+            if (calleeMethod.IsPInvoke)
+            {
+                return CorInfoInline.INLINE_NEVER;
+            }
+#endif
+
             if (_compilation.CanInline(callerMethod, calleeMethod))
             {
                 // No restrictions on inlining
@@ -3046,7 +3055,13 @@ namespace Internal.JitInterface
                 flags.Set(CorJitFlag.CORJIT_FLAG_REVERSE_PINVOKE);
 
             if (this.MethodBeingCompiled.IsPInvoke)
+            {
                 flags.Set(CorJitFlag.CORJIT_FLAG_IL_STUB);
+
+#if READYTORUN
+                flags.Set(CorJitFlag.CORJIT_FLAG_PUBLISH_SECRET_PARAM);
+#endif
+            }
 
             if (this.MethodBeingCompiled.IsNoOptimization)
                 flags.Set(CorJitFlag.CORJIT_FLAG_MIN_OPT);

--- a/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -349,6 +349,24 @@ namespace Internal.TypeSystem.Ecma
                         }
                     }
                     break;
+                case NativeTypeKind.SafeArray:
+                    {
+                        // There's nobody to consume SafeArrays, so let's just parse the data
+                        // to avoid asserting later.
+
+                        // Get optional VARTYPE for the element
+                        if (_reader.RemainingBytes != 0)
+                        {
+                            _reader.ReadCompressedInteger();
+                        }
+
+                        // VARTYPE can be followed by optional type name
+                        if (_reader.RemainingBytes != 0)
+                        {
+                            _reader.ReadSerializedString();
+                        }
+                    }
+                    break;
                 default:
                     break;
             }

--- a/src/tools/crossgen2/Common/TypeSystem/IL/EcmaMethodIL.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/IL/EcmaMethodIL.cs
@@ -43,6 +43,14 @@ namespace Internal.IL
             _clearInitLocals = clearInitLocals;
         }
 
+        public EcmaModule Module
+        {
+            get
+            {
+                return _module;
+            }
+        }
+
         public override MethodDesc OwningMethod
         {
             get

--- a/src/tools/crossgen2/Common/TypeSystem/IL/Stubs/PInvokeILCodeStreams.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/IL/Stubs/PInvokeILCodeStreams.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.IL.Stubs
+{
+    internal sealed class PInvokeILCodeStreams
+    {
+        public ILEmitter Emitter { get; }
+        public ILCodeStream FunctionPointerLoadStream { get; }
+        public ILCodeStream MarshallingCodeStream { get; }
+        public ILCodeStream CallsiteSetupCodeStream { get; }
+        public ILCodeStream ReturnValueMarshallingCodeStream { get; }
+        public ILCodeStream UnmarshallingCodestream { get; }
+        public PInvokeILCodeStreams()
+        {
+            Emitter = new ILEmitter();
+
+            // We have 4 code streams:
+            // - _marshallingCodeStream is used to convert each argument into a native type and 
+            // store that into the local
+            // - callsiteSetupCodeStream is used to used to load each previously generated local
+            // and call the actual target native method.
+            // - _returnValueMarshallingCodeStream is used to convert the native return value 
+            // to managed one.
+            // - _unmarshallingCodestream is used to propagate [out] native arguments values to 
+            // managed ones.
+            FunctionPointerLoadStream = Emitter.NewCodeStream();
+            MarshallingCodeStream = Emitter.NewCodeStream();
+            CallsiteSetupCodeStream = Emitter.NewCodeStream();
+            ReturnValueMarshallingCodeStream = Emitter.NewCodeStream();
+            UnmarshallingCodestream = Emitter.NewCodeStream();
+        }
+
+        public PInvokeILCodeStreams(ILEmitter emitter, ILCodeStream codeStream)
+        {
+            Emitter = emitter;
+            MarshallingCodeStream = codeStream;
+        }
+    }
+}

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -1,0 +1,693 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Internal.IL;
+using Debug = System.Diagnostics.Debug;
+using Internal.IL.Stubs;
+
+namespace Internal.TypeSystem.Interop
+{
+    public static partial class MarshalHelpers
+    {
+        internal static TypeDesc GetNativeTypeFromMarshallerKind(TypeDesc type, 
+                MarshallerKind kind, 
+                MarshallerKind elementMarshallerKind,
+#if !READYTORUN
+                InteropStateManager interopStateManager,
+#endif
+                MarshalAsDescriptor marshalAs,
+                bool isArrayElement = false)
+        {
+            TypeSystemContext context = type.Context;
+            NativeTypeKind nativeType = NativeTypeKind.Invalid;
+            if (marshalAs != null)
+            {
+                nativeType = isArrayElement ? marshalAs.ArraySubType : marshalAs.Type;
+            }
+
+            switch (kind)
+            {
+                case MarshallerKind.BlittableValue:
+                    {
+                        switch (nativeType)
+                        {
+                            case NativeTypeKind.I1:
+                                return context.GetWellKnownType(WellKnownType.SByte);
+                            case NativeTypeKind.U1:
+                                return context.GetWellKnownType(WellKnownType.Byte);
+                            case NativeTypeKind.I2:
+                                return context.GetWellKnownType(WellKnownType.Int16);
+                            case NativeTypeKind.U2:
+                                return context.GetWellKnownType(WellKnownType.UInt16);
+                            case NativeTypeKind.I4:
+                                return context.GetWellKnownType(WellKnownType.Int32);
+                            case NativeTypeKind.U4:
+                                return context.GetWellKnownType(WellKnownType.UInt32);
+                            case NativeTypeKind.I8:
+                                return context.GetWellKnownType(WellKnownType.Int64);
+                            case NativeTypeKind.U8:
+                                return context.GetWellKnownType(WellKnownType.UInt64);
+                            case NativeTypeKind.R4:
+                                return context.GetWellKnownType(WellKnownType.Single);
+                            case NativeTypeKind.R8:
+                                return context.GetWellKnownType(WellKnownType.Double);
+                            default:
+                                return type.UnderlyingType;
+                        }
+                    }
+
+                case MarshallerKind.Bool:
+                    return context.GetWellKnownType(WellKnownType.Int32);
+
+                case MarshallerKind.CBool:
+                        return context.GetWellKnownType(WellKnownType.Byte);
+
+                case MarshallerKind.Enum:
+                case MarshallerKind.BlittableStruct:
+                case MarshallerKind.Decimal:
+                case MarshallerKind.VoidReturn:
+                    return type;
+
+#if !READYTORUN
+                case MarshallerKind.Struct:
+                case MarshallerKind.LayoutClass:
+                    return interopStateManager.GetStructMarshallingNativeType((MetadataType)type);
+#endif
+
+                case MarshallerKind.BlittableStructPtr:
+                    return type.MakePointerType();
+
+                case MarshallerKind.HandleRef:
+                    return context.GetWellKnownType(WellKnownType.IntPtr);
+
+                case MarshallerKind.UnicodeChar:
+                    if (nativeType == NativeTypeKind.U2)
+                        return context.GetWellKnownType(WellKnownType.UInt16);
+                    else
+                        return context.GetWellKnownType(WellKnownType.Int16);
+
+                case MarshallerKind.OleDateTime:
+                    return context.GetWellKnownType(WellKnownType.Double);
+
+                case MarshallerKind.SafeHandle:
+                case MarshallerKind.CriticalHandle:
+                    return context.GetWellKnownType(WellKnownType.IntPtr);
+
+                case MarshallerKind.UnicodeString:
+                case MarshallerKind.UnicodeStringBuilder:
+                    return context.GetWellKnownType(WellKnownType.Char).MakePointerType();
+
+                case MarshallerKind.AnsiString:
+                case MarshallerKind.AnsiStringBuilder:
+                case MarshallerKind.UTF8String:
+                    return context.GetWellKnownType(WellKnownType.Byte).MakePointerType();
+
+                case MarshallerKind.BlittableArray:
+                case MarshallerKind.Array:
+                case MarshallerKind.AnsiCharArray:
+                    {
+                        ArrayType arrayType = type as ArrayType;
+                        Debug.Assert(arrayType != null, "Expecting array");
+
+                        //
+                        // We need to construct the unsafe array from the right unsafe array element type
+                        //
+                        TypeDesc elementNativeType = GetNativeTypeFromMarshallerKind(
+                            arrayType.ElementType,
+                            elementMarshallerKind,
+                            MarshallerKind.Unknown,
+#if !READYTORUN
+                            interopStateManager,
+#endif
+                            marshalAs, 
+                            isArrayElement: true);
+
+                        return elementNativeType.MakePointerType();
+                    }
+
+                case MarshallerKind.AnsiChar:
+                    return context.GetWellKnownType(WellKnownType.Byte);
+
+                case MarshallerKind.FunctionPointer:
+                    return context.GetWellKnownType(WellKnownType.IntPtr);
+
+#if !READYTORUN
+                case MarshallerKind.ByValUnicodeString:
+                case MarshallerKind.ByValAnsiString:
+                    {
+                        var inlineArrayCandidate = GetInlineArrayCandidate(context.GetWellKnownType(WellKnownType.Char), elementMarshallerKind, interopStateManager, marshalAs);
+                        return interopStateManager.GetInlineArrayType(inlineArrayCandidate);
+                    }
+
+                case MarshallerKind.ByValAnsiCharArray:
+                case MarshallerKind.ByValArray:
+                    {
+                        ArrayType arrayType = type as ArrayType;
+                        Debug.Assert(arrayType != null, "Expecting array");
+
+                        var inlineArrayCandidate = GetInlineArrayCandidate(arrayType.ElementType, elementMarshallerKind, interopStateManager, marshalAs);
+
+                        return interopStateManager.GetInlineArrayType(inlineArrayCandidate);
+                    }
+#endif
+
+                case MarshallerKind.LayoutClassPtr:
+                case MarshallerKind.AsAnyA:
+                case MarshallerKind.AsAnyW:
+                    return context.GetWellKnownType(WellKnownType.IntPtr);
+
+                case MarshallerKind.Unknown:
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        internal static MarshallerKind GetMarshallerKind(
+             TypeDesc type,
+             MarshalAsDescriptor marshalAs,
+             bool isReturn,
+             bool isAnsi,
+             MarshallerType marshallerType,
+             out MarshallerKind elementMarshallerKind)
+        {
+            if (type.IsByRef)
+            {
+                type = type.GetParameterType();
+            }
+            TypeSystemContext context = type.Context;
+            NativeTypeKind nativeType = NativeTypeKind.Invalid;
+            bool isField = marshallerType == MarshallerType.Field;
+
+            if (marshalAs != null)
+                nativeType = (NativeTypeKind)marshalAs.Type;
+
+
+            elementMarshallerKind = MarshallerKind.Invalid;
+
+            //
+            // Determine MarshalerKind
+            //
+            // This mostly resembles desktop CLR and .NET Native code as we need to match their behavior
+            // 
+            if (type.IsPrimitive)
+            {
+                switch (type.Category)
+                {
+                    case TypeFlags.Void:
+                        return MarshallerKind.VoidReturn;
+
+                    case TypeFlags.Boolean:
+                        switch (nativeType)
+                        {
+                            case NativeTypeKind.Invalid:
+                            case NativeTypeKind.Boolean:
+                                return MarshallerKind.Bool;
+
+                            case NativeTypeKind.U1:
+                            case NativeTypeKind.I1:
+                                return MarshallerKind.CBool;
+
+                            default:
+                                return MarshallerKind.Invalid;
+                        }
+
+                    case TypeFlags.Char:
+                        switch (nativeType)
+                        {
+                            case NativeTypeKind.I1:
+                            case NativeTypeKind.U1:
+                                return MarshallerKind.AnsiChar;
+
+                            case NativeTypeKind.I2:
+                            case NativeTypeKind.U2:
+                                return MarshallerKind.UnicodeChar;
+
+                            case NativeTypeKind.Invalid:
+                                if (isAnsi)
+                                    return MarshallerKind.AnsiChar;
+                                else
+                                    return MarshallerKind.UnicodeChar;
+                            default:
+                                return MarshallerKind.Invalid;
+                        }
+
+                    case TypeFlags.SByte:
+                    case TypeFlags.Byte:
+                        if (nativeType == NativeTypeKind.I1 || nativeType == NativeTypeKind.U1 || nativeType == NativeTypeKind.Invalid)
+                            return MarshallerKind.BlittableValue;
+                        else
+                            return MarshallerKind.Invalid;
+
+                    case TypeFlags.Int16:
+                    case TypeFlags.UInt16:
+                        if (nativeType == NativeTypeKind.I2 || nativeType == NativeTypeKind.U2 || nativeType == NativeTypeKind.Invalid)
+                            return MarshallerKind.BlittableValue;
+                        else
+                            return MarshallerKind.Invalid;
+
+                    case TypeFlags.Int32:
+                    case TypeFlags.UInt32:
+                        if (nativeType == NativeTypeKind.I4 || nativeType == NativeTypeKind.U4 || nativeType == NativeTypeKind.Invalid)
+                            return MarshallerKind.BlittableValue;
+                        else
+                            return MarshallerKind.Invalid;
+
+                    case TypeFlags.Int64:
+                    case TypeFlags.UInt64:
+                        if (nativeType == NativeTypeKind.I8 || nativeType == NativeTypeKind.U8 || nativeType == NativeTypeKind.Invalid)
+                            return MarshallerKind.BlittableValue;
+                        else
+                            return MarshallerKind.Invalid;
+
+                    case TypeFlags.IntPtr:
+                    case TypeFlags.UIntPtr:
+                        if (nativeType == NativeTypeKind.Invalid)
+                            return MarshallerKind.BlittableValue;
+                        else
+                            return MarshallerKind.Invalid;
+
+                    case TypeFlags.Single:
+                        if (nativeType == NativeTypeKind.R4 || nativeType == NativeTypeKind.Invalid)
+                            return MarshallerKind.BlittableValue;
+                        else
+                            return MarshallerKind.Invalid;
+
+                    case TypeFlags.Double:
+                        if (nativeType == NativeTypeKind.R8 || nativeType == NativeTypeKind.Invalid)
+                            return MarshallerKind.BlittableValue;
+                        else
+                            return MarshallerKind.Invalid;
+
+                    default:
+                        return MarshallerKind.Invalid;
+                }
+            }
+            else if (type.IsValueType)
+            {
+                if (type.IsEnum)
+                    return MarshallerKind.Enum;
+
+                if (InteropTypes.IsSystemDateTime(context, type))
+                {
+                    if (nativeType == NativeTypeKind.Invalid ||
+                        nativeType == NativeTypeKind.Struct)
+                        return MarshallerKind.OleDateTime;
+                    else
+                        return MarshallerKind.Invalid;
+                }
+                else if (InteropTypes.IsHandleRef(context, type))
+                {
+                    if (nativeType == NativeTypeKind.Invalid)
+                        return MarshallerKind.HandleRef;
+                    else
+                        return MarshallerKind.Invalid;
+                }
+
+                switch (nativeType)
+                {
+                    case NativeTypeKind.Invalid:
+                    case NativeTypeKind.Struct:
+                        if (InteropTypes.IsSystemDecimal(context, type))
+                            return MarshallerKind.Decimal;
+                        break;
+
+                    case NativeTypeKind.LPStruct:
+                        if (InteropTypes.IsSystemGuid(context, type) ||
+                            InteropTypes.IsSystemDecimal(context, type))
+                        {
+                            if (isField || isReturn)
+                                return MarshallerKind.Invalid;
+                            else
+                                return MarshallerKind.BlittableStructPtr;
+                        }
+                        break;
+
+                    default:
+                        return MarshallerKind.Invalid;
+                }
+
+                if (type is MetadataType)
+                {
+                    MetadataType metadataType = (MetadataType)type;
+                    // the struct type need to be either sequential or explicit. If it is
+                    // auto layout we will throw exception.
+                    if (!metadataType.HasLayout())
+                    {
+                        throw new InvalidProgramException("The specified structure " + metadataType.Name + " has invalid StructLayout information. It must be either Sequential or Explicit.");
+                    }
+                }
+
+                if (MarshalUtils.IsBlittableType(type))
+                {
+                    return MarshallerKind.BlittableStruct;
+                }
+                else
+                {
+                    return MarshallerKind.Struct;
+                }
+            }
+            else if (type.IsSzArray)
+            {
+                if (nativeType == NativeTypeKind.Invalid)
+                    nativeType = NativeTypeKind.Array;
+
+                switch (nativeType)
+                {
+                    case NativeTypeKind.Array:
+                        {
+                            if (isField || isReturn)
+                                return MarshallerKind.Invalid;
+
+                            var arrayType = (ArrayType)type;
+
+                            elementMarshallerKind = GetArrayElementMarshallerKind(
+                                arrayType,
+                                marshalAs,
+                                isAnsi);
+
+                            // If element is invalid type, the array itself is invalid
+                            if (elementMarshallerKind == MarshallerKind.Invalid)
+                                return MarshallerKind.Invalid;
+
+                            if (elementMarshallerKind == MarshallerKind.AnsiChar)
+                                return MarshallerKind.AnsiCharArray;
+                            else if (elementMarshallerKind == MarshallerKind.UnicodeChar    // Arrays of unicode char should be marshalled as blittable arrays
+                                || elementMarshallerKind == MarshallerKind.Enum
+                                || elementMarshallerKind == MarshallerKind.BlittableValue)
+                                return MarshallerKind.BlittableArray;
+                            else
+                                return MarshallerKind.Array;
+                        }
+
+                    case NativeTypeKind.ByValArray:         // fix sized array
+                        {
+                            var arrayType = (ArrayType)type;
+                            elementMarshallerKind = GetArrayElementMarshallerKind(
+                                arrayType,
+                                marshalAs,
+                                isAnsi);
+
+                            // If element is invalid type, the array itself is invalid
+                            if (elementMarshallerKind == MarshallerKind.Invalid)
+                                return MarshallerKind.Invalid;
+
+                            if (elementMarshallerKind == MarshallerKind.AnsiChar)
+                                return MarshallerKind.ByValAnsiCharArray;
+                            else
+                                return MarshallerKind.ByValArray;
+                        }
+
+                    default:
+                        return MarshallerKind.Invalid;
+                }
+            }
+            else if (type.IsPointer || type.IsFunctionPointer)
+            {
+                if (nativeType == NativeTypeKind.Invalid)
+                    return MarshallerKind.BlittableValue;
+                else
+                    return MarshallerKind.Invalid;
+            }
+            else if (type.IsDelegate)
+            {
+                if (nativeType == NativeTypeKind.Invalid || nativeType == NativeTypeKind.Func)
+                    return MarshallerKind.FunctionPointer;
+                else
+                    return MarshallerKind.Invalid;
+            }
+            else if (type.IsString)
+            {
+                switch (nativeType)
+                {
+                    case NativeTypeKind.LPWStr:
+                        return MarshallerKind.UnicodeString;
+
+                    case NativeTypeKind.LPStr:
+                        return MarshallerKind.AnsiString;
+
+                    case NativeTypeKind.LPUTF8Str:
+                        return MarshallerKind.UTF8String;
+
+                    case NativeTypeKind.LPTStr:
+                        return MarshallerKind.UnicodeString;
+
+                    case NativeTypeKind.ByValTStr:
+                        if (isAnsi)
+                        {
+                            elementMarshallerKind = MarshallerKind.AnsiChar;
+                            return MarshallerKind.ByValAnsiString;
+                        }
+                        else
+                        {
+                            elementMarshallerKind = MarshallerKind.UnicodeChar;
+                            return MarshallerKind.ByValUnicodeString;
+                        }
+
+                    case NativeTypeKind.Invalid:
+                        if (isAnsi)
+                            return MarshallerKind.AnsiString;
+                        else
+                            return MarshallerKind.UnicodeString;
+
+                    default:
+                        return MarshallerKind.Invalid;
+                }
+            }
+            else if (type.IsObject)
+            {
+                if (nativeType == NativeTypeKind.AsAny)
+                    return isAnsi ? MarshallerKind.AsAnyA : MarshallerKind.AsAnyW;
+                else
+                    return MarshallerKind.Invalid;
+            }
+            else if (InteropTypes.IsStringBuilder(context, type))
+            {
+                switch (nativeType)
+                {
+                    case NativeTypeKind.Invalid:
+                        if (isAnsi)
+                        {
+                            return MarshallerKind.AnsiStringBuilder;
+                        }
+                        else
+                        {
+                            return MarshallerKind.UnicodeStringBuilder;
+                        }
+
+                    case NativeTypeKind.LPStr:
+                        return MarshallerKind.AnsiStringBuilder;
+
+                    case NativeTypeKind.LPWStr:
+                        return MarshallerKind.UnicodeStringBuilder;
+                    default:
+                        return MarshallerKind.Invalid;
+                }
+            }
+            else if (InteropTypes.IsSafeHandle(context, type))
+            {
+                if (nativeType == NativeTypeKind.Invalid)
+                    return MarshallerKind.SafeHandle;
+                else
+                    return MarshallerKind.Invalid;
+            }
+            else if (InteropTypes.IsCriticalHandle(context, type))
+            {
+                if (nativeType == NativeTypeKind.Invalid)
+                    return MarshallerKind.CriticalHandle;
+                else
+                    return MarshallerKind.Invalid;
+            }
+            else if (type is MetadataType mdType && mdType.HasLayout())
+            {
+                if (!isField && nativeType == NativeTypeKind.Invalid || nativeType == NativeTypeKind.LPStruct)
+                    return MarshallerKind.LayoutClassPtr;
+                else if (isField && (nativeType == NativeTypeKind.Invalid || nativeType == NativeTypeKind.Struct))
+                    return MarshallerKind.LayoutClass;
+                else
+                    return MarshallerKind.Invalid;
+            }
+            else
+                return MarshallerKind.Invalid;
+        }
+
+        private static MarshallerKind GetArrayElementMarshallerKind(
+                   ArrayType arrayType,
+                   MarshalAsDescriptor marshalAs,
+                   bool isAnsi)
+        {
+            TypeDesc elementType = arrayType.ElementType;
+            NativeTypeKind nativeType = NativeTypeKind.Invalid;
+            TypeSystemContext context = arrayType.Context;
+
+            if (marshalAs != null)
+                nativeType = (NativeTypeKind)marshalAs.ArraySubType;
+
+            if (elementType.IsPrimitive)
+            {
+                switch (elementType.Category)
+                {
+                    case TypeFlags.Char:
+                        switch (nativeType)
+                        {
+                            case NativeTypeKind.I1:
+                            case NativeTypeKind.U1:
+                                return MarshallerKind.AnsiChar;
+                            case NativeTypeKind.I2:
+                            case NativeTypeKind.U2:
+                                return MarshallerKind.UnicodeChar;
+                            default:
+                                if (isAnsi)
+                                    return MarshallerKind.AnsiChar;
+                                else
+                                    return MarshallerKind.UnicodeChar;
+                        }
+
+                    case TypeFlags.Boolean:
+                        switch (nativeType)
+                        {
+                            case NativeTypeKind.Boolean:
+                                return MarshallerKind.Bool;
+                            case NativeTypeKind.I1:
+                            case NativeTypeKind.U1:
+                                return MarshallerKind.CBool;
+                            case NativeTypeKind.Invalid:
+                            default:
+                                return MarshallerKind.Bool;
+                        }
+                    case TypeFlags.IntPtr:
+                    case TypeFlags.UIntPtr:
+                        return MarshallerKind.BlittableValue;
+
+                    case TypeFlags.Void:
+                        return MarshallerKind.Invalid;
+
+                    case TypeFlags.SByte:
+                    case TypeFlags.Int16:
+                    case TypeFlags.Int32:
+                    case TypeFlags.Int64:
+                    case TypeFlags.Byte:
+                    case TypeFlags.UInt16:
+                    case TypeFlags.UInt32:
+                    case TypeFlags.UInt64:
+                    case TypeFlags.Single:
+                    case TypeFlags.Double:
+                        return MarshallerKind.BlittableValue;
+                    default:
+                        return MarshallerKind.Invalid;
+                }
+            }
+            else if (elementType.IsValueType)
+            {
+                if (elementType.IsEnum)
+                    return MarshallerKind.Enum;
+
+                if (InteropTypes.IsSystemDecimal(context, elementType))
+                {
+                    switch (nativeType)
+                    {
+                        case NativeTypeKind.Invalid:
+                        case NativeTypeKind.Struct:
+                            return MarshallerKind.Decimal;
+
+                        case NativeTypeKind.LPStruct:
+                            return MarshallerKind.BlittableStructPtr;
+
+                        default:
+                            return MarshallerKind.Invalid;
+                    }
+                }
+                else if (InteropTypes.IsSystemGuid(context, elementType))
+                {
+                    switch (nativeType)
+                    {
+                        case NativeTypeKind.Invalid:
+                        case NativeTypeKind.Struct:
+                            return MarshallerKind.BlittableValue;
+
+                        case NativeTypeKind.LPStruct:
+                            return MarshallerKind.BlittableStructPtr;
+
+                        default:
+                            return MarshallerKind.Invalid;
+                    }
+                }
+                else if (InteropTypes.IsSystemDateTime(context, elementType))
+                {
+                    if (nativeType == NativeTypeKind.Invalid ||
+                        nativeType == NativeTypeKind.Struct)
+                    {
+                        return MarshallerKind.OleDateTime;
+                    }
+                    else
+                    {
+                        return MarshallerKind.Invalid;
+                    }
+                }
+                else if (InteropTypes.IsHandleRef(context, elementType))
+                {
+                    if (nativeType == NativeTypeKind.Invalid)
+                        return MarshallerKind.HandleRef;
+                    else
+                        return MarshallerKind.Invalid;
+                }
+                else
+                {
+                    if (MarshalUtils.IsBlittableType(elementType))
+                    {
+                        switch (nativeType)
+                        {
+                            case NativeTypeKind.Invalid:
+                            case NativeTypeKind.Struct:
+                                return MarshallerKind.BlittableStruct;
+
+                            default:
+                                return MarshallerKind.Invalid;
+                        }
+                    }
+                    else
+                    {
+                        // TODO: Differentiate between struct and Union, we only need to support struct not union here
+                        return MarshallerKind.Struct;
+                    }
+                }
+            }
+            else if (elementType.IsPointer || elementType.IsFunctionPointer)
+            {
+                if (nativeType == NativeTypeKind.Invalid)
+                    return MarshallerKind.BlittableValue;
+                else
+                    return MarshallerKind.Invalid;
+            }
+            else if (elementType.IsString)
+            {
+                switch (nativeType)
+                {
+                    case NativeTypeKind.Invalid:
+                        if (isAnsi)
+                            return MarshallerKind.AnsiString;
+                        else
+                            return MarshallerKind.UnicodeString;
+                    case NativeTypeKind.LPStr:
+                        return MarshallerKind.AnsiString;
+                    case NativeTypeKind.LPWStr:
+                        return MarshallerKind.UnicodeString;
+                    default:
+                        return MarshallerKind.Invalid;
+                }
+            }
+            // else if (elementType.IsObject)
+            // {
+            //    if (nativeType == NativeTypeKind.Invalid)
+            //        return MarshallerKind.Variant;
+            //    else
+            //        return MarshallerKind.Invalid;
+            // }
+            else
+            {
+                return MarshallerKind.Invalid;
+            }
+        }
+    }
+}

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1,0 +1,1836 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using Internal.IL.Stubs;
+using Internal.IL;
+
+using Debug = System.Diagnostics.Debug;
+using ILLocalVariable = Internal.IL.Stubs.ILLocalVariable;
+
+namespace Internal.TypeSystem.Interop
+{
+    enum MarshallerKind
+    {
+        Unknown,
+        BlittableValue,
+        Array,
+        BlittableArray,
+        Bool,   // 4 byte bool
+        CBool,  // 1 byte bool
+        Enum,
+        AnsiChar,  // Marshal char (Unicode 16bits) for byte (Ansi 8bits)
+        UnicodeChar,
+        AnsiCharArray,
+        ByValArray,
+        ByValAnsiCharArray, // Particular case of ByValArray because the conversion between wide Char and Byte need special treatment.
+        AnsiString,
+        UnicodeString,
+        UTF8String,
+        ByValAnsiString,
+        ByValUnicodeString,
+        AnsiStringBuilder,
+        UnicodeStringBuilder,
+        FunctionPointer,
+        SafeHandle,
+        CriticalHandle,
+        HandleRef,
+        VoidReturn,
+        Variant,
+        Object,
+        OleDateTime,
+        Decimal,
+        Guid,
+        Struct,
+        BlittableStruct,
+        BlittableStructPtr,   // Additional indirection on top of blittable struct. Used by MarshalAs(LpStruct)
+        LayoutClass,
+        LayoutClassPtr,
+        AsAnyA,
+        AsAnyW,
+        Invalid
+    }
+    public enum MarshalDirection
+    {
+        Forward,    // safe-to-unsafe / managed-to-native
+        Reverse,    // unsafe-to-safe / native-to-managed
+    }
+
+    public enum MarshallerType
+    {
+        Argument,
+        Element,
+        Field
+    }
+
+    // Each type of marshaller knows how to generate the marshalling code for the argument it marshals.
+    // Marshallers contain method related marshalling information (which is common to all the Marshallers)
+    // and also argument specific marshalling informaiton
+    abstract partial class Marshaller
+    {
+        #region Instance state information
+        public TypeSystemContext Context;
+#if !READYTORUN
+        public InteropStateManager InteropStateManager;
+#endif
+        public MarshallerKind MarshallerKind;
+        public MarshallerType MarshallerType;
+        public MarshalAsDescriptor MarshalAsDescriptor;
+        public MarshallerKind ElementMarshallerKind;
+        public int Index;
+        public TypeDesc ManagedType;
+        public TypeDesc ManagedParameterType;
+        public PInvokeFlags PInvokeFlags;
+        protected Marshaller[] Marshallers;
+        private TypeDesc _nativeType;
+        private TypeDesc _nativeParamType;
+
+        /// <summary>
+        /// Native Type of the value being marshalled
+        /// For by-ref scenarios (ref T), Native Type is T
+        /// </summary>
+        public TypeDesc NativeType
+        {
+            get
+            {
+                if (_nativeType == null)
+                {
+                    _nativeType = MarshalHelpers.GetNativeTypeFromMarshallerKind(
+                        ManagedType,
+                        MarshallerKind,
+                        ElementMarshallerKind,
+#if !READYTORUN
+                        InteropStateManager,
+#endif
+                        MarshalAsDescriptor);
+                    Debug.Assert(_nativeType != null);
+                }
+
+                return _nativeType;
+            }
+        }
+
+        /// <summary>
+        /// NativeType appears in function parameters
+        /// For by-ref scenarios (ref T), NativeParameterType is T*
+        /// </summary>
+        public TypeDesc NativeParameterType
+        {
+            get
+            {
+                if (_nativeParamType == null)
+                {
+                    TypeDesc nativeParamType = NativeType;
+                    if (IsNativeByRef)
+                        nativeParamType = nativeParamType.MakePointerType();
+                    _nativeParamType = nativeParamType;
+                }
+
+                return _nativeParamType;
+            }
+        }
+
+        /// <summary>
+        ///  Indicates whether cleanup is necessay if this marshaller is used
+        ///  as an element of an array marshaller
+        /// </summary>
+        internal virtual bool CleanupRequired
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public bool In;
+        public bool Out;
+        public bool Return;
+        public bool IsManagedByRef;                     // Whether managed argument is passed by ref
+        public bool IsNativeByRef;                      // Whether native argument is passed by byref
+                                                        // There are special cases (such as LpStruct, and class) that 
+                                                        // isNativeByRef != IsManagedByRef
+        public MarshalDirection MarshalDirection;
+        protected PInvokeILCodeStreams _ilCodeStreams;
+        protected Home _managedHome;
+        protected Home _nativeHome;
+#endregion
+
+        enum HomeType
+        {
+            Arg,
+            Local,
+            ByRefArg,
+            ByRefLocal
+        }
+
+        /// <summary>
+        /// Abstraction for handling by-ref and non-by-ref locals/arguments
+        /// </summary>
+        internal class Home
+        {
+            public Home(ILLocalVariable var, TypeDesc type, bool isByRef)
+            {
+                _homeType = isByRef ? HomeType.ByRefLocal : HomeType.Local;
+                _type = type;
+                _var = var;
+            }
+
+            public Home(int argIndex, TypeDesc type, bool isByRef)
+            {
+                _homeType = isByRef ? HomeType.ByRefArg : HomeType.Arg;
+                _type = type;
+                _argIndex = argIndex;
+            }
+
+            public void LoadValue(ILCodeStream stream)
+            {
+                switch (_homeType)
+                {
+                    case HomeType.Arg:
+                        stream.EmitLdArg(_argIndex);
+                        break;
+                    case HomeType.ByRefArg:
+                        stream.EmitLdArg(_argIndex);
+                        stream.EmitLdInd(_type);
+                        break;
+                    case HomeType.Local:
+                        stream.EmitLdLoc(_var);
+                        break;
+                    case HomeType.ByRefLocal:
+                        stream.EmitLdLoc(_var);
+                        stream.EmitLdInd(_type);
+                        break;
+                    default:
+                        Debug.Assert(false);
+                        break;
+                }
+            }
+
+            public void LoadAddr(ILCodeStream stream)
+            {
+                switch (_homeType)
+                {
+                    case HomeType.Arg:
+                        stream.EmitLdArga(_argIndex);
+                        break;
+                    case HomeType.ByRefArg:
+                        stream.EmitLdArg(_argIndex);
+                        break;
+                    case HomeType.Local:
+                        stream.EmitLdLoca(_var);
+                        break;
+                    case HomeType.ByRefLocal:
+                        stream.EmitLdLoc(_var);
+                        break;
+                    default:
+                        Debug.Assert(false);
+                        break;
+                }
+            }
+
+            public void StoreValue(ILCodeStream stream)
+            {
+                switch (_homeType)
+                {
+                    case HomeType.Arg:
+                        Debug.Fail("Unexpectting setting value on non-byref arg");
+                        break;
+                    case HomeType.Local:
+                        stream.EmitStLoc(_var);
+                        break;
+                    default:
+                        // Storing by-ref arg/local is not supported because StInd require
+                        // address to be pushed first. Instead we need to introduce a non-byref 
+                        // local and propagate value as needed for by-ref arguments
+                        Debug.Assert(false);
+                        break;
+                }
+            }
+
+            HomeType _homeType;
+            TypeDesc _type;
+            ILLocalVariable _var;
+            int _argIndex;
+        }
+
+#region Creation of marshallers
+
+        /// <summary>
+        /// Protected ctor
+        /// Only Marshaller.CreateMarshaller can create a marshaller
+        /// </summary>
+        protected Marshaller()
+        {
+        }
+
+        /// <summary>
+        /// Create a marshaller
+        /// </summary>
+        /// <param name="parameterType">type of the parameter to marshal</param>
+        /// <returns>The created Marshaller</returns>
+        public static Marshaller CreateMarshaller(TypeDesc parameterType,
+            MarshallerType marshallerType,
+            MarshalAsDescriptor marshalAs,
+            MarshalDirection direction,
+            Marshaller[] marshallers,
+#if !READYTORUN
+            InteropStateManager interopStateManager,
+#endif
+            int index,
+            PInvokeFlags flags,
+            bool isIn,
+            bool isOut,
+            bool isReturn)
+        {
+            MarshallerKind elementMarshallerKind;
+            MarshallerKind marshallerKind = MarshalHelpers.GetMarshallerKind(parameterType,
+                                                marshalAs,
+                                                isReturn,
+                                                flags.CharSet == CharSet.Ansi,
+                                                marshallerType,
+                                                out elementMarshallerKind);
+
+            TypeSystemContext context = parameterType.Context;
+            // Create the marshaller based on MarshallerKind
+            Marshaller marshaller = CreateMarshaller(marshallerKind);
+            marshaller.Context = context;
+#if !READYTORUN
+            marshaller.InteropStateManager = interopStateManager;
+#endif
+            marshaller.MarshallerKind = marshallerKind;
+            marshaller.MarshallerType = marshallerType;
+            marshaller.ElementMarshallerKind = elementMarshallerKind;
+            marshaller.ManagedParameterType = parameterType;
+            marshaller.ManagedType = parameterType.IsByRef ? parameterType.GetParameterType() : parameterType;
+            marshaller.Return = isReturn;
+            marshaller.IsManagedByRef = parameterType.IsByRef;
+            marshaller.IsNativeByRef = marshaller.IsManagedByRef /* || isRetVal || LpStruct /etc */;
+            marshaller.In = isIn;
+            marshaller.MarshalDirection = direction;
+            marshaller.MarshalAsDescriptor = marshalAs;
+            marshaller.Marshallers = marshallers;
+            marshaller.Index = index;
+            marshaller.PInvokeFlags = flags;
+
+            //
+            // Desktop ignores [Out] on marshaling scenarios where they don't make sense
+            //
+            if (isOut)
+            {
+                // Passing as [Out] by ref is always valid. 
+                if (!marshaller.IsManagedByRef)
+                {
+                    // Ignore [Out] for ValueType, string and pointers
+                    if (parameterType.IsValueType || parameterType.IsString || parameterType.IsPointer || parameterType.IsFunctionPointer)
+                    {
+                        isOut = false;
+                    }
+                }
+            }
+            marshaller.Out = isOut;
+
+            if (!marshaller.In && !marshaller.Out)
+            {
+                //
+                // Rules for in/out
+                // 1. ByRef args: [in]/[out] implied by default
+                // 2. StringBuilder: [in, out] by default
+                // 3. non-ByRef args: [In] is implied if no [In]/[Out] is specified
+                //
+                if (marshaller.IsManagedByRef)
+                {
+                    marshaller.In = true;
+                    marshaller.Out = true;
+                }
+                else if (InteropTypes.IsStringBuilder(context, parameterType))
+                {
+                    marshaller.In = true;
+                    marshaller.Out = true;
+                }
+                else
+                {
+                    marshaller.In = true;
+                }
+            }
+
+            // For unicodestring/ansistring, ignore out when it's in
+            if (!marshaller.IsManagedByRef && marshaller.In)
+            {
+                if (marshaller.MarshallerKind == MarshallerKind.AnsiString || marshaller.MarshallerKind == MarshallerKind.UnicodeString)
+                    marshaller.Out = false;
+            }
+
+            return marshaller;
+        }
+
+        public bool IsMarshallingRequired()
+        {
+            if (Out)
+                return true;
+
+            switch (MarshallerKind)
+            {
+                case MarshallerKind.Enum:
+                case MarshallerKind.BlittableValue:
+                case MarshallerKind.BlittableStruct:
+                case MarshallerKind.UnicodeChar:
+                case MarshallerKind.VoidReturn:
+                    return false;
+            }
+            return true;
+        }
+#endregion
+
+        public virtual void EmitMarshallingIL(PInvokeILCodeStreams pInvokeILCodeStreams)
+        {
+            _ilCodeStreams = pInvokeILCodeStreams;
+
+            switch (MarshallerType)
+            {
+                case MarshallerType.Argument: EmitArgumentMarshallingIL(); return;
+                case MarshallerType.Element: EmitElementMarshallingIL(); return;
+                case MarshallerType.Field: EmitFieldMarshallingIL(); return;
+            }
+        }
+
+        private void EmitArgumentMarshallingIL()
+        {
+            switch (MarshalDirection)
+            {
+                case MarshalDirection.Forward: EmitForwardArgumentMarshallingIL(); return;
+                case MarshalDirection.Reverse: EmitReverseArgumentMarshallingIL(); return;
+            }
+        }
+
+        private void EmitElementMarshallingIL()
+        {
+            switch (MarshalDirection)
+            {
+                case MarshalDirection.Forward: EmitForwardElementMarshallingIL(); return;
+                case MarshalDirection.Reverse: EmitReverseElementMarshallingIL(); return;
+            }
+        }
+
+        private void EmitFieldMarshallingIL()
+        {
+            switch (MarshalDirection)
+            {
+                case MarshalDirection.Forward: EmitForwardFieldMarshallingIL(); return;
+                case MarshalDirection.Reverse: EmitReverseFieldMarshallingIL(); return;
+            }
+        }
+
+        protected virtual void EmitForwardArgumentMarshallingIL()
+        {
+            if (Return)
+            {
+                EmitMarshalReturnValueManagedToNative();
+            }
+            else
+            {
+                EmitMarshalArgumentManagedToNative();
+            }
+        }
+
+        protected virtual void EmitReverseArgumentMarshallingIL()
+        {
+            if (Return)
+            {
+                EmitMarshalReturnValueNativeToManaged();
+            }
+            else
+            {
+                EmitMarshalArgumentNativeToManaged();
+            }
+        }
+
+        protected virtual void EmitForwardElementMarshallingIL()
+        {
+            if (In)
+                EmitMarshalElementManagedToNative();
+            else
+                EmitMarshalElementNativeToManaged();
+        }
+
+        protected virtual void EmitReverseElementMarshallingIL()
+        {
+            if (In)
+                EmitMarshalElementNativeToManaged();
+            else
+                EmitMarshalElementManagedToNative();
+        }
+
+        protected virtual void EmitForwardFieldMarshallingIL()
+        {
+            if (In)
+                EmitMarshalFieldManagedToNative();
+            else
+                EmitMarshalFieldNativeToManaged();
+        }
+
+        protected virtual void EmitReverseFieldMarshallingIL()
+        {
+            if (In)
+                EmitMarshalFieldNativeToManaged();
+            else
+                EmitMarshalFieldManagedToNative();
+        }
+
+
+        protected virtual void EmitMarshalReturnValueManagedToNative()
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            SetupArgumentsForReturnValueMarshalling();
+
+            StoreNativeValue(_ilCodeStreams.ReturnValueMarshallingCodeStream);
+
+            AllocAndTransformNativeToManaged(_ilCodeStreams.ReturnValueMarshallingCodeStream);
+        }
+
+        public virtual void LoadReturnValue(ILCodeStream codeStream)
+        {
+            Debug.Assert(Return);
+
+            switch (MarshalDirection)
+            {
+                case MarshalDirection.Forward: LoadManagedValue(codeStream); return;
+                case MarshalDirection.Reverse: LoadNativeValue(codeStream); return;
+            }
+        }
+
+        protected virtual void SetupArguments()
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+            if (MarshalDirection == MarshalDirection.Forward)
+            {
+                // Due to StInd order (address, value), we can't do the following:
+                //   LoadValue
+                //   StoreManagedValue (LdArg + StInd)
+                // The way to work around this is to put it in a local
+                if (IsManagedByRef)
+                    _managedHome = new Home(emitter.NewLocal(ManagedType), ManagedType, false);
+                else
+                    _managedHome = new Home(Index - 1, ManagedType, false);
+                _nativeHome = new Home(emitter.NewLocal(NativeType), NativeType, isByRef: false);
+            }
+            else
+            {
+                _managedHome = new Home(emitter.NewLocal(ManagedType), ManagedType, isByRef: false);
+                if (IsNativeByRef)
+                    _nativeHome = new Home(emitter.NewLocal(NativeType), NativeType, isByRef: false);
+                else
+                    _nativeHome = new Home(Index - 1, NativeType, isByRef: false);
+            }
+        }
+
+        protected virtual void SetupArgumentsForElementMarshalling()
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+            _managedHome = new Home(emitter.NewLocal(ManagedType), ManagedType, isByRef: false);
+            _nativeHome = new Home(emitter.NewLocal(NativeType), NativeType, isByRef: false);
+        }
+
+        protected virtual void SetupArgumentsForFieldMarshalling()
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+            //
+            // these are temporary locals for propagating value
+            //
+            _managedHome = new Home(emitter.NewLocal(ManagedType), ManagedType, isByRef: false);
+            _nativeHome = new Home(emitter.NewLocal(NativeType), NativeType, isByRef: false);
+        }
+
+        protected virtual void SetupArgumentsForReturnValueMarshalling()
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+            _managedHome = new Home(emitter.NewLocal(ManagedType), ManagedType, isByRef: false);
+            _nativeHome = new Home(emitter.NewLocal(NativeType), NativeType, isByRef: false);
+        }
+
+        protected void LoadManagedValue(ILCodeStream stream)
+        {
+            _managedHome.LoadValue(stream);
+        }
+
+        protected void LoadManagedAddr(ILCodeStream stream)
+        {
+            _managedHome.LoadAddr(stream);
+        }
+
+        /// <summary>
+        /// Loads the argument to be passed to managed functions
+        /// In by-ref scenarios (ref T), it is &T
+        /// </summary>
+        protected void LoadManagedArg(ILCodeStream stream)
+        {
+            if (IsManagedByRef)
+                _managedHome.LoadAddr(stream);
+            else
+                _managedHome.LoadValue(stream);
+        }
+
+        protected void StoreManagedValue(ILCodeStream stream)
+        {
+            _managedHome.StoreValue(stream);
+        }
+
+        protected void LoadNativeValue(ILCodeStream stream)
+        {
+            _nativeHome.LoadValue(stream);
+        }
+
+        /// <summary>
+        /// Loads the argument to be passed to native functions
+        /// In by-ref scenarios (ref T), it is T*
+        /// </summary>
+        protected void LoadNativeArg(ILCodeStream stream)
+        {
+            if (IsNativeByRef)
+                _nativeHome.LoadAddr(stream);
+            else
+                _nativeHome.LoadValue(stream);
+        }
+
+        protected void LoadNativeAddr(ILCodeStream stream)
+        {
+            _nativeHome.LoadAddr(stream);
+        }
+
+        protected void StoreNativeValue(ILCodeStream stream)
+        {
+            _nativeHome.StoreValue(stream);
+        }
+
+
+        /// <summary>
+        /// Propagate by-ref arg to corresponding local
+        /// We can't load value + ldarg + ldind in the expected order, so 
+        /// we had to use a non-by-ref local and manually propagate the value
+        /// </summary>
+        protected void PropagateFromByRefArg(ILCodeStream stream, Home home)
+        {
+            stream.EmitLdArg(Index - 1);
+            stream.EmitLdInd(ManagedType);
+            home.StoreValue(stream);
+        }
+
+        /// <summary>
+        /// Propagate local to corresponding by-ref arg
+        /// We can't load value + ldarg + ldind in the expected order, so 
+        /// we had to use a non-by-ref local and manually propagate the value
+        /// </summary>
+        protected void PropagateToByRefArg(ILCodeStream stream, Home home)
+        {
+            stream.EmitLdArg(Index - 1);
+            home.LoadValue(stream);
+            stream.EmitStInd(ManagedType);
+        }
+
+        protected virtual void EmitMarshalArgumentManagedToNative()
+        {
+            SetupArguments();
+
+            if (IsManagedByRef && In)
+            {
+                // Propagate byref arg to local
+                PropagateFromByRefArg(_ilCodeStreams.MarshallingCodeStream, _managedHome);
+            }
+
+            //
+            // marshal
+            //
+            if (IsManagedByRef && !In)
+            {
+                ReInitNativeTransform(_ilCodeStreams.MarshallingCodeStream);
+            }
+            else
+            {
+                AllocAndTransformManagedToNative(_ilCodeStreams.MarshallingCodeStream);
+            }
+
+            LoadNativeArg(_ilCodeStreams.CallsiteSetupCodeStream);
+
+            //
+            // unmarshal
+            //
+            if (Out)
+            {
+                if (In)
+                {
+                    ClearManagedTransform(_ilCodeStreams.UnmarshallingCodestream);
+                }
+
+                if (IsManagedByRef && !In)
+                {
+                    AllocNativeToManaged(_ilCodeStreams.UnmarshallingCodestream);
+                }
+
+                TransformNativeToManaged(_ilCodeStreams.UnmarshallingCodestream);
+
+                if (IsManagedByRef)
+                {
+                    // Propagate back to byref arguments
+                    PropagateToByRefArg(_ilCodeStreams.UnmarshallingCodestream, _managedHome);
+                }
+            }
+
+            // TODO This should be in finally block
+            // https://github.com/dotnet/corert/issues/6075
+            EmitCleanupManaged(_ilCodeStreams.UnmarshallingCodestream);
+        }
+
+        /// <summary>
+        /// Reads managed parameter from _vManaged and writes the marshalled parameter in _vNative
+        /// </summary>
+        protected virtual void AllocAndTransformManagedToNative(ILCodeStream codeStream)
+        {
+            AllocManagedToNative(codeStream);
+            if (In)
+            {
+                TransformManagedToNative(codeStream);
+            }
+        }
+
+        protected virtual void AllocAndTransformNativeToManaged(ILCodeStream codeStream)
+        {
+            AllocNativeToManaged(codeStream);
+            TransformNativeToManaged(codeStream);
+        }
+
+        protected virtual void AllocManagedToNative(ILCodeStream codeStream)
+        {
+        }
+        protected virtual void TransformManagedToNative(ILCodeStream codeStream)
+        {
+            LoadManagedValue(codeStream);
+            StoreNativeValue(codeStream);
+        }
+
+        protected virtual void ClearManagedTransform(ILCodeStream codeStream)
+        {
+        }
+        protected virtual void AllocNativeToManaged(ILCodeStream codeStream)
+        {
+        }
+
+        protected virtual void TransformNativeToManaged(ILCodeStream codeStream)
+        {
+            LoadNativeValue(codeStream);
+            StoreManagedValue(codeStream);
+        }
+
+        protected virtual void EmitCleanupManaged(ILCodeStream codeStream)
+        {
+        }
+
+        protected virtual void EmitMarshalReturnValueNativeToManaged()
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            SetupArgumentsForReturnValueMarshalling();
+
+            StoreManagedValue(_ilCodeStreams.ReturnValueMarshallingCodeStream);
+
+            AllocAndTransformManagedToNative(_ilCodeStreams.ReturnValueMarshallingCodeStream);
+        }
+
+        protected virtual void EmitMarshalArgumentNativeToManaged()
+        {
+            SetupArguments();
+
+            if (IsNativeByRef && In)
+            {
+                // Propagate byref arg to local
+                PropagateFromByRefArg(_ilCodeStreams.MarshallingCodeStream, _nativeHome);
+            }
+
+            if (IsNativeByRef && !In)
+            {
+                ReInitManagedTransform(_ilCodeStreams.MarshallingCodeStream);
+            }
+            else
+            {
+                AllocAndTransformNativeToManaged(_ilCodeStreams.MarshallingCodeStream);
+            }
+
+            LoadManagedArg(_ilCodeStreams.CallsiteSetupCodeStream);
+
+            if (Out)
+            {
+                if (IsNativeByRef)
+                {
+                    AllocManagedToNative(_ilCodeStreams.UnmarshallingCodestream);
+                }
+
+                TransformManagedToNative(_ilCodeStreams.UnmarshallingCodestream);
+
+                if (IsNativeByRef)
+                {
+                    // Propagate back to byref arguments
+                    PropagateToByRefArg(_ilCodeStreams.UnmarshallingCodestream, _nativeHome);
+                }
+            }
+        }
+
+        protected virtual void EmitMarshalElementManagedToNative()
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            ILCodeStream codeStream = _ilCodeStreams.MarshallingCodeStream;
+            Debug.Assert(codeStream != null);
+
+            SetupArgumentsForElementMarshalling();
+
+            StoreManagedValue(codeStream);
+
+            // marshal
+            AllocAndTransformManagedToNative(codeStream);
+
+            LoadNativeValue(codeStream);
+        }
+
+        protected virtual void EmitMarshalElementNativeToManaged()
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            ILCodeStream codeStream = _ilCodeStreams.MarshallingCodeStream;
+            Debug.Assert(codeStream != null);
+
+            SetupArgumentsForElementMarshalling();
+
+            StoreNativeValue(codeStream);
+
+            // unmarshal
+            AllocAndTransformNativeToManaged(codeStream);
+            LoadManagedValue(codeStream);
+        }
+
+        protected virtual void EmitMarshalFieldManagedToNative()
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            ILCodeStream marshallingCodeStream = _ilCodeStreams.MarshallingCodeStream;
+
+            SetupArgumentsForFieldMarshalling();
+            //
+            // For field marshalling we expect the value of the field is already loaded
+            // in the stack. 
+            //
+            StoreManagedValue(marshallingCodeStream);
+
+            // marshal
+            AllocAndTransformManagedToNative(marshallingCodeStream);
+
+            LoadNativeValue(marshallingCodeStream);
+        }
+
+        protected virtual void EmitMarshalFieldNativeToManaged()
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            ILCodeStream codeStream = _ilCodeStreams.MarshallingCodeStream;
+
+            SetupArgumentsForFieldMarshalling();
+
+            StoreNativeValue(codeStream);
+
+            // unmarshal
+            AllocAndTransformNativeToManaged(codeStream);
+            LoadManagedValue(codeStream);
+        }
+
+        protected virtual void ReInitManagedTransform(ILCodeStream codeStream)
+        {
+        }
+
+        protected virtual void ReInitNativeTransform(ILCodeStream codeStream)
+        {
+        }
+
+        internal virtual void EmitElementCleanup(ILCodeStream codestream, ILEmitter emitter)
+        {
+        }
+    }
+
+    class NotSupportedMarshaller : Marshaller
+    {
+        public override void EmitMarshallingIL(PInvokeILCodeStreams pInvokeILCodeStreams)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    class VoidReturnMarshaller : Marshaller
+    {
+        protected override void EmitMarshalReturnValueManagedToNative()
+        {
+        }
+        protected override void EmitMarshalReturnValueNativeToManaged()
+        {
+        }
+        public override void LoadReturnValue(ILCodeStream codeStream)
+        {
+            Debug.Assert(Return);
+        }
+    }
+
+    class BlittableValueMarshaller : Marshaller
+    {
+        protected override void EmitMarshalArgumentManagedToNative()
+        {
+            if (IsNativeByRef && MarshalDirection == MarshalDirection.Forward)
+            {
+                ILCodeStream marshallingCodeStream = _ilCodeStreams.MarshallingCodeStream;
+                ILEmitter emitter = _ilCodeStreams.Emitter;
+                ILLocalVariable native = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.IntPtr));
+
+                ILLocalVariable vPinnedByRef = emitter.NewLocal(ManagedParameterType, true);
+                marshallingCodeStream.EmitLdArg(Index - 1);
+                marshallingCodeStream.EmitStLoc(vPinnedByRef);
+                marshallingCodeStream.EmitLdLoc(vPinnedByRef);
+                marshallingCodeStream.Emit(ILOpcode.conv_i);
+                marshallingCodeStream.EmitStLoc(native);
+                _ilCodeStreams.CallsiteSetupCodeStream.EmitLdLoc(native);
+            }
+            else
+            {
+                _ilCodeStreams.CallsiteSetupCodeStream.EmitLdArg(Index - 1);
+            }
+        }
+
+        protected override void EmitMarshalArgumentNativeToManaged()
+        {
+            if (Out)
+            {
+                base.EmitMarshalArgumentNativeToManaged();
+            }
+            else
+            {
+                _ilCodeStreams.CallsiteSetupCodeStream.EmitLdArg(Index - 1);
+            }
+        }
+    }
+
+    class BlittableStructPtrMarshaller : Marshaller
+    {
+        protected override void TransformManagedToNative(ILCodeStream codeStream)
+        {
+            if (Out)
+            {
+                // TODO: https://github.com/dotnet/corert/issues/4466
+                throw new NotSupportedException("Marshalling an LPStruct argument not yet implemented");
+            }
+            else
+            {
+                LoadManagedAddr(codeStream);
+                StoreNativeValue(codeStream);
+            }
+        }
+
+        protected override void TransformNativeToManaged(ILCodeStream codeStream)
+        {
+            // TODO: https://github.com/dotnet/corert/issues/4466
+            throw new NotSupportedException("Marshalling an LPStruct argument not yet implemented");
+        }
+    }
+
+    class ArrayMarshaller : Marshaller
+    {
+        private Marshaller _elementMarshaller;
+
+        protected TypeDesc ManagedElementType
+        {
+            get
+            {
+                Debug.Assert(ManagedType is ArrayType);
+                var arrayType = (ArrayType)ManagedType;
+                return arrayType.ElementType;
+            }
+        }
+
+        protected TypeDesc NativeElementType
+        {
+            get
+            {
+                Debug.Assert(NativeType is PointerType);
+                return ((PointerType)NativeType).ParameterType;
+            }
+        }
+
+        protected Marshaller GetElementMarshaller(MarshalDirection direction)
+        {
+            if (_elementMarshaller == null)
+            {
+                _elementMarshaller = CreateMarshaller(ElementMarshallerKind);
+                _elementMarshaller.MarshallerKind = ElementMarshallerKind;
+                _elementMarshaller.MarshallerType = MarshallerType.Element;
+#if !READYTORUN
+                _elementMarshaller.InteropStateManager = InteropStateManager;
+#endif
+                _elementMarshaller.Return = Return;
+                _elementMarshaller.Context = Context;
+                _elementMarshaller.ManagedType = ManagedElementType;
+                _elementMarshaller.MarshalAsDescriptor = MarshalAsDescriptor;
+                _elementMarshaller.PInvokeFlags = PInvokeFlags;
+            }
+            _elementMarshaller.In = (direction == MarshalDirection);
+            _elementMarshaller.Out = !In;
+            _elementMarshaller.MarshalDirection = MarshalDirection;
+
+            return _elementMarshaller;
+        }
+
+        protected virtual void EmitElementCount(ILCodeStream codeStream, MarshalDirection direction)
+        {
+            if (direction == MarshalDirection.Forward)
+            {
+                // In forward direction we skip whatever is passed through SizeParamIndex, because the
+                // size of the managed array is already known
+                LoadManagedValue(codeStream);
+                codeStream.Emit(ILOpcode.ldlen);
+                codeStream.Emit(ILOpcode.conv_i4);
+
+            }
+            else if (MarshalDirection == MarshalDirection.Forward
+                    && MarshallerType == MarshallerType.Argument
+                    && !Return
+                    && !IsManagedByRef)
+            {
+                EmitElementCount(codeStream, MarshalDirection.Forward);
+            }
+            else
+            {
+
+                uint? sizeParamIndex = MarshalAsDescriptor != null ? MarshalAsDescriptor.SizeParamIndex : null;
+                uint? sizeConst = MarshalAsDescriptor != null ? MarshalAsDescriptor.SizeConst : null;
+
+                if (sizeConst.HasValue)
+                {
+                    codeStream.EmitLdc((int)sizeConst.Value);
+                }
+
+                if (sizeParamIndex.HasValue)
+                {
+                    uint index = sizeParamIndex.Value;
+
+                    if (index < 0 || index >= Marshallers.Length - 1)
+                    {
+                        throw new InvalidProgramException("Invalid SizeParamIndex, must be between 0 and parameter count");
+                    }
+
+                    //zero-th index is for return type
+                    index++;
+                    var indexType = Marshallers[index].ManagedType;
+                    switch (indexType.Category)
+                    {
+                        case TypeFlags.Byte:
+                        case TypeFlags.SByte:
+                        case TypeFlags.Int16:
+                        case TypeFlags.UInt16:
+                        case TypeFlags.Int32:
+                        case TypeFlags.UInt32:
+                        case TypeFlags.Int64:
+                        case TypeFlags.UInt64:
+                        case TypeFlags.IntPtr:
+                        case TypeFlags.UIntPtr:
+                            break;
+                        default:
+                            throw new InvalidProgramException("Invalid SizeParamIndex, parameter must be  of type int/uint");
+                    }
+
+                    // @TODO - We can use LoadManagedValue, but that requires byref arg propagation happen in a special setup stream
+                    // otherwise there is an ordering issue
+                    codeStream.EmitLdArg(Marshallers[index].Index - 1);
+                    if (Marshallers[index].IsManagedByRef)
+                        codeStream.EmitLdInd(indexType);
+
+                    if (sizeConst.HasValue)
+                        codeStream.Emit(ILOpcode.add);
+                }
+
+                if (!sizeConst.HasValue && !sizeParamIndex.HasValue)
+                {
+                    // if neither sizeConst or sizeParamIndex are specified, default to 1
+                    codeStream.EmitLdc(1);
+                }
+            }
+        }
+
+        protected override void AllocManagedToNative(ILCodeStream codeStream)
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            ILCodeLabel lNullArray = emitter.NewCodeLabel();
+
+            LoadNativeAddr(codeStream);
+            codeStream.Emit(ILOpcode.initobj, emitter.NewToken(NativeType));
+
+            // Check for null array
+            LoadManagedValue(codeStream);
+            codeStream.Emit(ILOpcode.brfalse, lNullArray);
+
+            // allocate memory
+            // nativeParameter = (byte**)CoTaskMemAllocAndZeroMemory((IntPtr)(checked(managedParameter.Length * sizeof(byte*))));
+
+            // loads the number of elements
+            EmitElementCount(codeStream, MarshalDirection.Forward);
+
+            TypeDesc nativeElementType = NativeElementType;
+            codeStream.Emit(ILOpcode.sizeof_, emitter.NewToken(nativeElementType));
+
+            codeStream.Emit(ILOpcode.mul_ovf);
+
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(
+                                Context.GetHelperEntryPoint("InteropHelpers", "CoTaskMemAllocAndZeroMemory")));
+            StoreNativeValue(codeStream);
+
+            codeStream.EmitLabel(lNullArray);
+        }
+
+        protected override void TransformManagedToNative(ILCodeStream codeStream)
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            var elementType = ManagedElementType;
+
+            var lRangeCheck = emitter.NewCodeLabel();
+            var lLoopHeader = emitter.NewCodeLabel();
+            var  lNullArray = emitter.NewCodeLabel();
+
+            var vNativeTemp = emitter.NewLocal(NativeType);
+            var vIndex = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.Int32));
+            var vSizeOf = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.IntPtr));
+            var vLength = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.Int32));
+            
+            // Check for null array
+            LoadManagedValue(codeStream);
+            codeStream.Emit(ILOpcode.brfalse, lNullArray);
+            
+            // loads the number of elements
+            EmitElementCount(codeStream, MarshalDirection.Forward);
+            codeStream.EmitStLoc(vLength);
+
+            TypeDesc nativeElementType = NativeElementType;
+            codeStream.Emit(ILOpcode.sizeof_, emitter.NewToken(nativeElementType));
+
+            codeStream.EmitStLoc(vSizeOf);
+
+            LoadNativeValue(codeStream);
+            codeStream.EmitStLoc(vNativeTemp);
+
+            codeStream.EmitLdc(0);
+            codeStream.EmitStLoc(vIndex);
+            codeStream.Emit(ILOpcode.br, lRangeCheck);
+
+            codeStream.EmitLabel(lLoopHeader);
+            codeStream.EmitLdLoc(vNativeTemp);
+
+            LoadManagedValue(codeStream);
+            codeStream.EmitLdLoc(vIndex);
+            codeStream.EmitLdElem(elementType);
+            // generate marshalling IL for the element
+            GetElementMarshaller(MarshalDirection.Forward)
+                .EmitMarshallingIL(new PInvokeILCodeStreams(_ilCodeStreams.Emitter, codeStream));
+
+            codeStream.EmitStInd(nativeElementType);
+            codeStream.EmitLdLoc(vIndex);
+            codeStream.EmitLdc(1);
+            codeStream.Emit(ILOpcode.add);
+            codeStream.EmitStLoc(vIndex);
+            codeStream.EmitLdLoc(vNativeTemp);
+            codeStream.EmitLdLoc(vSizeOf);
+            codeStream.Emit(ILOpcode.add);
+            codeStream.EmitStLoc(vNativeTemp);
+
+            codeStream.EmitLabel(lRangeCheck);
+
+            codeStream.EmitLdLoc(vIndex);
+            codeStream.EmitLdLoc(vLength);
+            codeStream.Emit(ILOpcode.blt, lLoopHeader);
+            codeStream.EmitLabel(lNullArray);
+        }
+
+        protected override void TransformNativeToManaged(ILCodeStream codeStream)
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+            var elementType = ManagedElementType;
+            var nativeElementType = NativeElementType;
+
+            ILLocalVariable vSizeOf = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.Int32));
+            ILLocalVariable vLength = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.IntPtr));
+
+            ILCodeLabel lRangeCheck = emitter.NewCodeLabel();
+            ILCodeLabel lLoopHeader = emitter.NewCodeLabel();
+            var lNullArray = emitter.NewCodeLabel();
+            
+            // Check for null array
+            LoadManagedValue(codeStream);
+            codeStream.Emit(ILOpcode.brfalse, lNullArray);
+
+
+            EmitElementCount(codeStream, MarshalDirection.Reverse);
+
+            codeStream.EmitStLoc(vLength);
+            codeStream.Emit(ILOpcode.sizeof_, emitter.NewToken(nativeElementType));
+
+            codeStream.EmitStLoc(vSizeOf);
+
+            var vIndex = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.Int32));
+            ILLocalVariable vNativeTemp = emitter.NewLocal(NativeType);
+
+            LoadNativeValue(codeStream);
+            codeStream.EmitStLoc(vNativeTemp);
+            codeStream.EmitLdc(0);
+            codeStream.EmitStLoc(vIndex);
+            codeStream.Emit(ILOpcode.br, lRangeCheck);
+
+
+            codeStream.EmitLabel(lLoopHeader);
+
+            LoadManagedValue(codeStream);
+
+            codeStream.EmitLdLoc(vIndex);
+            codeStream.EmitLdLoc(vNativeTemp);
+
+            codeStream.EmitLdInd(nativeElementType);
+
+            // generate marshalling IL for the element
+            GetElementMarshaller(MarshalDirection.Reverse)
+                .EmitMarshallingIL(new PInvokeILCodeStreams(_ilCodeStreams.Emitter, codeStream));
+
+            codeStream.EmitStElem(elementType);
+
+            codeStream.EmitLdLoc(vIndex);
+            codeStream.EmitLdc(1);
+            codeStream.Emit(ILOpcode.add);
+            codeStream.EmitStLoc(vIndex);
+            codeStream.EmitLdLoc(vNativeTemp);
+            codeStream.EmitLdLoc(vSizeOf);
+            codeStream.Emit(ILOpcode.add);
+            codeStream.EmitStLoc(vNativeTemp);
+
+
+            codeStream.EmitLabel(lRangeCheck);
+            codeStream.EmitLdLoc(vIndex);
+            codeStream.EmitLdLoc(vLength);
+            codeStream.Emit(ILOpcode.blt, lLoopHeader);
+            codeStream.EmitLabel(lNullArray);
+        }
+
+        protected override void AllocNativeToManaged(ILCodeStream codeStream)
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+            var elementType = ManagedElementType;
+            EmitElementCount(codeStream, MarshalDirection.Reverse);
+            codeStream.Emit(ILOpcode.newarr, emitter.NewToken(elementType));
+            StoreManagedValue(codeStream);
+        }
+
+        protected override void EmitCleanupManaged(ILCodeStream codeStream)
+        {
+            Marshaller elementMarshaller = GetElementMarshaller(MarshalDirection.Forward);
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+            var lNullArray = emitter.NewCodeLabel();
+
+            // Check for null array
+            LoadManagedValue(codeStream);
+            codeStream.Emit(ILOpcode.brfalse, lNullArray);
+
+            // generate cleanup code only if it is necessary
+            if (elementMarshaller.CleanupRequired)
+            {
+                //
+                //     for (index=0; index< array.length; index++)
+                //         Cleanup(array[i]);
+                //
+                var vIndex = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.Int32));
+                ILLocalVariable vLength = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.IntPtr));
+
+                ILCodeLabel lRangeCheck = emitter.NewCodeLabel();
+                ILCodeLabel lLoopHeader = emitter.NewCodeLabel();
+                ILLocalVariable vSizeOf = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.IntPtr));
+
+                var nativeElementType = NativeElementType;
+                // calculate sizeof(array[i])
+                codeStream.Emit(ILOpcode.sizeof_, emitter.NewToken(nativeElementType));
+
+                codeStream.EmitStLoc(vSizeOf);
+
+
+                // calculate array.length
+                EmitElementCount(codeStream, MarshalDirection.Forward);
+                codeStream.EmitStLoc(vLength);
+
+                // load native value
+                ILLocalVariable vNativeTemp = emitter.NewLocal(NativeType);
+                LoadNativeValue(codeStream);
+                codeStream.EmitStLoc(vNativeTemp);
+
+                // index = 0
+                codeStream.EmitLdc(0);
+                codeStream.EmitStLoc(vIndex);
+                codeStream.Emit(ILOpcode.br, lRangeCheck);
+
+                codeStream.EmitLabel(lLoopHeader);
+                codeStream.EmitLdLoc(vNativeTemp);
+                codeStream.EmitLdInd(nativeElementType);
+                // generate cleanup code for this element
+                elementMarshaller.EmitElementCleanup(codeStream, emitter);
+
+                codeStream.EmitLdLoc(vIndex);
+                codeStream.EmitLdc(1);
+                codeStream.Emit(ILOpcode.add);
+                codeStream.EmitStLoc(vIndex);
+                codeStream.EmitLdLoc(vNativeTemp);
+                codeStream.EmitLdLoc(vSizeOf);
+                codeStream.Emit(ILOpcode.add);
+                codeStream.EmitStLoc(vNativeTemp);
+
+                codeStream.EmitLabel(lRangeCheck);
+
+                codeStream.EmitLdLoc(vIndex);
+                codeStream.EmitLdLoc(vLength);
+                codeStream.Emit(ILOpcode.blt, lLoopHeader);
+            }
+
+            LoadNativeValue(codeStream);
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(
+                                Context.GetHelperEntryPoint("InteropHelpers", "CoTaskMemFree")));
+            codeStream.EmitLabel(lNullArray);
+        }
+    }
+
+    class BlittableArrayMarshaller : ArrayMarshaller
+    {
+        protected override void AllocAndTransformManagedToNative(ILCodeStream codeStream)
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            var arrayType = (ArrayType)ManagedType;
+            Debug.Assert(arrayType.IsSzArray);
+
+            ILLocalVariable vPinnedFirstElement = emitter.NewLocal(arrayType.ParameterType.MakeByRefType(), true);
+            ILCodeLabel lNullArray = emitter.NewCodeLabel();
+
+            // Check for null array, or 0 element array.
+            LoadManagedValue(codeStream);
+            codeStream.Emit(ILOpcode.brfalse, lNullArray);
+            LoadManagedValue(codeStream);
+            codeStream.Emit(ILOpcode.ldlen);
+            codeStream.Emit(ILOpcode.conv_i4);
+            codeStream.Emit(ILOpcode.brfalse, lNullArray);
+
+            // Array has elements.
+            LoadManagedValue(codeStream);
+            codeStream.EmitLdc(0);
+            codeStream.Emit(ILOpcode.ldelema, emitter.NewToken(arrayType.ElementType));
+            codeStream.EmitStLoc(vPinnedFirstElement);
+
+            // Fall through. If array didn't have elements, vPinnedFirstElement is zeroinit.
+            codeStream.EmitLabel(lNullArray);
+            codeStream.EmitLdLoc(vPinnedFirstElement);
+            codeStream.Emit(ILOpcode.conv_i);
+            StoreNativeValue(codeStream);
+        }
+
+        protected override void ReInitNativeTransform(ILCodeStream codeStream)
+        {
+            codeStream.EmitLdc(0);
+            codeStream.Emit(ILOpcode.conv_u);
+            StoreNativeValue(codeStream);
+        }
+
+        protected override void TransformNativeToManaged(ILCodeStream codeStream)
+        {
+            if ((IsManagedByRef && !In) || (MarshalDirection == MarshalDirection.Reverse && MarshallerType == MarshallerType.Argument))
+                base.TransformNativeToManaged(codeStream);
+        }
+
+        protected override void EmitCleanupManaged(ILCodeStream codeStream)
+        {
+            if (IsManagedByRef && !In)
+                base.EmitCleanupManaged(codeStream);
+        }
+    }
+
+    class BooleanMarshaller : Marshaller
+    {
+        protected override void AllocAndTransformManagedToNative(ILCodeStream codeStream)
+        {
+            LoadManagedValue(codeStream);
+            codeStream.EmitLdc(0);
+            codeStream.Emit(ILOpcode.ceq);
+            codeStream.EmitLdc(0);
+            codeStream.Emit(ILOpcode.ceq);
+            StoreNativeValue(codeStream);
+        }
+
+        protected override void AllocAndTransformNativeToManaged(ILCodeStream codeStream)
+        {
+            LoadNativeValue(codeStream);
+            codeStream.EmitLdc(0);
+            codeStream.Emit(ILOpcode.ceq);
+            codeStream.EmitLdc(0);
+            codeStream.Emit(ILOpcode.ceq);
+            StoreManagedValue(codeStream);
+        }
+    }
+
+    class UnicodeStringMarshaller : Marshaller
+    {
+        private bool ShouldBePinned
+        {
+            get
+            {
+                return MarshalDirection == MarshalDirection.Forward 
+                    && MarshallerType != MarshallerType.Field
+                    && !IsManagedByRef
+                    && In
+                    && !Out;
+            }
+        }
+
+        internal override bool CleanupRequired
+        {
+            get
+            {
+                return !ShouldBePinned; //cleanup is only required when it is not pinned
+            }
+        }
+
+        internal override void EmitElementCleanup(ILCodeStream codeStream, ILEmitter emitter)
+        {
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(
+                                Context.GetHelperEntryPoint("InteropHelpers", "CoTaskMemFree")));
+        }
+
+        protected override void AllocAndTransformManagedToNative(ILCodeStream codeStream)
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+            if (ShouldBePinned)
+            {
+                //
+                // Pin the string and push a pointer to the first character on the stack.
+                //
+                TypeDesc stringType = Context.GetWellKnownType(WellKnownType.String);
+
+                ILLocalVariable vPinnedString = emitter.NewLocal(stringType, true);
+                ILCodeLabel lNullString = emitter.NewCodeLabel();
+
+                LoadManagedValue(codeStream);
+                codeStream.EmitStLoc(vPinnedString);
+                codeStream.EmitLdLoc(vPinnedString);
+
+                codeStream.Emit(ILOpcode.conv_i);
+                codeStream.Emit(ILOpcode.dup);
+
+                // Marshalling a null string?
+                codeStream.Emit(ILOpcode.brfalse, lNullString);
+
+                codeStream.Emit(ILOpcode.call, emitter.NewToken(
+                    Context.SystemModule.
+                        GetKnownType("System.Runtime.CompilerServices", "RuntimeHelpers").
+                            GetKnownMethod("get_OffsetToStringData", null)));
+
+                codeStream.Emit(ILOpcode.add);
+
+                codeStream.EmitLabel(lNullString);
+                StoreNativeValue(codeStream);
+            }
+            else
+            {
+                var helper = Context.GetHelperEntryPoint("InteropHelpers", "StringToUnicodeBuffer");
+                LoadManagedValue(codeStream);
+
+                codeStream.Emit(ILOpcode.call, emitter.NewToken(helper));
+
+                StoreNativeValue(codeStream);
+            }
+        }
+
+        protected override void TransformNativeToManaged(ILCodeStream codeStream)
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            var charPtrConstructor = Context.GetWellKnownType(WellKnownType.String).GetMethod(".ctor",
+                new MethodSignature(
+                    MethodSignatureFlags.None, 0, Context.GetWellKnownType(WellKnownType.Void),
+                        new TypeDesc[] {
+                            Context.GetWellKnownType(WellKnownType.Char).MakePointerType() }
+                        ));
+            LoadNativeValue(codeStream);
+            codeStream.Emit(ILOpcode.newobj, emitter.NewToken(charPtrConstructor));
+            StoreManagedValue(codeStream);
+        }
+
+        protected override void EmitCleanupManaged(ILCodeStream codeStream)
+        {
+            if (CleanupRequired)
+            {
+                var emitter = _ilCodeStreams.Emitter;
+                var lNullCheck = emitter.NewCodeLabel();
+
+                // Check for null array
+                LoadManagedValue(codeStream);
+                codeStream.Emit(ILOpcode.brfalse, lNullCheck);
+
+                LoadNativeValue(codeStream);
+                codeStream.Emit(ILOpcode.call, emitter.NewToken(
+                                    InteropTypes.GetMarshal(Context).GetKnownMethod("FreeCoTaskMem", null)));
+
+                codeStream.EmitLabel(lNullCheck);
+            }
+        }
+    }
+
+    class AnsiStringMarshaller : Marshaller
+    {
+        internal override bool CleanupRequired
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        internal override void EmitElementCleanup(ILCodeStream codeStream, ILEmitter emitter)
+        {
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(
+                                Context.GetHelperEntryPoint("InteropHelpers", "CoTaskMemFree")));
+        }
+
+        protected override void AllocAndTransformManagedToNative(ILCodeStream codeStream)
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+            //
+            // ANSI marshalling. Allocate a byte array, copy characters
+            //
+            
+#if READYTORUN
+            var stringToAnsi =
+                Context.SystemModule.GetKnownType("System.StubHelpers", "AnsiBSTRMarshaler")
+                .GetKnownMethod("ConvertToNative", null);
+            int flags = (PInvokeFlags.BestFitMapping ? 0x1 : 0)
+                | (PInvokeFlags.ThrowOnUnmappableChar ? 0x100 : 0);
+            codeStream.EmitLdc(flags);
+            LoadManagedValue(codeStream);
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(stringToAnsi));
+#else
+            LoadManagedValue(codeStream);
+            var stringToAnsi = Context.GetHelperEntryPoint("InteropHelpers", "StringToAnsiString");
+
+            codeStream.Emit(PInvokeFlags.BestFitMapping ? ILOpcode.ldc_i4_1 : ILOpcode.ldc_i4_0);
+            codeStream.Emit(PInvokeFlags.ThrowOnUnmappableChar ? ILOpcode.ldc_i4_1 : ILOpcode.ldc_i4_0);
+
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(stringToAnsi));
+#endif
+
+            StoreNativeValue(codeStream);
+        }
+
+        protected override void TransformNativeToManaged(ILCodeStream codeStream)
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+#if READYTORUN
+            var ansiToString =
+                Context.SystemModule.GetKnownType("System.StubHelpers", "AnsiBSTRMarshaler")
+                .GetKnownMethod("ConvertToManaged", null);
+#else
+            var ansiToString = Context.GetHelperEntryPoint("InteropHelpers", "AnsiStringToString");
+#endif
+            LoadNativeValue(codeStream);
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(ansiToString));
+            StoreManagedValue(codeStream);
+        }
+
+        protected override void EmitCleanupManaged(ILCodeStream codeStream)
+        {
+            var emitter = _ilCodeStreams.Emitter;
+#if READYTORUN
+            MethodDesc clearNative =
+                Context.SystemModule.GetKnownType("System.StubHelpers", "AnsiBSTRMarshaler")
+                .GetKnownMethod("ClearNative", null);
+            LoadNativeValue(codeStream);
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(clearNative));
+#else
+            var lNullCheck = emitter.NewCodeLabel();
+
+            // Check for null array
+            LoadManagedValue(codeStream);
+            codeStream.Emit(ILOpcode.brfalse, lNullCheck);
+
+            LoadNativeValue(codeStream);
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(
+                                Context.GetHelperEntryPoint("InteropHelpers", "CoTaskMemFree")));
+
+            codeStream.EmitLabel(lNullCheck);
+#endif
+        }
+    }
+
+    class UTF8StringMarshaller : Marshaller
+    {
+        internal override bool CleanupRequired
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        internal override void EmitElementCleanup(ILCodeStream codeStream, ILEmitter emitter)
+        {
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(
+                                Context.GetHelperEntryPoint("InteropHelpers", "CoTaskMemFree")));
+        }
+
+        protected override void AllocAndTransformManagedToNative(ILCodeStream codeStream)
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+            //
+            // UTF8 marshalling. Allocate a byte array, copy characters
+            //
+            var stringToAnsi = Context.GetHelperEntryPoint("InteropHelpers", "StringToUTF8String");
+            LoadManagedValue(codeStream);
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(stringToAnsi));
+            StoreNativeValue(codeStream);
+        }
+
+        protected override void TransformNativeToManaged(ILCodeStream codeStream)
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            var ansiToString = Context.GetHelperEntryPoint("InteropHelpers", "UTF8StringToString");
+            LoadNativeValue(codeStream);
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(ansiToString));
+            StoreManagedValue(codeStream);
+        }
+
+        protected override void EmitCleanupManaged(ILCodeStream codeStream)
+        {
+            var emitter = _ilCodeStreams.Emitter;
+            var lNullCheck = emitter.NewCodeLabel();
+
+            // Check for null array
+            LoadManagedValue(codeStream);
+            codeStream.Emit(ILOpcode.brfalse, lNullCheck);
+
+            LoadNativeValue(codeStream);
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(
+                                Context.GetHelperEntryPoint("InteropHelpers", "CoTaskMemFree")));
+
+            codeStream.EmitLabel(lNullCheck);
+        }
+    }
+
+    class SafeHandleMarshaller : Marshaller
+    {
+        private void AllocSafeHandle(ILCodeStream codeStream)
+        {
+            var ctor = ManagedType.GetParameterlessConstructor();
+            if (ctor == null)
+            {
+                var emitter = _ilCodeStreams.Emitter;
+
+                MethodSignature ctorSignature = new MethodSignature(0, 0, Context.GetWellKnownType(WellKnownType.Void),
+                      new TypeDesc[] {
+#if !READYTORUN
+                          Context.GetWellKnownType(WellKnownType.String)
+#endif
+                      });
+                MethodDesc exceptionCtor = InteropTypes.GetMissingMemberException(Context).GetKnownMethod(".ctor", ctorSignature);
+
+#if !READYTORUN // In ReadyToRun we cannot make new string literals out of thin air
+                string name = ((MetadataType)ManagedType).Name;
+                codeStream.Emit(ILOpcode.ldstr, emitter.NewToken(String.Format("'{0}' does not have a default constructor. Subclasses of SafeHandle must have a default constructor to support marshaling a Windows HANDLE into managed code.", name)));
+#endif
+                codeStream.Emit(ILOpcode.newobj, emitter.NewToken(exceptionCtor));
+                codeStream.Emit(ILOpcode.throw_);
+                
+                // This is unreachable, but it maintains invariants about stack height prescribed by ECMA-335
+                codeStream.Emit(ILOpcode.ldnull);
+                return;
+            }
+
+            codeStream.Emit(ILOpcode.newobj, _ilCodeStreams.Emitter.NewToken(ctor));
+        }
+
+        protected override void EmitMarshalReturnValueManagedToNative()
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            ILCodeStream marshallingCodeStream = _ilCodeStreams.MarshallingCodeStream;
+            ILCodeStream returnValueMarshallingCodeStream = _ilCodeStreams.ReturnValueMarshallingCodeStream;
+
+            SetupArgumentsForReturnValueMarshalling();
+
+            AllocSafeHandle(marshallingCodeStream);
+            StoreManagedValue(marshallingCodeStream);
+
+            StoreNativeValue(returnValueMarshallingCodeStream);
+
+            LoadManagedValue(returnValueMarshallingCodeStream);
+            LoadNativeValue(returnValueMarshallingCodeStream);
+            returnValueMarshallingCodeStream.Emit(ILOpcode.call, emitter.NewToken(
+               InteropTypes.GetSafeHandle(Context).GetKnownMethod("SetHandle", null)));
+        }
+
+        protected override void EmitMarshalArgumentManagedToNative()
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+            ILCodeStream marshallingCodeStream = _ilCodeStreams.MarshallingCodeStream;
+            ILCodeStream callsiteCodeStream = _ilCodeStreams.CallsiteSetupCodeStream;
+            ILCodeStream unmarshallingCodeStream = _ilCodeStreams.UnmarshallingCodestream;
+
+            SetupArguments();
+
+            if (IsManagedByRef && In)
+            {
+                PropagateFromByRefArg(marshallingCodeStream, _managedHome);
+            }
+
+            var safeHandleType = InteropTypes.GetSafeHandle(Context);
+
+            if (In)
+            {
+                if (IsManagedByRef)
+                    PropagateFromByRefArg(marshallingCodeStream, _managedHome);
+
+                var vAddRefed = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.Boolean));
+                LoadManagedValue(marshallingCodeStream);
+                marshallingCodeStream.EmitLdLoca(vAddRefed);
+                marshallingCodeStream.Emit(ILOpcode.call, emitter.NewToken(
+                    safeHandleType.GetKnownMethod("DangerousAddRef",
+                        new MethodSignature(0, 0, Context.GetWellKnownType(WellKnownType.Void),
+                            new TypeDesc[] { Context.GetWellKnownType(WellKnownType.Boolean).MakeByRefType() }))));
+
+                LoadManagedValue(marshallingCodeStream);
+                marshallingCodeStream.Emit(ILOpcode.call, emitter.NewToken(
+                    safeHandleType.GetKnownMethod("DangerousGetHandle",
+                        new MethodSignature(0, 0, Context.GetWellKnownType(WellKnownType.IntPtr), TypeDesc.EmptyTypes))));
+                StoreNativeValue(marshallingCodeStream);
+
+                // TODO: This should be inside finally block and only executed if the handle was addrefed
+                // https://github.com/dotnet/corert/issues/6075
+                LoadManagedValue(unmarshallingCodeStream);
+                unmarshallingCodeStream.Emit(ILOpcode.call, emitter.NewToken(
+                    safeHandleType.GetKnownMethod("DangerousRelease",
+                        new MethodSignature(0, 0, Context.GetWellKnownType(WellKnownType.Void), TypeDesc.EmptyTypes))));
+            }
+
+            if (Out && IsManagedByRef)
+            {
+                // 1) If this is an output parameter we need to preallocate a SafeHandle to wrap the new native handle value. We
+                //    must allocate this before the native call to avoid a failure point when we already have a native resource
+                //    allocated. We must allocate a new SafeHandle even if we have one on input since both input and output native
+                //    handles need to be tracked and released by a SafeHandle.
+                // 2) Initialize a local IntPtr that will be passed to the native call. 
+                // 3) After the native call, the new handle value is written into the output SafeHandle and that SafeHandle
+                //    is propagated back to the caller.
+                var vSafeHandle = emitter.NewLocal(ManagedType);
+                AllocSafeHandle(marshallingCodeStream);
+                marshallingCodeStream.EmitStLoc(vSafeHandle);
+
+                var lSkipPropagation = emitter.NewCodeLabel();
+                if (In)
+                {
+                    // Propagate the value only if it has changed
+                    ILLocalVariable vOriginalValue = emitter.NewLocal(NativeType);
+                    LoadNativeValue(marshallingCodeStream);
+                    marshallingCodeStream.EmitStLoc(vOriginalValue);
+
+                    unmarshallingCodeStream.EmitLdLoc(vOriginalValue);
+                    LoadNativeValue(unmarshallingCodeStream);
+                    unmarshallingCodeStream.Emit(ILOpcode.beq, lSkipPropagation);
+                }
+
+                unmarshallingCodeStream.EmitLdLoc(vSafeHandle);
+                LoadNativeValue(unmarshallingCodeStream);
+                unmarshallingCodeStream.Emit(ILOpcode.call, emitter.NewToken(
+                    safeHandleType.GetKnownMethod("SetHandle",
+                        new MethodSignature(0, 0, Context.GetWellKnownType(WellKnownType.Void),
+                            new TypeDesc[] { Context.GetWellKnownType(WellKnownType.IntPtr) }))));
+
+                unmarshallingCodeStream.EmitLdArg(Index - 1);
+                unmarshallingCodeStream.EmitLdLoc(vSafeHandle);
+                unmarshallingCodeStream.EmitStInd(ManagedType);
+
+                unmarshallingCodeStream.EmitLabel(lSkipPropagation);
+            }
+
+            LoadNativeArg(callsiteCodeStream);
+        }
+
+        protected override void EmitMarshalArgumentNativeToManaged()
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void EmitMarshalElementNativeToManaged()
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void EmitMarshalElementManagedToNative()
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void EmitMarshalFieldManagedToNative()
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void EmitMarshalFieldNativeToManaged()
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    class DelegateMarshaller : Marshaller
+    {
+        protected override void AllocAndTransformManagedToNative(ILCodeStream codeStream)
+        {
+            LoadManagedValue(codeStream);
+
+            codeStream.Emit(ILOpcode.call, _ilCodeStreams.Emitter.NewToken(
+                InteropTypes.GetMarshal(Context).GetKnownMethod("GetFunctionPointerForDelegate",
+                new MethodSignature(MethodSignatureFlags.Static, 0, Context.GetWellKnownType(WellKnownType.IntPtr),
+                    new TypeDesc[] { Context.GetWellKnownType(WellKnownType.MulticastDelegate).BaseType }
+                ))));
+
+            StoreNativeValue(codeStream);
+        }
+
+        protected override void TransformNativeToManaged(ILCodeStream codeStream)
+        {
+            LoadNativeValue(codeStream);
+
+            TypeDesc systemType = Context.SystemModule.GetKnownType("System", "Type");
+
+            codeStream.Emit(ILOpcode.ldtoken, _ilCodeStreams.Emitter.NewToken(ManagedType));
+            codeStream.Emit(ILOpcode.call, _ilCodeStreams.Emitter.NewToken(systemType.GetKnownMethod("GetTypeFromHandle", null)));
+
+            codeStream.Emit(ILOpcode.call, _ilCodeStreams.Emitter.NewToken(
+                InteropTypes.GetMarshal(Context).GetKnownMethod("GetDelegateForFunctionPointer",
+                new MethodSignature(MethodSignatureFlags.Static, 0, Context.GetWellKnownType(WellKnownType.MulticastDelegate).BaseType,
+                    new TypeDesc[] { Context.GetWellKnownType(WellKnownType.IntPtr), systemType }
+                ))));
+
+            StoreManagedValue(codeStream);
+        }
+
+        protected override void EmitCleanupManaged(ILCodeStream codeStream)
+        {
+            if (In
+                && MarshalDirection == MarshalDirection.Forward
+                && MarshallerType == MarshallerType.Argument)
+            {
+                LoadManagedValue(codeStream);
+                codeStream.Emit(ILOpcode.call, _ilCodeStreams.Emitter.NewToken(InteropTypes.GetGC(Context).GetKnownMethod("KeepAlive", null)));
+            }
+        }
+    }
+}

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/InteropTypes.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/InteropTypes.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.IL;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.TypeSystem.Interop
+{
+    public static class InteropTypes
+    {
+        public static MetadataType GetGC(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System", "GC");
+        }
+
+        public static MetadataType GetSafeHandle(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System.Runtime.InteropServices", "SafeHandle");
+        }
+
+        public static MetadataType GetCriticalHandle(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System.Runtime.InteropServices", "CriticalHandle");
+        }
+
+        public static MetadataType GetHandleRef(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System.Runtime.InteropServices", "HandleRef");
+        }
+
+        public static MetadataType GetMissingMemberException(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System", "MissingMemberException");
+        }
+
+        public static MetadataType GetPInvokeMarshal(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System.Runtime.InteropServices", "PInvokeMarshal");
+        }
+
+        public static MetadataType GetMarshal(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System.Runtime.InteropServices", "Marshal");
+        }
+
+        public static MetadataType GetStubHelpers(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System.StubHelpers", "StubHelpers");
+        }
+
+        public static MetadataType GetNativeFunctionPointerWrapper(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System.Runtime.InteropServices", "NativeFunctionPointerWrapper");
+        }
+
+        public static bool IsSafeHandle(TypeSystemContext context, TypeDesc type)
+        {
+            return IsOrDerivesFromType(type, GetSafeHandle(context));
+        }
+
+        public static bool IsCriticalHandle(TypeSystemContext context, TypeDesc type)
+        {
+            return IsOrDerivesFromType(type, GetCriticalHandle(context));
+        }
+
+        private static bool IsCoreNamedType(TypeSystemContext context, TypeDesc type, string @namespace, string name)
+        {
+            return type is MetadataType mdType &&
+                mdType.Name == name &&
+                mdType.Namespace == @namespace &&
+                mdType.Module == context.SystemModule;
+        }
+
+        public static bool IsHandleRef(TypeSystemContext context, TypeDesc type)
+        {
+            return IsCoreNamedType(context, type, "System.Runtime.InteropServices", "HandleRef");
+        }
+
+        public static bool IsSystemDateTime(TypeSystemContext context, TypeDesc type)
+        {
+            return IsCoreNamedType(context, type, "System", "DateTime");
+        }
+
+        public static bool IsStringBuilder(TypeSystemContext context, TypeDesc type)
+        {
+            return IsCoreNamedType(context, type, "System.Text", "StringBuilder");
+        }
+
+        public static bool IsSystemDecimal(TypeSystemContext context, TypeDesc type)
+        {
+            return IsCoreNamedType(context, type, "System", "Decimal");
+        }
+
+        public static bool IsSystemGuid(TypeSystemContext context, TypeDesc type)
+        {
+            return IsCoreNamedType(context, type, "System", "Guid");
+        }
+
+        private static bool IsOrDerivesFromType(TypeDesc type, MetadataType targetType)
+        {
+            while (type != null)
+            {
+                if (type == targetType)
+                    return true;
+                type = type.BaseType;
+            }
+            return false;
+        }
+    }
+}

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
@@ -7,7 +7,6 @@ using System;
 
 namespace Internal.TypeSystem
 {
-    [Flags]
     public enum NativeTypeKind : byte
     {
         Boolean = 0x2,
@@ -26,6 +25,7 @@ namespace Internal.TypeSystem
         LPTStr = 0x16,        // Ptr to OS preferred (SBCS/Unicode) string
         ByValTStr = 0x17,     // OS preferred (SBCS/Unicode) inline string (only valid in structs)
         Struct = 0x1b,
+        SafeArray = 0x1d,
         ByValArray = 0x1e,
         SysInt = 0x1f,
         SysUInt = 0x20,

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
@@ -28,5 +28,7 @@ namespace ILCompiler
         /// <param name="methodDesc">Method to check</param>
         /// <returns>True if the given method versions with the current compilation module group</returns>
         public virtual bool VersionsWithMethodBody(MethodDesc methodDesc) => ContainsMethodBody(methodDesc, unboxingStub: false);
+
+        public abstract bool GeneratesPInvoke(MethodDesc method);
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -140,7 +140,8 @@ namespace ILCompiler
                     && key.IsPInvoke
                     && _compilationModuleGroup.GeneratesPInvoke(key))
                 {
-                    methodIL = PInvokeILEmitter.EmitIL(key);
+                    // TODO: enable when IL Stubs are fixed to be non-shared
+                    // methodIL = PInvokeILEmitter.EmitIL(key);
                 }
 
                 return new MethodILData() { Method = key, MethodIL = methodIL };

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 
 using Internal.IL;
+using Internal.IL.Stubs;
 using Internal.JitInterface;
 using Internal.TypeSystem;
 
@@ -56,7 +57,7 @@ namespace ILCompiler
             foreach (var rootProvider in compilationRoots)
                 rootProvider.AddCompilationRoots(rootingService);
 
-            _methodILCache = new ILCache(ilProvider);
+            _methodILCache = new ILCache(ilProvider, NodeFactory.CompilationModuleGroup);
         }
 
         public abstract void Compile(string outputFileName);
@@ -80,7 +81,7 @@ namespace ILCompiler
         {
             // Flush the cache when it grows too big
             if (_methodILCache.Count > 1000)
-                _methodILCache = new ILCache(_methodILCache.ILProvider);
+                _methodILCache = new ILCache(_methodILCache.ILProvider, NodeFactory.CompilationModuleGroup);
 
             return _methodILCache.GetOrCreateValue(method).MethodIL;
         }
@@ -108,10 +109,12 @@ namespace ILCompiler
         private sealed class ILCache : LockFreeReaderHashtable<MethodDesc, ILCache.MethodILData>
         {
             public ILProvider ILProvider { get; }
+            private readonly CompilationModuleGroup _compilationModuleGroup;
 
-            public ILCache(ILProvider provider)
+            public ILCache(ILProvider provider, CompilationModuleGroup compilationModuleGroup)
             {
                 ILProvider = provider;
+                _compilationModuleGroup = compilationModuleGroup;
             }
 
             protected override int GetKeyHashCode(MethodDesc key)
@@ -132,7 +135,15 @@ namespace ILCompiler
             }
             protected override MethodILData CreateValueFromKey(MethodDesc key)
             {
-                return new MethodILData() { Method = key, MethodIL = ILProvider.GetMethodIL(key) };
+                MethodIL methodIL = ILProvider.GetMethodIL(key);
+                if (methodIL == null
+                    && key.IsPInvoke
+                    && _compilationModuleGroup.GeneratesPInvoke(key))
+                {
+                    methodIL = PInvokeILEmitter.EmitIL(key);
+                }
+
+                return new MethodILData() { Method = key, MethodIL = methodIL };
             }
 
             internal class MethodILData

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
+using Debug = System.Diagnostics.Debug;
+
 namespace ILCompiler
 {
     public class ReadyToRunSingleAssemblyCompilationModuleGroup : CompilationModuleGroup
@@ -180,6 +182,17 @@ namespace ILCompiler
                     calleeMethod.HasCustomAttribute("System.Runtime.Versioning", "NonVersionableAttribute"));
 
             return canInline;
+        }
+
+        public override bool GeneratesPInvoke(MethodDesc method)
+        {
+            // PInvokes depend on details of the core library.
+            //
+            // We allow compiling them if both the module of the pinvoke and the core library
+            // are in the version bubble.
+            Debug.Assert(method is EcmaMethod);
+            return _versionBubbleModuleSet.Contains(((EcmaMethod)method).Module)
+                && _versionBubbleModuleSet.Contains(method.Context.SystemModule);
         }
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -28,5 +28,10 @@ namespace ILCompiler
         {
             return type == _method.OwningType;
         }
+
+        public override bool GeneratesPInvoke(MethodDesc method)
+        {
+            return true;
+        }
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/IL/ReadyToRunILProvider.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/IL/ReadyToRunILProvider.cs
@@ -93,7 +93,7 @@ namespace Internal.IL
 
         public override MethodIL GetMethodIL(MethodDesc method)
         {
-            if (method is EcmaMethod)
+            if (method is EcmaMethod ecmaMethod)
             {
                 if (method.IsIntrinsicWorkaround())
                 {
@@ -102,7 +102,7 @@ namespace Internal.IL
                         return result;
                 }
 
-                MethodIL methodIL = EcmaMethodIL.Create((EcmaMethod)method);
+                MethodIL methodIL = EcmaMethodIL.Create(ecmaMethod);
                 if (methodIL != null)
                     return methodIL;
 

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/IL/Stubs/PInvokeILEmitter.cs
@@ -1,0 +1,181 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Interop;
+using Internal.JitInterface;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.IL.Stubs
+{
+    /// <summary>
+    /// Provides method bodies for PInvoke methods
+    /// </summary>
+    public struct PInvokeILEmitter
+    {
+        private readonly MethodDesc _targetMethod;
+        private readonly Marshaller[] _marshallers;
+        private readonly PInvokeMetadata _importMetadata;
+
+        private PInvokeILEmitter(MethodDesc targetMethod)
+        {
+            Debug.Assert(targetMethod.IsPInvoke);
+            _targetMethod = targetMethod;
+            _importMetadata = targetMethod.GetPInvokeMethodMetadata();
+
+            _marshallers = InitializeMarshallers(targetMethod, _importMetadata.Flags);
+        }
+
+        private static Marshaller[] InitializeMarshallers(MethodDesc targetMethod, PInvokeFlags flags)
+        {
+            MarshalDirection direction = MarshalDirection.Forward;
+            MethodSignature methodSig = targetMethod.Signature;
+
+            ParameterMetadata[] parameterMetadataArray = targetMethod.GetParameterMetadata();
+            Marshaller[] marshallers = new Marshaller[methodSig.Length + 1];
+            int parameterIndex = 0;
+            ParameterMetadata parameterMetadata;
+
+            for (int i = 0; i < marshallers.Length; i++)
+            {
+                Debug.Assert(parameterIndex == parameterMetadataArray.Length || i <= parameterMetadataArray[parameterIndex].Index);
+                if (parameterIndex == parameterMetadataArray.Length || i < parameterMetadataArray[parameterIndex].Index)
+                {
+                    // if we don't have metadata for the parameter, create a dummy one
+                    parameterMetadata = new ParameterMetadata(i, ParameterMetadataAttributes.None, null);
+                }
+                else 
+                {
+                    Debug.Assert(i == parameterMetadataArray[parameterIndex].Index);
+                    parameterMetadata = parameterMetadataArray[parameterIndex++];
+                }
+                TypeDesc parameterType = (i == 0) ? methodSig.ReturnType : methodSig[i - 1];  //first item is the return type
+                marshallers[i] = Marshaller.CreateMarshaller(parameterType,
+                                                    MarshallerType.Argument,
+                                                    parameterMetadata.MarshalAsDescriptor,
+                                                    direction,
+                                                    marshallers,
+                                                    parameterMetadata.Index,
+                                                    flags,
+                                                    parameterMetadata.In,
+                                                    parameterMetadata.Out,
+                                                    parameterMetadata.Return
+                                                    );
+            }
+
+            return marshallers;
+        }
+
+        private void EmitPInvokeCall(PInvokeILCodeStreams ilCodeStreams)
+        {
+            ILEmitter emitter = ilCodeStreams.Emitter;
+            ILCodeStream callsiteSetupCodeStream = ilCodeStreams.CallsiteSetupCodeStream;
+            TypeSystemContext context = _targetMethod.Context;
+
+            TypeDesc nativeReturnType = _marshallers[0].NativeParameterType;
+            TypeDesc[] nativeParameterTypes = new TypeDesc[_marshallers.Length - 1];
+
+            MetadataType stubHelpersType = InteropTypes.GetStubHelpers(context);
+
+            // if the SetLastError flag is set in DllImport, clear the error code before doing P/Invoke 
+            if (_importMetadata.Flags.SetLastError)
+            {
+                callsiteSetupCodeStream.Emit(ILOpcode.call, emitter.NewToken(
+                            stubHelpersType.GetKnownMethod("ClearLastError", null)));
+            }
+
+            for (int i = 1; i < _marshallers.Length; i++)
+            {
+                nativeParameterTypes[i - 1] = _marshallers[i].NativeParameterType;
+            }
+
+            callsiteSetupCodeStream.Emit(ILOpcode.call, emitter.NewToken(
+                            stubHelpersType.GetKnownMethod("GetStubContext", null)));
+            callsiteSetupCodeStream.Emit(ILOpcode.call, emitter.NewToken(
+                            stubHelpersType.GetKnownMethod("GetNDirectTarget", null)));
+            
+            MethodSignatureFlags unmanagedCallConv = _importMetadata.Flags.UnmanagedCallingConvention;
+
+            MethodSignature nativeSig = new MethodSignature(
+                _targetMethod.Signature.Flags | unmanagedCallConv, 0, nativeReturnType,
+                nativeParameterTypes);
+
+            callsiteSetupCodeStream.Emit(ILOpcode.calli, emitter.NewToken(nativeSig));
+
+            // if the SetLastError flag is set in DllImport, call the PInvokeMarshal.
+            // SaveLastWin32Error so that last error can be used later by calling 
+            // PInvokeMarshal.GetLastWin32Error
+            if (_importMetadata.Flags.SetLastError)
+            {
+                callsiteSetupCodeStream.Emit(ILOpcode.call, emitter.NewToken(
+                            stubHelpersType.GetKnownMethod("SetLastError", null)));
+            }
+        }
+
+        private MethodIL EmitIL()
+        {
+            PInvokeILCodeStreams pInvokeILCodeStreams = new PInvokeILCodeStreams();
+            ILEmitter emitter = pInvokeILCodeStreams.Emitter;
+            ILCodeStream unmarshallingCodestream = pInvokeILCodeStreams.UnmarshallingCodestream;
+
+            // Marshal the arguments
+            for (int i = 0; i < _marshallers.Length; i++)
+            {
+                _marshallers[i].EmitMarshallingIL(pInvokeILCodeStreams);
+            }
+
+            EmitPInvokeCall(pInvokeILCodeStreams);
+
+            _marshallers[0].LoadReturnValue(unmarshallingCodestream);
+            unmarshallingCodestream.Emit(ILOpcode.ret);
+
+            return new PInvokeILStubMethodIL((ILStubMethodIL)emitter.Link(_targetMethod), IsStubRequired());
+        }
+
+        public static MethodIL EmitIL(MethodDesc method)
+        {
+            try
+            {
+                return new PInvokeILEmitter(method).EmitIL();
+            }
+            catch (NotSupportedException)
+            {
+                throw new RequiresRuntimeJitException(method);
+            }
+            catch (InvalidProgramException)
+            {
+                throw new RequiresRuntimeJitException(method);
+            }
+        }
+
+        private bool IsStubRequired()
+        {
+            Debug.Assert(_targetMethod.IsPInvoke);
+
+            if (_importMetadata.Flags.SetLastError)
+            {
+                return true;
+            }
+
+            for (int i = 0; i < _marshallers.Length; i++)
+            {
+                if (_marshallers[i].IsMarshallingRequired())
+                    return true;
+            }
+            return false;
+        }
+    }
+
+    public sealed class PInvokeILStubMethodIL : ILStubMethodIL
+    {
+        public bool IsStubRequired { get; }
+        public PInvokeILStubMethodIL(ILStubMethodIL methodIL, bool isStubRequired) : base(methodIL)
+        {
+            IsStubRequired = isStubRequired;
+        }
+    }
+}

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -40,6 +40,9 @@
     <Compile Include="..\Common\TypeSystem\IL\Stubs\RuntimeHelpersIntrinsics.cs" Link="IL\Stubs\RuntimeHelpersIntrinsics.cs" />
     <Compile Include="..\Common\TypeSystem\IL\Stubs\UnsafeIntrinsics.cs" Link="IL\Stubs\UnsafeIntrinsics.cs" />
     <Compile Include="..\Common\TypeSystem\IL\Stubs\VolatileIntrinsics.cs" Link="IL\Stubs\VolatileIntrinsics.cs" />
+    <Compile Include="..\Common\TypeSystem\IL\Stubs\PInvokeILCodeStreams.cs" Link="IL\Stubs\PInvokeILCodeStreams.cs" />
+    <Compile Include="..\Common\TypeSystem\Interop\IL\Marshaller.cs" Link="Interop\IL\Marshaller.cs" />
+    <Compile Include="..\Common\TypeSystem\Interop\IL\MarshalHelpers.cs" Link="Interop\IL\MarshalHelpers.cs" />
     <Compile Include="..\Common\Compiler\CodeGenerationFailedException.cs" Link="Compiler\CodeGenerationFailedException.cs" />
     <Compile Include="..\Common\Compiler\CompilationBuilder.cs" Link="Compiler\CompilationBuilder.cs" />
     <Compile Include="..\Common\Compiler\CompilationModuleGroup.cs" Link="Compiler\CompilationModuleGroup.cs" />
@@ -95,6 +98,7 @@
     <Compile Include="..\Common\Compiler\Logger.cs" Link="Compiler\Logger.cs" />
     <Compile Include="..\Common\JitInterface\CorInfoTypes.VarInfo.cs" Link="JitInterface\CorInfoTypes.VarInfo.cs" />
     <Compile Include="..\Common\JitInterface\SystemVStructClassificator.cs" Link="JitInterface\SystemVStructClassificator.cs" />
+    <Compile Include="..\Common\TypeSystem\Interop\InteropTypes.cs" Link="Interop\InteropTypes.cs" />
     <Compile Include="CodeGen\ReadyToRunObjectWriter.cs" />
     <Compile Include="Compiler\CompilationModuleGroup.ReadyToRun.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ArgIterator.cs" />
@@ -178,6 +182,8 @@
     <Compile Include="Compiler\ReadyToRunTableManager.cs" />
     <Compile Include="IBC\IBCProfileData.cs" />
     <Compile Include="IBC\IBCProfileParser.cs" />
+    <Compile Include="IL\Stubs\PInvokeILEmitter.cs" />
+    <Compile Include="Interop\IL\Marshaller.ReadyToRun.cs" />
     <Compile Include="Compiler\PerfEventSource.cs" />
     <Compile Include="Win32Resources\ResourceData.cs" />
     <Compile Include="Win32Resources\ResourceData.Reader.cs" />

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Interop/IL/Marshaller.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Interop/IL/Marshaller.ReadyToRun.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem.Interop
+{
+    partial class Marshaller
+    {
+        protected static Marshaller CreateMarshaller(MarshallerKind kind)
+        {
+            switch (kind)
+            {
+                case MarshallerKind.Enum:
+                case MarshallerKind.BlittableValue:
+                case MarshallerKind.BlittableStruct:
+                case MarshallerKind.UnicodeChar:
+                    return new BlittableValueMarshaller();
+                case MarshallerKind.BlittableStructPtr:
+                    return new BlittableStructPtrMarshaller();
+                case MarshallerKind.BlittableArray:
+                    return new BlittableArrayMarshaller();
+                case MarshallerKind.Bool:
+                case MarshallerKind.CBool:
+                    return new BooleanMarshaller();
+                case MarshallerKind.AnsiString:
+                    return new AnsiStringMarshaller();
+                case MarshallerKind.UTF8String:
+                    return new UTF8StringMarshaller();
+                case MarshallerKind.SafeHandle:
+                    return new SafeHandleMarshaller();
+                case MarshallerKind.UnicodeString:
+                    return new UnicodeStringMarshaller();
+                case MarshallerKind.VoidReturn:
+                    return new VoidReturnMarshaller();
+                case MarshallerKind.FunctionPointer:
+                    return new DelegateMarshaller();
+                default:
+                    // ensures we don't throw during create marshaller. We will throw NSE
+                    // during EmitIL which will be handled.
+                    return new NotSupportedMarshaller();
+            }
+        }
+    }
+}

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -352,7 +352,7 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
     if (pConfig->MayUsePrecompiledCode())
     {
 #ifdef FEATURE_READYTORUN
-        if (this->IsDynamicMethod() && GetLoaderModule()->IsSystem() && MayUsePrecompiledILStub())
+        if (this->IsDynamicMethod() && MayUsePrecompiledILStub())
         {
             DynamicMethodDesc *stubMethodDesc = this->AsDynamicMethodDesc();
             if (stubMethodDesc->IsILStub() && stubMethodDesc->IsPInvokeStub())

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -352,7 +352,8 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
     if (pConfig->MayUsePrecompiledCode())
     {
 #ifdef FEATURE_READYTORUN
-        if (this->IsDynamicMethod() && MayUsePrecompiledILStub())
+        // TODO: Remove IsSystem check when IL Stubs are fixed to be non-shared
+        if (this->IsDynamicMethod() && GetLoaderModule()->IsSystem() && MayUsePrecompiledILStub())
         {
             DynamicMethodDesc *stubMethodDesc = this->AsDynamicMethodDesc();
             if (stubMethodDesc->IsILStub() && stubMethodDesc->IsPInvokeStub())


### PR DESCRIPTION
Taking PR #27585 on behalf of @MichalStrehovsky, but without the prestub.cpp changes, and without the changes to emit the IL stubs.

This is a first step into getting the changes, and the ILStubs will be enabled in a separate PR once they get fixed to be non-shared.

cc @MichalStrehovsky @jkotas @sergiy-k @dotnet/crossgen-contrib