### PR TITLE
Avoid memset in case of HENUMInternal

### DIFF
--- a/src/md/compiler/filtermanager.cpp
+++ b/src/md/compiler/filtermanager.cpp
@@ -900,7 +900,7 @@ HRESULT FilterManager::MarkMethodImplsWithParentToken(mdTypeDef td)
     // We know that the filter table is not null here.  Tell PREFIX that we know it.
     PREFIX_ASSUME(m_pMiniMd->GetFilterTable() != NULL);
 
-    memset(&hEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(&hEnum);
     IfFailGo( m_pMiniMd->FindMethodImplHelper(td, &hEnum) );
 
     while (HENUMInternal::EnumNext(&hEnum, (mdToken *)&index))

--- a/src/md/compiler/import.cpp
+++ b/src/md/compiler/import.cpp
@@ -794,7 +794,7 @@ STDMETHODIMP RegMeta::EnumMethodImpls(        // S_OK, S_FALSE, or error
     START_MD_PERF();
     LOCKREAD();
 
-    memset(&hEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(&hEnum);
 
     if ( pEnum == 0 )
     {
@@ -1545,7 +1545,7 @@ STDMETHODIMP RegMeta::GetEventProps(          // S_OK, S_FALSE, or error.
 
     _ASSERTE(TypeFromToken(ev) == mdtEvent);
 
-    memset(&hEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(&hEnum);
     IfFailGo(pMiniMd->GetEventRecord(RidFromToken(ev), &pRec));
 
     if ( pClass )
@@ -1717,7 +1717,7 @@ STDMETHODIMP RegMeta::GetMethodSemantics(     // S_OK, S_FALSE, or error.
     _ASSERTE( pdwSemanticsFlags );
 
     *pdwSemanticsFlags = 0;
-    memset(&hEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(&hEnum);
 
     // loop through all methods associated with this tkEventProp
     IfFailGo( pMiniMd->FindMethodSemanticsHelper(tkEventProp, &hEnum) );
@@ -2990,7 +2990,7 @@ HRESULT RegMeta::GetPropertyProps(      // S_OK, S_FALSE, or error.
 
     pMiniMd = &(m_pStgdb->m_MiniMd);
 
-    memset(&hEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(&hEnum);
     IfFailGo(pMiniMd->GetPropertyRecord(RidFromToken(prop), &pRec));
 
     if ( pClass )

--- a/src/md/compiler/regmeta_emit.cpp
+++ b/src/md/compiler/regmeta_emit.cpp
@@ -1089,7 +1089,7 @@ HRESULT RegMeta::_DefineMethodSemantics(    // S_OK or error.
 
     _ASSERTE(TypeFromToken(md) == mdtMethodDef || IsNilToken(md));
     _ASSERTE(RidFromToken(tkAssoc));
-    memset(&hEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(&hEnum);
 
     // Clear all matching records by setting association to a Nil token.
     if (bClear)

--- a/src/md/enc/mdinternalrw.cpp
+++ b/src/md/enc/mdinternalrw.cpp
@@ -756,7 +756,7 @@ HRESULT MDInternalRW::EnumTypeDefInit( // return hresult
 
     _ASSERTE(phEnum);
 
-    memset(phEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(phEnum);
     phEnum->m_tkKind = mdtTypeDef;
 
     if ( m_pStgdb->m_MiniMd.HasDelete() )
@@ -821,9 +821,9 @@ HRESULT MDInternalRW::EnumMethodImplInit( // return hresult
     _ASSERTE(TypeFromToken(td) == mdtTypeDef && !IsNilToken(td));
     _ASSERTE(phEnumBody && phEnumDecl);
 
-    memset(phEnumBody, 0, sizeof(HENUMInternal));
-    memset(phEnumDecl, 0, sizeof(HENUMInternal));
-    memset(&hEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(phEnumBody);
+    HENUMInternal::ZeroEnum(phEnumDecl);
+    HENUMInternal::ZeroEnum(&hEnum);
 
     HENUMInternal::InitDynamicArrayEnum(phEnumBody);
     HENUMInternal::InitDynamicArrayEnum(phEnumDecl);
@@ -968,7 +968,7 @@ HRESULT MDInternalRW::EnumInit(     // return S_FALSE if record not found
 
     // Vars for query.
     _ASSERTE(phEnum);
-    memset(phEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(phEnum);
 
     // cache the tkKind and the scope
     phEnum->m_tkKind = TypeFromToken(tkKind);
@@ -1385,7 +1385,7 @@ HRESULT MDInternalRW::EnumAllInit(      // return S_FALSE if record not found
 
     // Vars for query.
     _ASSERTE(phEnum);
-    memset(phEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(phEnum);
 
     // cache the tkKind and the scope
     phEnum->m_tkKind = TypeFromToken(tkKind);
@@ -3971,7 +3971,7 @@ HRESULT MDInternalRW::EnumDeltaTokensInit(  // return hresult
 
     // Vars for query.
     _ASSERTE(phEnum);
-    memset(phEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(phEnum);
 
     // cache the tkKind and the scope
     phEnum->m_tkKind = 0;

--- a/src/md/enc/metamodelrw.cpp
+++ b/src/md/enc/metamodelrw.cpp
@@ -792,7 +792,7 @@ CMiniMdRW::CommonEnumCustomAttributeByName(
 
     _ASSERTE(phEnum != NULL);
 
-    memset(phEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(phEnum);
 
     HENUMInternal::InitDynamicArrayEnum(phEnum);
 

--- a/src/md/enc/rwutil.cpp
+++ b/src/md/enc/rwutil.cpp
@@ -68,7 +68,7 @@ HRESULT HENUMInternal::CreateSimpleEnum(
     if (pEnum == NULL)
         IfFailGo( E_OUTOFMEMORY );
 
-    memset(pEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(pEnum);
     pEnum->m_tkKind = tkKind;
     pEnum->m_EnumType = MDSimpleEnum;
     pEnum->u.m_ulStart = pEnum->u.m_ulCur = ridStart;
@@ -334,7 +334,7 @@ HRESULT HENUMInternal::CreateDynamicArrayEnum(
     if (pEnum == NULL)
         IfFailGo( E_OUTOFMEMORY );
 
-    memset(pEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(pEnum);
     pEnum->m_tkKind = tkKind;
     pEnum->m_EnumType = MDDynamicArrayEnum;
 
@@ -358,7 +358,7 @@ void HENUMInternal::InitDynamicArrayEnum(
 {
     TOKENLIST       *pdalist;
 
-    memset(pEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(pEnum);
     pEnum->m_EnumType = MDDynamicArrayEnum;
     pEnum->m_tkKind = (DWORD) -1;
 

--- a/src/md/runtime/mdinternalro.cpp
+++ b/src/md/runtime/mdinternalro.cpp
@@ -199,7 +199,7 @@ HRESULT MDInternalRO::EnumTypeDefInit( // return hresult
 
     _ASSERTE(phEnum);
 
-    memset(phEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(phEnum);
     phEnum->m_tkKind = mdtTypeDef;
     phEnum->m_EnumType = MDSimpleEnum;
     phEnum->m_ulCount = m_LiteWeightStgdb.m_MiniMd.getCountTypeDefs();
@@ -502,7 +502,7 @@ HRESULT MDInternalRO::EnumAllInit(      // return S_FALSE if record not found
 
     // Vars for query.
     _ASSERTE(phEnum);
-    memset(phEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(phEnum);
 
     // cache the tkKind and the scope
     phEnum->m_tkKind = TypeFromToken(tkKind);
@@ -2582,7 +2582,7 @@ HRESULT MDInternalRO::EnumAssociateInit(
     HRESULT hr;
     _ASSERTE(phEnum);
 
-    memset(phEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(phEnum);
 
     // There is no token kind!!!
     phEnum->m_tkKind = UINT32_MAX;

--- a/src/md/runtime/metamodelro.cpp
+++ b/src/md/runtime/metamodelro.cpp
@@ -211,7 +211,7 @@ CMiniMd::CommonEnumCustomAttributeByName(
 
     _ASSERTE(phEnum != NULL);
 
-    memset(phEnum, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(phEnum);
 
     HENUMInternal::InitDynamicArrayEnum(phEnum);
 

--- a/src/md/winmd/winmdinternalimportro.cpp
+++ b/src/md/winmd/winmdinternalimportro.cpp
@@ -196,7 +196,7 @@ class WinMDInternalImportRO : public IMDInternalImport, IWinMDImport, IMetaModel
         if (FAILED(hr))
         {
             HENUMInternal::ClearEnum(phEnumBody);
-            INDEBUG(memset(phEnumBody, 0xcc, sizeof(HENUMInternal)));
+            INDEBUG(HENUMInternal::ZeroEnum(phEnumBody));
         }
         return hr;
     }

--- a/src/vm/encee.cpp
+++ b/src/vm/encee.cpp
@@ -206,7 +206,7 @@ HRESULT EditAndContinueModule::ApplyEditAndContinue(
     memcpy(pLocalILMemory, pDeltaIL, cbDeltaIL);
 
     // Enumerate all of the EnC delta tokens
-    memset(&enumENC, 0, sizeof(HENUMInternal));
+    HENUMInternal::ZeroEnum(&enumENC);
     IfFailGo(pIMDInternalImportENC->EnumDeltaTokensInit(&enumENC));
 
     mdToken token;


### PR DESCRIPTION
gcc9 complains:

```sh
/datadrive/projects/coreclr/src/md/runtime/mdinternalro.cpp: In member function virtual HRESULT MDInternalRO::EnumTypeDefInit(HENUMInternal*):
/datadrive/projects/coreclr/src/md/runtime/mdinternalro.cpp:202:44: error: void* memset(void*, int, size_t) clearing an object of non-trivial type struct HENUMInternal; use assignment or value-initialization instead [-Werror=class-memaccess]
  202 |     memset(phEnum, 0, sizeof(HENUMInternal));
      |                                            ^
In file included from /datadrive/projects/coreclr/src/inc/corpriv.h:21,
                 from /datadrive/projects/coreclr/src/md/runtime/stdafx.h:20,
                 from /datadrive/projects/coreclr/src/md/runtime/mdinternalro.cpp:12:
/datadrive/projects/coreclr/src/inc/metadata.h:87:8: note: struct HENUMInternal declared here
   87 | struct HENUMInternal
      |        ^~~~~~~~~~~~~
```

As it turned out, there already is a static helper defined on this type
with a comment to prefer it over memset, this patch just replaces the
usage.

Contributes to: #24518