### PR TITLE
Fix intermittent arm/arm64 Linux build failures

### DIFF
--- a/src/pal/src/eventprovider/lttngprovider/CMakeLists.txt
+++ b/src/pal/src/eventprovider/lttngprovider/CMakeLists.txt
@@ -40,16 +40,27 @@ add_custom_command(OUTPUT ${LTTNG_PROVIDER_SOURCES} ${TRACEPOINT_PROVIDER_SOURCE
   COMMAND ${GENERATE_COMMAND}
   DEPENDS ${EVENT_MANIFEST} ${GENERATE_SCRIPT})
 
+set_source_files_properties(
+  ${LTTNG_PROVIDER_SOURCES} ${TRACEPOINT_PROVIDER_SOURCES} ${LTTNG_HEADERS}
+  PROPERTIES GENERATED TRUE)
+
+add_custom_target(
+  generated_eventing_headers
+  DEPENDS ${LTTNG_HEADERS})
+
 add_library(eventprovider
-    STATIC
-    ${LTTNG_PROVIDER_SOURCES}
-    eventproviderhelpers.cpp
+  STATIC
+  ${LTTNG_PROVIDER_SOURCES}
+  eventproviderhelpers.cpp
 )
 
 add_library(coreclrtraceptprovider
-    SHARED
-    ${TRACEPOINT_PROVIDER_SOURCES}
+  SHARED
+  ${TRACEPOINT_PROVIDER_SOURCES}
 )
+
+add_dependencies(eventprovider generated_eventing_headers)
+add_dependencies(coreclrtraceptprovider generated_eventing_headers)
 
 find_library(LTTNG NAMES lttng-ust)
 


### PR DESCRIPTION
The arm/arm64 Linux builds were recently failing intermittently
with a weird error in macro expansion in one of the generated
eventing headers. It seems that the issue is caused by the fact
that we were not creating a custom_target to enable handling
dependencies on the generated header files and we were also
not marking the files as generated.
I've noticed that the message indicating that the headers are
being generated was printed twice in the build log. with this
fix, it occurs only once there.
So I believe that the issue was caused by the headers being
generated twice by two different threads and when that happened,
the files got corrupted.

Close #27622