### PR TITLE
Fix VN for byrefx on x86.

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -1592,6 +1592,41 @@ ValueNumStore::Chunk* ValueNumStore::GetAllocChunk(var_types              typ,
     return res;
 }
 
+//------------------------------------------------------------------------
+// VnForConst: Return value number for a constant.
+//
+// Arguments:
+//   cnsVal - `T` constant to return a VN for;
+//   numMap - VNMap<T> map where `T` type constants should be stored;
+//   varType - jit type for the `T`: TYP_INT for int, TYP_LONG for long etc.
+//
+// Return value:
+//    value number for the given constant.
+//
+// Notes:
+//   First try to find an existing VN for `cnsVal` in `numMap`,
+//   if it fails then allocate a new `varType` chunk and return that.
+//
+template <typename T, typename NumMap>
+ValueNum ValueNumStore::VnForConst(T cnsVal, NumMap* numMap, var_types varType)
+{
+    ValueNum res;
+    if (numMap->Lookup(cnsVal, &res))
+    {
+        return res;
+    }
+    else
+    {
+        Chunk*   chunk               = GetAllocChunk(varType, CEA_Const);
+        unsigned offsetWithinChunk   = chunk->AllocVN();
+        res                          = chunk->m_baseVN + offsetWithinChunk;
+        T* chunkDefs                 = reinterpret_cast<T*>(chunk->m_defs);
+        chunkDefs[offsetWithinChunk] = cnsVal;
+        numMap->Set(cnsVal, res);
+        return res;
+    }
+}
+
 ValueNum ValueNumStore::VNForIntCon(INT32 cnsVal)
 {
     if (IsSmallIntConst(cnsVal))
@@ -1602,86 +1637,34 @@ ValueNum ValueNumStore::VNForIntCon(INT32 cnsVal)
         {
             return vn;
         }
-        vn                          = GetVNForIntCon(cnsVal);
+        vn                          = VnForConst(cnsVal, GetIntCnsMap(), TYP_INT);
         m_VNsForSmallIntConsts[ind] = vn;
         return vn;
     }
     else
     {
-        return GetVNForIntCon(cnsVal);
+        return VnForConst(cnsVal, GetIntCnsMap(), TYP_INT);
     }
 }
 
 ValueNum ValueNumStore::VNForLongCon(INT64 cnsVal)
 {
-    ValueNum res;
-    if (GetLongCnsMap()->Lookup(cnsVal, &res))
-    {
-        return res;
-    }
-    else
-    {
-        Chunk*   c                                             = GetAllocChunk(TYP_LONG, CEA_Const);
-        unsigned offsetWithinChunk                             = c->AllocVN();
-        res                                                    = c->m_baseVN + offsetWithinChunk;
-        reinterpret_cast<INT64*>(c->m_defs)[offsetWithinChunk] = cnsVal;
-        GetLongCnsMap()->Set(cnsVal, res);
-        return res;
-    }
+    return VnForConst(cnsVal, GetLongCnsMap(), TYP_LONG);
 }
 
 ValueNum ValueNumStore::VNForFloatCon(float cnsVal)
 {
-    ValueNum res;
-    if (GetFloatCnsMap()->Lookup(cnsVal, &res))
-    {
-        return res;
-    }
-    else
-    {
-        Chunk*   c                                             = GetAllocChunk(TYP_FLOAT, CEA_Const);
-        unsigned offsetWithinChunk                             = c->AllocVN();
-        res                                                    = c->m_baseVN + offsetWithinChunk;
-        reinterpret_cast<float*>(c->m_defs)[offsetWithinChunk] = cnsVal;
-        GetFloatCnsMap()->Set(cnsVal, res);
-        return res;
-    }
+    return VnForConst(cnsVal, GetFloatCnsMap(), TYP_FLOAT);
 }
 
 ValueNum ValueNumStore::VNForDoubleCon(double cnsVal)
 {
-    ValueNum res;
-    if (GetDoubleCnsMap()->Lookup(cnsVal, &res))
-    {
-        return res;
-    }
-    else
-    {
-        Chunk*   c                                              = GetAllocChunk(TYP_DOUBLE, CEA_Const);
-        unsigned offsetWithinChunk                              = c->AllocVN();
-        res                                                     = c->m_baseVN + offsetWithinChunk;
-        reinterpret_cast<double*>(c->m_defs)[offsetWithinChunk] = cnsVal;
-        GetDoubleCnsMap()->Set(cnsVal, res);
-        return res;
-    }
+    return VnForConst(cnsVal, GetDoubleCnsMap(), TYP_DOUBLE);
 }
 
 ValueNum ValueNumStore::VNForByrefCon(size_t cnsVal)
 {
-    ValueNum res;
-    if (GetByrefCnsMap()->Lookup(cnsVal, &res))
-    {
-        return res;
-    }
-    else
-    {
-        Chunk*   c                                             = GetAllocChunk(TYP_BYREF, CEA_Const);
-        unsigned offsetWithinChunk                             = c->AllocVN();
-        res                                                    = c->m_baseVN + offsetWithinChunk;
-        reinterpret_cast<size_t*>(c->m_defs)[offsetWithinChunk] = cnsVal;
-        GetByrefCnsMap()->Set(cnsVal, res);
-        return res;
-    }
+    return VnForConst(cnsVal, GetByrefCnsMap(), TYP_BYREF);
 }
 
 ValueNum ValueNumStore::VNForCastOper(var_types castToType, bool srcIsUnsigned /*=false*/)

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -1678,7 +1678,7 @@ ValueNum ValueNumStore::VNForByrefCon(size_t cnsVal)
         Chunk*   c                                             = GetAllocChunk(TYP_BYREF, CEA_Const);
         unsigned offsetWithinChunk                             = c->AllocVN();
         res                                                    = c->m_baseVN + offsetWithinChunk;
-        reinterpret_cast<INT64*>(c->m_defs)[offsetWithinChunk] = cnsVal;
+        reinterpret_cast<size_t*>(c->m_defs)[offsetWithinChunk] = cnsVal;
         GetByrefCnsMap()->Set(cnsVal, res);
         return res;
     }

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -225,6 +225,9 @@ private:
     // MapSelect application.
     int m_mapSelectBudget;
 
+    template <typename T, typename NumMap>
+    inline ValueNum VnForConst(T cnsVal, NumMap* numMap, var_types varType);
+
 public:
     // Initializes any static variables of ValueNumStore.
     static void InitValueNumStoreStatics();
@@ -257,15 +260,11 @@ public:
 #endif // DEBUG
 
     // This block of methods gets value numbers for constants of primitive types.
-
     ValueNum VNForIntCon(INT32 cnsVal);
     ValueNum VNForLongCon(INT64 cnsVal);
     ValueNum VNForFloatCon(float cnsVal);
     ValueNum VNForDoubleCon(double cnsVal);
     ValueNum VNForByrefCon(size_t byrefVal);
-
-    template <typename T, typename NumMap>
-    inline ValueNum VnForConst(T cnsVal, NumMap* numMap, var_types varType);
 
 #ifdef _TARGET_64BIT_
     ValueNum VNForPtrSizeIntCon(INT64 cnsVal)

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -264,6 +264,9 @@ public:
     ValueNum VNForDoubleCon(double cnsVal);
     ValueNum VNForByrefCon(size_t byrefVal);
 
+    template <typename T, typename NumMap>
+    inline ValueNum VnForConst(T cnsVal, NumMap* numMap, var_types varType);
+
 #ifdef _TARGET_64BIT_
     ValueNum VNForPtrSizeIntCon(INT64 cnsVal)
     {
@@ -1144,24 +1147,6 @@ private:
             m_intCnsMap = new (m_alloc) IntToValueNumMap(m_alloc);
         }
         return m_intCnsMap;
-    }
-
-    ValueNum GetVNForIntCon(INT32 cnsVal)
-    {
-        ValueNum res;
-        if (GetIntCnsMap()->Lookup(cnsVal, &res))
-        {
-            return res;
-        }
-        else
-        {
-            Chunk*   c                                             = GetAllocChunk(TYP_INT, CEA_Const);
-            unsigned offsetWithinChunk                             = c->AllocVN();
-            res                                                    = c->m_baseVN + offsetWithinChunk;
-            reinterpret_cast<INT32*>(c->m_defs)[offsetWithinChunk] = cnsVal;
-            GetIntCnsMap()->Set(cnsVal, res);
-            return res;
-        }
     }
 
     typedef VNMap<INT64> LongToValueNumMap;

--- a/tests/src/JIT/Regression/JitBlue/GitHub_27279/GitHub_27279.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_27279/GitHub_27279.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+class GitHub_27279
+{
+    unsafe static int Main()
+    {
+        bool res = Unsafe.IsAddressLessThan(ref Unsafe.AsRef<byte>((void*)(-1)), ref Unsafe.AsRef<byte>((void*)(1)));
+        Console.WriteLine(res.ToString());
+        if (res)
+        {
+            return 101;
+        }        
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_27279/GitHub_27279.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_27279/GitHub_27279.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #27279.

Thanks @jkotas for the small repro, I have added it as [the first commit](https://github.com/dotnet/coreclr/pull/27702/commits/6672efdd97f79882ee352446b01ae377b5c21d6c).

[The second commit](https://github.com/dotnet/coreclr/pull/27702/commits/4c6b7bbfa2c792a7a0585be965a10569d05e736f) fixes the issues.

[The third commit](https://github.com/dotnet/coreclr/pull/27702/commits/2749ca315950baed754937cfc23ea40e1afad1e5) was my try to delete code duplication between `VNFor*Con` methods so we don't have issues like that in the future. However, I do not like that the template function has 3 arguments, so I will probably drop it unless somebody thinks that it is better than the current version or knows how to improve that.

The issue itself means that all byrefs value numbers were incorrect on x86, but it is not a regression (the bug existing in 2015) so I do not think it should be backported.
