### PR TITLE
Fix for two subtle bugs I made yesterday in init-dotnet

### DIFF
--- a/init-dotnet.cmd
+++ b/init-dotnet.cmd
@@ -1,10 +1,11 @@
 @if not defined _echo @echo off
 setlocal
 
-set "__RepoRootDir=%~dp0..\..\"
+set "__ProjectDir=%~dp0"
+set "__RepoRootDir=%__ProjectDir%..\..\"
 
 rem Remove after repo consolidation
-if not exist "%__RepoRootDir%\.dotnet-runtime-placeholder" ( set "__RepoRootDir=!__ProjectDir!" )
+if not exist "%__RepoRootDir%\.dotnet-runtime-placeholder" ( set "__RepoRootDir=%__ProjectDir%" )
 
 echo Installing dotnet using Arcade...
 set PS_DOTNET_INSTALL_SCRIPT=". %__RepoRootDir%eng\configure-toolset.ps1; . %__RepoRootDir%eng\common\tools.ps1; InitializeBuildTool"


### PR DESCRIPTION
1) In the "old repo conditional block", I used __ProjectDir even
though it was not defined in the script. This is normally benign
when the script is run from build.cmd which defines the variable
but it means that the script cannot be run directly from shell.

2) In a similar vein, I used !__ProjectDir! in the script even though
it doesn't have the delayed variable expansion flag enabled. Again,
the flag is set in the main build.cmd script but the init-dotnet
script couldn't be run directly. Thankfully in this particular case
we don't need the delayed expansion so I just changed ! to %.

Thanks

Tomas