### PR TITLE
Support custom modifier for method signature

### DIFF
--- a/src/tools/crossgen2/Common/TypeSystem/Common/MethodDesc.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Common/MethodDesc.cs
@@ -24,10 +24,16 @@ namespace Internal.TypeSystem
         Static = 0x0010,
     }
 
-    public struct CustomModifier
+    public enum EmbeddedSignatureDataKind
+    {
+        RequiredCustomModifier = 0,
+        OptionalCustomModifier = 1
+    }
+
+    public struct EmbeddedSignatureData
     {
         public string index;
-        public bool required;
+        public EmbeddedSignatureDataKind kind;
         public TypeDesc type;
     }
 
@@ -40,15 +46,15 @@ namespace Internal.TypeSystem
         internal int _genericParameterCount;
         internal TypeDesc _returnType;
         internal TypeDesc[] _parameters;
-        internal CustomModifier[] _customModifiers;
+        internal EmbeddedSignatureData[] _embeddedSignatureData;
 
-        public MethodSignature(MethodSignatureFlags flags, int genericParameterCount, TypeDesc returnType, TypeDesc[] parameters, CustomModifier[] customModifiers = null)
+        public MethodSignature(MethodSignatureFlags flags, int genericParameterCount, TypeDesc returnType, TypeDesc[] parameters, EmbeddedSignatureData[] embeddedSignatureData = null)
         {
             _flags = flags;
             _genericParameterCount = genericParameterCount;
             _returnType = returnType;
             _parameters = parameters;
-            _customModifiers = customModifiers;
+            _embeddedSignatureData = embeddedSignatureData;
 
             Debug.Assert(parameters != null, "Parameters must not be null");
         }
@@ -129,25 +135,25 @@ namespace Internal.TypeSystem
                     return false;
             }
 
-            if (this._customModifiers == null && otherSignature._customModifiers == null)
+            if (this._embeddedSignatureData == null && otherSignature._embeddedSignatureData == null)
             {
                 return true;
             }
 
-            if (this._customModifiers != null && otherSignature._customModifiers != null)
+            if (this._embeddedSignatureData != null && otherSignature._embeddedSignatureData != null)
             {
-                if (this._customModifiers.Length != otherSignature._customModifiers.Length)
+                if (this._embeddedSignatureData.Length != otherSignature._embeddedSignatureData.Length)
                 {
                     return false;
                 }
 
-                for (int i = 0; i < this._customModifiers.Length; i++)
+                for (int i = 0; i < this._embeddedSignatureData.Length; i++)
                 {
-                    if (this._customModifiers[i].index != otherSignature._customModifiers[i].index)
+                    if (this._embeddedSignatureData[i].index != otherSignature._embeddedSignatureData[i].index)
                         return false;
-                    if (this._customModifiers[i].required != otherSignature._customModifiers[i].required)
+                    if (this._embeddedSignatureData[i].kind != otherSignature._embeddedSignatureData[i].kind)
                         return false;
-                    if (this._customModifiers[i].type != otherSignature._customModifiers[i].type)
+                    if (this._embeddedSignatureData[i].type != otherSignature._embeddedSignatureData[i].type)
                         return false;
                 }
 
@@ -208,7 +214,7 @@ namespace Internal.TypeSystem
         private int _genericParameterCount;
         private TypeDesc _returnType;
         private TypeDesc[] _parameters;
-        private CustomModifier[] _customModifiers;
+        private EmbeddedSignatureData[] _customModifiers;
 
         public MethodSignatureBuilder(MethodSignature template)
         {
@@ -218,7 +224,7 @@ namespace Internal.TypeSystem
             _genericParameterCount = template._genericParameterCount;
             _returnType = template._returnType;
             _parameters = template._parameters;
-            _customModifiers = template._customModifiers;
+            _customModifiers = template._embeddedSignatureData;
         }
 
         public MethodSignatureFlags Flags

--- a/src/tools/crossgen2/Common/TypeSystem/Common/MethodDesc.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Common/MethodDesc.cs
@@ -24,6 +24,13 @@ namespace Internal.TypeSystem
         Static = 0x0010,
     }
 
+    public struct CustomModifier
+    {
+        public string index;
+        public bool required;
+        public TypeDesc type;
+    }
+
     /// <summary>
     /// Represents the parameter types, the return type, and flags of a method.
     /// </summary>
@@ -33,13 +40,15 @@ namespace Internal.TypeSystem
         internal int _genericParameterCount;
         internal TypeDesc _returnType;
         internal TypeDesc[] _parameters;
+        internal CustomModifier[] _customModifiers;
 
-        public MethodSignature(MethodSignatureFlags flags, int genericParameterCount, TypeDesc returnType, TypeDesc[] parameters)
+        public MethodSignature(MethodSignatureFlags flags, int genericParameterCount, TypeDesc returnType, TypeDesc[] parameters, CustomModifier[] customModifiers = null)
         {
             _flags = flags;
             _genericParameterCount = genericParameterCount;
             _returnType = returnType;
             _parameters = parameters;
+            _customModifiers = customModifiers;
 
             Debug.Assert(parameters != null, "Parameters must not be null");
         }
@@ -120,7 +129,32 @@ namespace Internal.TypeSystem
                     return false;
             }
 
-            return true;
+            if (this._customModifiers == null && otherSignature._customModifiers == null)
+            {
+                return true;
+            }
+
+            if (this._customModifiers != null && otherSignature._customModifiers != null)
+            {
+                if (this._customModifiers.Length != otherSignature._customModifiers.Length)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < this._customModifiers.Length; i++)
+                {
+                    if (this._customModifiers[i].index != otherSignature._customModifiers[i].index)
+                        return false;
+                    if (this._customModifiers[i].required != otherSignature._customModifiers[i].required)
+                        return false;
+                    if (this._customModifiers[i].type != otherSignature._customModifiers[i].type)
+                        return false;
+                }
+
+                return true;
+            }
+
+            return false;
         }
 
         public override bool Equals(object obj)
@@ -174,6 +208,7 @@ namespace Internal.TypeSystem
         private int _genericParameterCount;
         private TypeDesc _returnType;
         private TypeDesc[] _parameters;
+        private CustomModifier[] _customModifiers;
 
         public MethodSignatureBuilder(MethodSignature template)
         {
@@ -183,6 +218,7 @@ namespace Internal.TypeSystem
             _genericParameterCount = template._genericParameterCount;
             _returnType = template._returnType;
             _parameters = template._parameters;
+            _customModifiers = template._customModifiers;
         }
 
         public MethodSignatureFlags Flags
@@ -237,7 +273,7 @@ namespace Internal.TypeSystem
                 _returnType != _template._returnType ||
                 _parameters != _template._parameters)
             {
-                _template = new MethodSignature(_flags, _genericParameterCount, _returnType, _parameters);
+                _template = new MethodSignature(_flags, _genericParameterCount, _returnType, _parameters, _customModifiers);
             }
 
             return _template;

--- a/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -137,7 +137,7 @@ namespace Internal.TypeSystem.Ecma
                 case SignatureTypeCode.TypedReference:
                     return GetWellKnownType(WellKnownType.TypedReference);
                 case SignatureTypeCode.FunctionPointer:
-                    return _module.Context.GetFunctionPointerType(ParseMethodSignatureInternal());
+                    return _module.Context.GetFunctionPointerType(ParseMethodSignatureInternal(skipCustomModifier: true));
                 default:
                     throw new BadImageFormatException();
             }
@@ -231,7 +231,7 @@ namespace Internal.TypeSystem.Ecma
                 _indexStack = new Stack<Frame>();
                 _indexStack.Push(new Frame());
                 _customModifiers = new List<CustomModifier>();
-                return ParseMethodSignatureInternal();
+                return ParseMethodSignatureInternal(skipCustomModifier: false);
             }
             finally
             {
@@ -241,14 +241,14 @@ namespace Internal.TypeSystem.Ecma
 
         }
 
-        private MethodSignature ParseMethodSignatureInternal()
+        private MethodSignature ParseMethodSignatureInternal(bool skipCustomModifier)
         {
             if (_indexStack != null)
             {
                 _indexStack.Peek().index++;
                 _indexStack.Push(new Frame());
             }
-            MethodSignature result = ParseMethodSignatureImpl();
+            MethodSignature result = ParseMethodSignatureImpl(skipCustomModifier);
             if (_indexStack != null)
             {
                 _indexStack.Pop();
@@ -256,7 +256,7 @@ namespace Internal.TypeSystem.Ecma
             return result;
         }
 
-        public MethodSignature ParseMethodSignatureImpl()
+        public MethodSignature ParseMethodSignatureImpl(bool skipCustomModifier)
         {
             SignatureHeader header = _reader.ReadSignatureHeader();
 
@@ -298,7 +298,7 @@ namespace Internal.TypeSystem.Ecma
                 parameters = TypeDesc.EmptyTypes;
             }
 
-            CustomModifier[] customModifiersArray = (_customModifiers == null || _customModifiers.Count == 0) ? null : _customModifiers.ToArray();
+            CustomModifier[] customModifiersArray = (_customModifiers == null || _customModifiers.Count == 0 || skipCustomModifier) ? null : _customModifiers.ToArray();
 
             return new MethodSignature(flags, arity, returnType, parameters, customModifiersArray);
 


### PR DESCRIPTION
To support proper method overloading resolution, we need to capture and compare the custom modifiers in the signature. 

@dotnet/crossgen-contrib 