### PR TITLE
Updating NumberToFloatingPointBitsSlow to handle the remaining parsed fractional digits being zero.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Number.NumberToFloatingPointBits.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.NumberToFloatingPointBits.cs
@@ -484,7 +484,16 @@ namespace System
             }
 
             AccumulateDecimalDigitsIntoBigInteger(ref number, fractionalFirstIndex, fractionalLastIndex, out BigInteger fractionalNumerator);
-            Debug.Assert(!fractionalNumerator.IsZero());
+
+            if (fractionalNumerator.IsZero())
+            {
+                return ConvertBigIntegerToFloatingPointBits(
+                    ref integerValue,
+                    in info,
+                    integerBitsOfPrecision,
+                    fractionalDigitsPresent != 0
+                );
+            }
 
             BigInteger.Pow10(fractionalDenominatorExponent, out BigInteger fractionalDenominator);
 


### PR DESCRIPTION
This is required for https://github.com/dotnet/coreclr/pull/27280 and can be hit in the scenario where the user requests, for example, 17 digits (`"G17"), and the exact value contains more than 17 digits where not all 17 digits are integral. So, if the first 16 digits are integral, the 17th digit (the first fractional digit) can be zero and the 18th digit (non-included fractional) is non-zero.