### PR TITLE
Consistently use `default` instead of `new Struct()`

### DIFF
--- a/src/System.Private.CoreLib/shared/Internal/IO/File.Windows.cs
+++ b/src/System.Private.CoreLib/shared/Internal/IO/File.Windows.cs
@@ -12,7 +12,7 @@ namespace Internal.IO
     {
         internal static bool InternalExists(string fullPath)
         {
-            Interop.Kernel32.WIN32_FILE_ATTRIBUTE_DATA data = new Interop.Kernel32.WIN32_FILE_ATTRIBUTE_DATA();
+            Interop.Kernel32.WIN32_FILE_ATTRIBUTE_DATA data = default;
             int errorCode = FillAttributeInfo(fullPath, ref data, returnErrorOnNotFound: true);
 
             return (errorCode == 0) && (data.dwFileAttributes != -1)
@@ -40,7 +40,7 @@ namespace Internal.IO
                         // FindFirstFile, however, will. Historically we always gave back attributes
                         // for marked-for-deletion files.
 
-                        var findData = new Interop.Kernel32.WIN32_FIND_DATA();
+                        Interop.Kernel32.WIN32_FIND_DATA findData = default;
                         using (SafeFindHandle handle = Interop.Kernel32.FindFirstFile(path, ref findData))
                         {
                             if (handle.IsInvalid)

--- a/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueue.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueue.cs
@@ -259,7 +259,7 @@ namespace System.Collections.Concurrent
         {
             get
             {
-                var spinner = new SpinWait();
+                SpinWait spinner = default;
                 while (true)
                 {
                     // Capture the head and tail, as well as the head's head and tail.
@@ -536,7 +536,7 @@ namespace System.Collections.Concurrent
             // an enqueuer to finish storing it.  Spin until it's there.
             if ((segment._slots[i].SequenceNumber & segment._slotsMask) != expectedSequenceNumberAndMask)
             {
-                var spinner = new SpinWait();
+                SpinWait spinner = default;
                 while ((Volatile.Read(ref segment._slots[i].SequenceNumber) & segment._slotsMask) != expectedSequenceNumberAndMask)
                 {
                     spinner.SpinOnce();

--- a/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
@@ -133,7 +133,7 @@ namespace System.Collections.Concurrent
             Slot[] slots = _slots;
 
             // Loop in case of contention...
-            var spinner = new SpinWait();
+            SpinWait spinner = default;
             while (true)
             {
                 // Get the head at which to try to dequeue.
@@ -215,7 +215,7 @@ namespace System.Collections.Concurrent
             Slot[] slots = _slots;
 
             // Loop in case of contention...
-            var spinner = new SpinWait();
+            SpinWait spinner = default;
             while (true)
             {
                 // Get the head at which to try to peek.
@@ -270,7 +270,7 @@ namespace System.Collections.Concurrent
             Slot[] slots = _slots;
 
             // Loop in case of contention...
-            var spinner = new SpinWait();
+            SpinWait spinner = default;
             while (true)
             {
                 // Get the tail at which to try to return.

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -1191,7 +1191,7 @@ namespace System.Collections.Generic
                 _version = dictionary._version;
                 _index = 0;
                 _getEnumeratorRetType = getEnumeratorRetType;
-                _current = new KeyValuePair<TKey, TValue>();
+                _current = default;
             }
 
             public bool MoveNext()
@@ -1215,7 +1215,7 @@ namespace System.Collections.Generic
                 }
 
                 _index = _dictionary._count + 1;
-                _current = new KeyValuePair<TKey, TValue>();
+                _current = default;
                 return false;
             }
 
@@ -1253,7 +1253,7 @@ namespace System.Collections.Generic
                 }
 
                 _index = 0;
-                _current = new KeyValuePair<TKey, TValue>();
+                _current = default;
             }
 
             DictionaryEntry IDictionaryEnumerator.Entry

--- a/src/System.Private.CoreLib/shared/System/Collections/Hashtable.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Hashtable.cs
@@ -669,7 +669,7 @@ namespace System.Collections
                     // Our memory model guarantee if we pick up the change in bucket from another processor,
                     // we will see the 'isWriterProgress' flag to be true or 'version' is changed in the reader.
                     //
-                    SpinWait spin = new SpinWait();
+                    SpinWait spin = default;
                     while (true)
                     {
                         // this is volatile read, following memory accesses can not be moved ahead of it.

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -536,7 +536,7 @@ namespace System.Diagnostics.Tracing
             {
                 // We ignore errors to keep with the convention that EventSources do not throw
                 // errors. Note we can't access m_throwOnWrites because this is a static method.
-                Guid retVal = new Guid();
+                Guid retVal = default;
 #if FEATURE_MANAGED_ETW
 #if PLATFORM_WINDOWS
                 Interop.Advapi32.EventActivityIdControl(
@@ -1700,7 +1700,7 @@ namespace System.Diagnostics.Tracing
             }
 
             byte[] bytes = Encoding.BigEndianUnicode.GetBytes(name);
-            var hash = new Sha1ForNonSecretPurposes();
+            Sha1ForNonSecretPurposes hash = default;
             hash.Start();
             hash.Append(namespaceBytes);
             hash.Append(bytes);
@@ -2172,7 +2172,7 @@ namespace System.Diagnostics.Tracing
                     fixed (char* msgStringPtr = msgString)
                     {
                         EventDescriptor descr = new EventDescriptor(0, 0, 0, (byte)level, 0, 0, keywords);
-                        EventProvider.EventData data = new EventProvider.EventData();
+                        EventProvider.EventData data = default;
                         data.Ptr = (ulong)msgStringPtr;
                         data.Size = (uint)(2 * (msgString.Length + 1));
                         data.Reserved = 0;
@@ -2935,7 +2935,7 @@ namespace System.Diagnostics.Tracing
                 // we don't want the manifest to show up in the event log channels so we specify as keywords
                 // everything but the first 8 bits (reserved for the 8 channels)
                 var manifestDescr = new EventDescriptor(0xFFFE, 1, 0, 0, 0xFE, 0xFFFE, 0x00ffFFFFffffFFFF);
-                ManifestEnvelope envelope = new ManifestEnvelope();
+                ManifestEnvelope envelope = default;
 
                 envelope.Format = ManifestEnvelope.ManifestFormats.SimpleXmlFormat;
                 envelope.MajorVersion = 1;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/DataCollector.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/DataCollector.cs
@@ -61,7 +61,7 @@ namespace System.Diagnostics.Tracing
 
         internal void Disable()
         {
-            this = new DataCollector();
+            this = default;
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/EventSourceActivity.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/EventSourceActivity.cs
@@ -94,8 +94,8 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public EventSourceActivity Start(string? eventName)
         {
-            var options = new EventSourceOptions();
-            var data = new EmptyStruct();
+            EventSourceOptions options = default;
+            EmptyStruct data = default;
             return this.Start(eventName, ref options, ref data);
         }
         /// <summary>
@@ -103,7 +103,7 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public EventSourceActivity Start(string? eventName, EventSourceOptions options)
         {
-            var data = new EmptyStruct();
+            EmptyStruct data = default;
             return this.Start(eventName, ref options, ref data);
         }
         /// <summary>
@@ -112,7 +112,7 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public EventSourceActivity Start<T>(string? eventName, T data)
         {
-            var options = new EventSourceOptions();
+            EventSourceOptions options = default;
             return this.Start(eventName, ref options, ref data);
         }
 
@@ -135,7 +135,7 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public void Stop<T>(string? eventName)
         {
-            var data = new EmptyStruct();
+            EmptyStruct data = default;
             this.Stop(eventName, ref data);
         }
         /// <summary>
@@ -175,7 +175,7 @@ namespace System.Diagnostics.Tracing
         /// <param name="data">The data to include in the event.</param>
         public void Write<T>(string? eventName, T data)
         {
-            var options = new EventSourceOptions();
+            EventSourceOptions options = default;
             this.Write(this.eventSource, eventName, ref options, ref data);
         }
         /// <summary>
@@ -190,7 +190,7 @@ namespace System.Diagnostics.Tracing
         /// </param>
         public void Write(string? eventName, EventSourceOptions options)
         {
-            var data = new EmptyStruct();
+            EmptyStruct data = default;
             this.Write(this.eventSource, eventName, ref options, ref data);
         }
         /// <summary>
@@ -202,8 +202,8 @@ namespace System.Diagnostics.Tracing
         /// </param>
         public void Write(string? eventName)
         {
-            var options = new EventSourceOptions();
-            var data = new EmptyStruct();
+            EventSourceOptions options = default;
+            EmptyStruct data = default;
             this.Write(this.eventSource, eventName, ref options, ref data);
         }
         /// <summary>
@@ -222,7 +222,7 @@ namespace System.Diagnostics.Tracing
         {
             if (this.state == State.Started)
             {
-                var data = new EmptyStruct();
+                EmptyStruct data = default;
                 this.Stop(null, ref data);
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -85,7 +85,7 @@ namespace System.Diagnostics.Tracing
             EventSourceSettings config,
             params string[]? traits)
             : this(
-                eventSourceName == null ? new Guid() : GenerateGuidFromName(eventSourceName.ToUpperInvariant()),
+                eventSourceName == null ? default : GenerateGuidFromName(eventSourceName.ToUpperInvariant()),
                 eventSourceName!,
                 config, traits)
         {
@@ -107,7 +107,7 @@ namespace System.Diagnostics.Tracing
                 return;
             }
 
-            var options = new EventSourceOptions();
+            EventSourceOptions options = default;
             this.WriteImpl(eventName, ref options, null, null, null, SimpleEventTypes<EmptyStruct>.Instance);
         }
 
@@ -158,7 +158,7 @@ namespace System.Diagnostics.Tracing
                 return;
             }
 
-            var options = new EventSourceOptions();
+            EventSourceOptions options = default;
             this.WriteImpl(eventName, ref options, data, null, null, SimpleEventTypes<T>.Instance);
         }
 

--- a/src/System.Private.CoreLib/shared/System/Globalization/CalendarData.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CalendarData.Unix.cs
@@ -134,7 +134,7 @@ namespace System.Globalization
         {
             datePatterns = null;
 
-            EnumCalendarsData callbackContext = new EnumCalendarsData();
+            EnumCalendarsData callbackContext = default;
             callbackContext.Results = new List<string>();
             callbackContext.DisallowDuplicates = true;
             bool result = EnumCalendarInfo(localeName, calendarId, dataType, ref callbackContext);
@@ -359,7 +359,7 @@ namespace System.Globalization
         {
             monthNames = null;
 
-            EnumCalendarsData callbackContext = new EnumCalendarsData();
+            EnumCalendarsData callbackContext = default;
             callbackContext.Results = new List<string>();
             bool result = EnumCalendarInfo(localeName, calendarId, dataType, ref callbackContext);
             if (result)
@@ -407,7 +407,7 @@ namespace System.Globalization
         {
             calendarData = null;
 
-            EnumCalendarsData callbackContext = new EnumCalendarsData();
+            EnumCalendarsData callbackContext = default;
             callbackContext.Results = new List<string>();
             bool result = EnumCalendarInfo(localeName, calendarId, dataType, ref callbackContext);
             if (result)

--- a/src/System.Private.CoreLib/shared/System/Globalization/CalendarData.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CalendarData.Windows.cs
@@ -116,7 +116,7 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            EnumCalendarsData data = new EnumCalendarsData();
+            EnumCalendarsData data = default;
             data.userOverride = 0;
             data.calendars = new List<int>();
 
@@ -288,7 +288,7 @@ namespace System.Globalization
 
         private static unsafe bool CallEnumCalendarInfo(string localeName, CalendarId calendar, uint calType, uint lcType, out string[]? data)
         {
-            EnumData context = new EnumData();
+            EnumData context = default;
             context.userOverride = null;
             context.strings = new List<string>();
             // First call GetLocaleInfo if necessary

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -594,7 +594,7 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            Interop.Kernel32.NlsVersionInfoEx nlsVersion = new Interop.Kernel32.NlsVersionInfoEx();
+            Interop.Kernel32.NlsVersionInfoEx nlsVersion = default;
             nlsVersion.dwNLSVersionInfoSize = sizeof(Interop.Kernel32.NlsVersionInfoEx);
             Interop.Kernel32.GetNLSVersionEx(Interop.Kernel32.COMPARE_STRING, _sortName, &nlsVersion);
             return new SortVersion(

--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureData.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureData.Windows.cs
@@ -256,7 +256,7 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert(regionName != null);
 
-            EnumLocaleData context = new EnumLocaleData();
+            EnumLocaleData context;
             context.cultureName = null;
             context.regionName = regionName;
 
@@ -541,7 +541,7 @@ namespace System.Globalization
 
         private static unsafe string[]? nativeEnumTimeFormats(string localeName, uint dwFlags, bool useUserOverride)
         {
-            EnumData data = new EnumData();
+            EnumData data = default;
             data.strings = new List<string>();
 
             // Now call the enumeration API. Work is done by our callback function
@@ -669,7 +669,7 @@ namespace System.Globalization
                 flags |= Interop.Kernel32.LOCALE_SUPPLEMENTAL;
             }
 
-            EnumData context = new EnumData();
+            EnumData context = default;
             context.strings = new List<string>();
 
             unsafe
@@ -697,7 +697,7 @@ namespace System.Globalization
         {
             get
             {
-                EnumData context = new EnumData();
+                EnumData context = default;
                 context.strings = new List<string>();
 
                 unsafe

--- a/src/System.Private.CoreLib/shared/System/Globalization/DateTimeParse.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/DateTimeParse.cs
@@ -49,7 +49,7 @@ namespace System
 
         internal static bool TryParseExact(ReadOnlySpan<char> s, ReadOnlySpan<char> format, DateTimeFormatInfo dtfi, DateTimeStyles style, out DateTime result)
         {
-            DateTimeResult resultData = new DateTimeResult();       // The buffer to store the parsing result.
+            DateTimeResult resultData = default;       // The buffer to store the parsing result.
             resultData.Init(s);
 
             if (TryParseExact(s, format, dtfi, style, ref resultData))
@@ -64,7 +64,7 @@ namespace System
 
         internal static bool TryParseExact(ReadOnlySpan<char> s, ReadOnlySpan<char> format, DateTimeFormatInfo dtfi, DateTimeStyles style, out DateTime result, out TimeSpan offset)
         {
-            DateTimeResult resultData = new DateTimeResult();       // The buffer to store the parsing result.
+            DateTimeResult resultData = default;       // The buffer to store the parsing result.
             resultData.Init(s);
             resultData.flags |= ParseFlags.CaptureOffset;
 
@@ -102,7 +102,7 @@ namespace System
         internal static DateTime ParseExactMultiple(ReadOnlySpan<char> s, string[] formats,
                                                 DateTimeFormatInfo dtfi, DateTimeStyles style)
         {
-            DateTimeResult result = new DateTimeResult();       // The buffer to store the parsing result.
+            DateTimeResult result = default;       // The buffer to store the parsing result.
             result.Init(s);
             if (TryParseExactMultiple(s, formats, dtfi, style, ref result))
             {
@@ -117,7 +117,7 @@ namespace System
         internal static DateTime ParseExactMultiple(ReadOnlySpan<char> s, string[] formats,
                                                 DateTimeFormatInfo dtfi, DateTimeStyles style, out TimeSpan offset)
         {
-            DateTimeResult result = new DateTimeResult();       // The buffer to store the parsing result.
+            DateTimeResult result = default;       // The buffer to store the parsing result.
             result.Init(s);
             result.flags |= ParseFlags.CaptureOffset;
             if (TryParseExactMultiple(s, formats, dtfi, style, ref result))
@@ -134,7 +134,7 @@ namespace System
         internal static bool TryParseExactMultiple(ReadOnlySpan<char> s, string?[]? formats,
                                                    DateTimeFormatInfo dtfi, DateTimeStyles style, out DateTime result, out TimeSpan offset)
         {
-            DateTimeResult resultData = new DateTimeResult();       // The buffer to store the parsing result.
+            DateTimeResult resultData = default;       // The buffer to store the parsing result.
             resultData.Init(s);
             resultData.flags |= ParseFlags.CaptureOffset;
 
@@ -153,7 +153,7 @@ namespace System
         internal static bool TryParseExactMultiple(ReadOnlySpan<char> s, string?[]? formats,
                                                    DateTimeFormatInfo dtfi, DateTimeStyles style, out DateTime result)
         {
-            DateTimeResult resultData = new DateTimeResult();       // The buffer to store the parsing result.
+            DateTimeResult resultData = default;       // The buffer to store the parsing result.
             resultData.Init(s);
 
             if (TryParseExactMultiple(s, formats, dtfi, style, ref resultData))
@@ -202,7 +202,7 @@ namespace System
                 }
                 // Create a new result each time to ensure the runs are independent. Carry through
                 // flags from the caller and return the result.
-                DateTimeResult innerResult = new DateTimeResult();       // The buffer to store the parsing result.
+                DateTimeResult innerResult = default;       // The buffer to store the parsing result.
                 innerResult.Init(s);
                 innerResult.flags = result.flags;
                 if (TryParseExact(s, formats[i], dtfi, style, ref innerResult))
@@ -2426,7 +2426,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
 
         internal static DateTime Parse(ReadOnlySpan<char> s, DateTimeFormatInfo dtfi, DateTimeStyles styles)
         {
-            DateTimeResult result = new DateTimeResult();       // The buffer to store the parsing result.
+            DateTimeResult result = default;       // The buffer to store the parsing result.
             result.Init(s);
             if (TryParse(s, dtfi, styles, ref result))
             {
@@ -2440,7 +2440,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
 
         internal static DateTime Parse(ReadOnlySpan<char> s, DateTimeFormatInfo dtfi, DateTimeStyles styles, out TimeSpan offset)
         {
-            DateTimeResult result = new DateTimeResult();       // The buffer to store the parsing result.
+            DateTimeResult result = default;       // The buffer to store the parsing result.
             result.Init(s);
             result.flags |= ParseFlags.CaptureOffset;
             if (TryParse(s, dtfi, styles, ref result))
@@ -2456,7 +2456,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
 
         internal static bool TryParse(ReadOnlySpan<char> s, DateTimeFormatInfo dtfi, DateTimeStyles styles, out DateTime result)
         {
-            DateTimeResult resultData = new DateTimeResult();       // The buffer to store the parsing result.
+            DateTimeResult resultData = default;       // The buffer to store the parsing result.
             resultData.Init(s);
 
             if (TryParse(s, dtfi, styles, ref resultData))
@@ -2471,7 +2471,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
 
         internal static bool TryParse(ReadOnlySpan<char> s, DateTimeFormatInfo dtfi, DateTimeStyles styles, out DateTime result, out TimeSpan offset)
         {
-            DateTimeResult parseResult = new DateTimeResult();       // The buffer to store the parsing result.
+            DateTimeResult parseResult = default;       // The buffer to store the parsing result.
             parseResult.Init(s);
             parseResult.flags |= ParseFlags.CaptureOffset;
 
@@ -2512,9 +2512,9 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             DS dps = DS.BEGIN;     // Date Parsing State.
             bool reachTerminalState = false;
 
-            DateTimeToken dtok = new DateTimeToken();      // The buffer to store the parsing token.
+            DateTimeToken dtok = default;      // The buffer to store the parsing token.
             dtok.suffix = TokenType.SEP_Unk;
-            DateTimeRawInfo raw = new DateTimeRawInfo();    // The buffer to store temporary parsing information.
+            DateTimeRawInfo raw = default;    // The buffer to store temporary parsing information.
             unsafe
             {
                 int* numberPointer = stackalloc int[3];
@@ -4469,7 +4469,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             DateTimeFormatInfo dtfi,
             ref DateTimeResult result)
         {
-            ParsingInfo parseInfo = new ParsingInfo();
+            ParsingInfo parseInfo = default;
             parseInfo.Init();
 
             parseInfo.calendar = dtfi.Calendar;
@@ -5775,7 +5775,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
 
         internal DTSubString GetSubString()
         {
-            DTSubString sub = new DTSubString();
+            DTSubString sub = default;
             sub.index = Index;
             sub.s = Value;
             while (Index + sub.length < Length)

--- a/src/System.Private.CoreLib/shared/System/Globalization/TimeSpanFormat.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/TimeSpanFormat.cs
@@ -502,7 +502,7 @@ namespace System.Globalization
             /* factory method for static invariant FormatLiterals */
             internal static FormatLiterals InitInvariant(bool isNegative)
             {
-                FormatLiterals x = new FormatLiterals();
+                FormatLiterals x = default;
                 x._literals = new string[6];
                 x._literals[0] = isNegative ? "-" : string.Empty;
                 x._literals[1] = ".";

--- a/src/System.Private.CoreLib/shared/System/Globalization/TimeSpanParse.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/TimeSpanParse.cs
@@ -268,7 +268,7 @@ namespace System.Globalization
                 {
                     if (!_posLocInit)
                     {
-                        _posLoc = new TimeSpanFormat.FormatLiterals();
+                        _posLoc = default;
                         _posLoc.Init(_fullPosPattern, false);
                         _posLocInit = true;
                     }
@@ -282,7 +282,7 @@ namespace System.Globalization
                 {
                     if (!_negLocInit)
                     {
-                        _negLoc = new TimeSpanFormat.FormatLiterals();
+                        _negLoc = default;
                         _negLoc.Init(_fullNegPattern, false);
                         _negLocInit = true;
                     }
@@ -685,7 +685,7 @@ namespace System.Globalization
 
             var tokenizer = new TimeSpanTokenizer(input);
 
-            var raw = new TimeSpanRawInfo();
+            TimeSpanRawInfo raw = default;
             raw.Init(DateTimeFormatInfo.GetInstance(formatProvider));
 
             TimeSpanToken tok = tokenizer.GetNextToken();
@@ -729,7 +729,7 @@ namespace System.Globalization
         {
             if (raw._lastSeenTTT == TTT.Num)
             {
-                TimeSpanToken tok = new TimeSpanToken();
+                TimeSpanToken tok = default;
                 tok._ttt = TTT.Sep;
                 if (!raw.ProcessToken(ref tok, ref result))
                 {
@@ -1459,7 +1459,7 @@ namespace System.Globalization
         /// and exists for performance/appcompat with legacy callers who cannot move onto the globalized Parse overloads.
         /// </summary>
         private static bool TryParseTimeSpanConstant(ReadOnlySpan<char> input, ref TimeSpanResult result) =>
-            new StringParser().TryParse(input, ref result);
+            default(StringParser).TryParse(input, ref result);
 
         private ref struct StringParser
         {

--- a/src/System.Private.CoreLib/shared/System/Guid.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.cs
@@ -18,7 +18,7 @@ namespace System
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public partial struct Guid : IFormattable, IComparable, IComparable<Guid>, IEquatable<Guid>, ISpanFormattable
     {
-        public static readonly Guid Empty = new Guid();
+        public static readonly Guid Empty = default;
 
         private int _a;   // Do not rename (binary serialization)
         private short _b; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/IO/DisableMediaInsertionPrompt.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/DisableMediaInsertionPrompt.cs
@@ -27,7 +27,7 @@ namespace System.IO
 
         public static DisableMediaInsertionPrompt Create()
         {
-            DisableMediaInsertionPrompt prompt = new DisableMediaInsertionPrompt();
+            DisableMediaInsertionPrompt prompt = default;
             prompt._disableSuccess = Interop.Kernel32.SetThreadErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS, out prompt._oldMode);
             return prompt;
         }

--- a/src/System.Private.CoreLib/shared/System/IO/PathHelper.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/PathHelper.Windows.cs
@@ -146,7 +146,7 @@ namespace System.IO
             bool isDevice = PathInternal.IsDevice(outputBuilder.AsSpan());
 
             // As this is a corner case we're not going to add a stackalloc here to keep the stack pressure down.
-            var inputBuilder = new ValueStringBuilder();
+            ValueStringBuilder inputBuilder = default;
 
             bool isDosUnc = false;
             int rootDifference = 0;

--- a/src/System.Private.CoreLib/shared/System/Lazy.cs
+++ b/src/System.Private.CoreLib/shared/System/Lazy.cs
@@ -380,7 +380,7 @@ namespace System
 
         private void PublicationOnlyWaitForOtherThreadToPublish()
         {
-            var spinWait = new SpinWait();
+            SpinWait spinWait = default;
             while (!ReferenceEquals(_state, null))
             {
                 // We get here when PublicationOnly temporarily sets _state to LazyHelper.PublicationOnlyWaitForOtherThreadToPublish.

--- a/src/System.Private.CoreLib/shared/System/Numerics/Matrix4x4.cs
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Matrix4x4.cs
@@ -1512,7 +1512,7 @@ namespace System.Numerics
                     Vector3** pVectorBasis = (Vector3**)&vectorBasis;
 
                     Matrix4x4 matTemp = Matrix4x4.Identity;
-                    CanonicalBasis canonicalBasis = new CanonicalBasis();
+                    CanonicalBasis canonicalBasis = default;
                     Vector3* pCanonicalBasis = &canonicalBasis.Row0;
 
                     canonicalBasis.Row0 = new Vector3(1.0f, 0.0f, 0.0f);

--- a/src/System.Private.CoreLib/shared/System/Numerics/Quaternion.cs
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Quaternion.cs
@@ -224,7 +224,7 @@ namespace System.Numerics
         {
             float trace = matrix.M11 + matrix.M22 + matrix.M33;
 
-            Quaternion q = new Quaternion();
+            Quaternion q = default;
 
             if (trace > 0.0f)
             {
@@ -346,7 +346,7 @@ namespace System.Numerics
             float t = amount;
             float t1 = 1.0f - t;
 
-            Quaternion r = new Quaternion();
+            Quaternion r = default;
 
             float dot = quaternion1.X * quaternion2.X + quaternion1.Y * quaternion2.Y +
                         quaternion1.Z * quaternion2.Z + quaternion1.W * quaternion2.W;

--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector.cs
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector.cs
@@ -77,7 +77,7 @@ namespace System.Numerics
             [Intrinsic]
             get => s_zero;
         }
-        private static readonly Vector<T> s_zero = new Vector<T>();
+        private static readonly Vector<T> s_zero;
 
         /// <summary>
         /// Returns a vector containing all ones.
@@ -630,7 +630,7 @@ namespace System.Numerics
         /// <returns>The hash code.</returns>
         public override readonly int GetHashCode()
         {
-            HashCode hashCode = new HashCode();
+            HashCode hashCode = default;
 
             if (typeof(T) == typeof(byte) ||
                 typeof(T) == typeof(sbyte) ||
@@ -858,7 +858,7 @@ namespace System.Numerics
                 }
                 else
                 {
-                    Vector<T> sum = new Vector<T>();
+                    Vector<T> sum = default;
                     if (typeof(T) == typeof(byte))
                     {
                         sum.register.byte_0 = (byte)(left.register.byte_0 + right.register.byte_0);
@@ -1070,7 +1070,7 @@ namespace System.Numerics
                 }
                 else
                 {
-                    Vector<T> difference = new Vector<T>();
+                    Vector<T> difference = default;
                     if (typeof(T) == typeof(byte))
                     {
                         difference.register.byte_0 = (byte)(left.register.byte_0 - right.register.byte_0);
@@ -1283,7 +1283,7 @@ namespace System.Numerics
                 }
                 else
                 {
-                    Vector<T> product = new Vector<T>();
+                    Vector<T> product = default;
                     if (typeof(T) == typeof(byte))
                     {
                         product.register.byte_0 = (byte)(left.register.byte_0 * right.register.byte_0);
@@ -1516,7 +1516,7 @@ namespace System.Numerics
                 }
                 else
                 {
-                    Vector<T> quotient = new Vector<T>();
+                    Vector<T> quotient = default;
                     if (typeof(T) == typeof(byte))
                     {
                         quotient.register.byte_0 = (byte)(left.register.byte_0 / right.register.byte_0);
@@ -1636,7 +1636,7 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<T> operator &(Vector<T> left, Vector<T> right)
         {
-            Vector<T> result = new Vector<T>();
+            Vector<T> result = default;
             unchecked
             {
                 if (Vector.IsHardwareAccelerated)
@@ -1667,7 +1667,7 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<T> operator |(Vector<T> left, Vector<T> right)
         {
-            Vector<T> result = new Vector<T>();
+            Vector<T> result = default;
             unchecked
             {
                 if (Vector.IsHardwareAccelerated)
@@ -1698,7 +1698,7 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<T> operator ^(Vector<T> left, Vector<T> right)
         {
-            Vector<T> result = new Vector<T>();
+            Vector<T> result = default;
             unchecked
             {
                 if (Vector.IsHardwareAccelerated)
@@ -1954,7 +1954,7 @@ namespace System.Numerics
             }
             else
             {
-                Register register = new Register();
+                Register register = default;
                 if (typeof(T) == typeof(byte))
                 {
                     register.byte_0 = left.register.byte_0 == right.register.byte_0 ? ConstantHelper.GetByteWithAllBitsSet() : (byte)0;
@@ -2171,7 +2171,7 @@ namespace System.Numerics
             }
             else
             {
-                Register register = new Register();
+                Register register = default;
                 if (typeof(T) == typeof(byte))
                 {
                     register.byte_0 = left.register.byte_0 < right.register.byte_0 ? ConstantHelper.GetByteWithAllBitsSet() : (byte)0;
@@ -2388,7 +2388,7 @@ namespace System.Numerics
             }
             else
             {
-                Register register = new Register();
+                Register register = default;
                 if (typeof(T) == typeof(byte))
                 {
                     register.byte_0 = left.register.byte_0 > right.register.byte_0 ? ConstantHelper.GetByteWithAllBitsSet() : (byte)0;
@@ -2773,7 +2773,7 @@ namespace System.Numerics
             }
             else
             {
-                Vector<T> vec = new Vector<T>();
+                Vector<T> vec = default;
                 if (typeof(T) == typeof(byte))
                 {
                     vec.register.byte_0 = left.register.byte_0 < right.register.byte_0 ? left.register.byte_0 : right.register.byte_0;
@@ -2989,7 +2989,7 @@ namespace System.Numerics
             }
             else
             {
-                Vector<T> vec = new Vector<T>();
+                Vector<T> vec = default;
                 if (typeof(T) == typeof(byte))
                 {
                     vec.register.byte_0 = left.register.byte_0 > right.register.byte_0 ? left.register.byte_0 : right.register.byte_0;

--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector.tt
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector.tt
@@ -82,7 +82,7 @@ namespace System.Numerics
             [Intrinsic]
             get => s_zero;
         }
-        private static readonly Vector<T> s_zero = new Vector<T>();
+        private static readonly Vector<T> s_zero;
 
         /// <summary>
         /// Returns a vector containing all ones.
@@ -400,7 +400,7 @@ namespace System.Numerics
         /// <returns>The hash code.</returns>
         public override readonly int GetHashCode()
         {
-            HashCode hashCode = new HashCode();
+            HashCode hashCode = default;
 
             if (typeof(T) == typeof(byte) ||
                 typeof(T) == typeof(sbyte) ||
@@ -554,7 +554,7 @@ namespace System.Numerics
                 }
                 else
                 {
-                    Vector<T> sum = new Vector<T>();
+                    Vector<T> sum = default;
 <#
     foreach (Type type in supportedTypes)
     {
@@ -614,7 +614,7 @@ namespace System.Numerics
                 }
                 else
                 {
-                    Vector<T> difference = new Vector<T>();
+                    Vector<T> difference = default;
 <#
     foreach (Type type in supportedTypes)
     {
@@ -675,7 +675,7 @@ namespace System.Numerics
                 }
                 else
                 {
-                    Vector<T> product = new Vector<T>();
+                    Vector<T> product = default;
 <#
     foreach (Type type in supportedTypes)
     {
@@ -756,7 +756,7 @@ namespace System.Numerics
                 }
                 else
                 {
-                    Vector<T> quotient = new Vector<T>();
+                    Vector<T> quotient = default;
 <#
     foreach (Type type in supportedTypes)
     {
@@ -798,7 +798,7 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<T> operator &(Vector<T> left, Vector<T> right)
         {
-            Vector<T> result = new Vector<T>();
+            Vector<T> result = default;
             unchecked
             {
                 if (Vector.IsHardwareAccelerated)
@@ -829,7 +829,7 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<T> operator |(Vector<T> left, Vector<T> right)
         {
-            Vector<T> result = new Vector<T>();
+            Vector<T> result = default;
             unchecked
             {
                 if (Vector.IsHardwareAccelerated)
@@ -860,7 +860,7 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<T> operator ^(Vector<T> left, Vector<T> right)
         {
-            Vector<T> result = new Vector<T>();
+            Vector<T> result = default;
             unchecked
             {
                 if (Vector.IsHardwareAccelerated)
@@ -972,7 +972,7 @@ namespace System.Numerics
             }
             else
             {
-                Register register = new Register();
+                Register register = default;
 <#
     foreach (Type type in supportedTypes)
     {
@@ -1028,7 +1028,7 @@ namespace System.Numerics
             }
             else
             {
-                Register register = new Register();
+                Register register = default;
 <#
     foreach (Type type in supportedTypes)
     {
@@ -1084,7 +1084,7 @@ namespace System.Numerics
             }
             else
             {
-                Register register = new Register();
+                Register register = default;
 <#
     foreach (Type type in supportedTypes)
     {
@@ -1227,7 +1227,7 @@ namespace System.Numerics
             }
             else
             {
-                Vector<T> vec = new Vector<T>();
+                Vector<T> vec = default;
 <#
     foreach (Type type in supportedTypes)
     {
@@ -1282,7 +1282,7 @@ namespace System.Numerics
             }
             else
             {
-                Vector<T> vec = new Vector<T>();
+                Vector<T> vec = default;
 <#
     foreach (Type type in supportedTypes)
     {

--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector2.cs
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector2.cs
@@ -23,7 +23,7 @@ namespace System.Numerics
             [Intrinsic]
             get
             {
-                return new Vector2();
+                return default;
             }
         }
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector3.cs
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector3.cs
@@ -23,7 +23,7 @@ namespace System.Numerics
             [Intrinsic]
             get
             {
-                return new Vector3();
+                return default;
             }
         }
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector4.cs
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector4.cs
@@ -23,7 +23,7 @@ namespace System.Numerics
             [Intrinsic]
             get
             {
-                return new Vector4();
+                return default;
             }
         }
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Reflection/Emit/EventToken.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Emit/EventToken.cs
@@ -6,7 +6,7 @@ namespace System.Reflection.Emit
 {
     public struct EventToken
     {
-        public static readonly EventToken Empty = new EventToken();
+        public static readonly EventToken Empty = default;
 
         internal EventToken(int eventToken)
         {

--- a/src/System.Private.CoreLib/shared/System/Reflection/Emit/FieldToken.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Emit/FieldToken.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Emit
     /// </summary>
     public struct FieldToken
     {
-        public static readonly FieldToken Empty = new FieldToken();
+        public static readonly FieldToken Empty = default;
 
         private readonly object _class;
 

--- a/src/System.Private.CoreLib/shared/System/Reflection/Emit/MethodToken.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Emit/MethodToken.cs
@@ -6,7 +6,7 @@ namespace System.Reflection.Emit
 {
     public struct MethodToken
     {
-        public static readonly MethodToken Empty = new MethodToken();
+        public static readonly MethodToken Empty = default;
 
         internal MethodToken(int methodToken)
         {

--- a/src/System.Private.CoreLib/shared/System/Reflection/Emit/ParameterToken.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Emit/ParameterToken.cs
@@ -10,7 +10,7 @@ namespace System.Reflection.Emit
     /// </summary>
     public struct ParameterToken
     {
-        public static readonly ParameterToken Empty = new ParameterToken();
+        public static readonly ParameterToken Empty = default;
 
         internal ParameterToken(int parameterToken)
         {

--- a/src/System.Private.CoreLib/shared/System/Reflection/Emit/PropertyToken.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Emit/PropertyToken.cs
@@ -6,7 +6,7 @@ namespace System.Reflection.Emit
 {
     public struct PropertyToken
     {
-        public static readonly PropertyToken Empty = new PropertyToken();
+        public static readonly PropertyToken Empty = default;
 
         internal PropertyToken(int propertyToken)
         {

--- a/src/System.Private.CoreLib/shared/System/Reflection/Emit/SignatureToken.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Emit/SignatureToken.cs
@@ -6,7 +6,7 @@ namespace System.Reflection.Emit
 {
     public struct SignatureToken
     {
-        public static readonly SignatureToken Empty = new SignatureToken();
+        public static readonly SignatureToken Empty = default;
 
         internal SignatureToken(int signatureToken)
         {

--- a/src/System.Private.CoreLib/shared/System/Reflection/Emit/TypeToken.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Emit/TypeToken.cs
@@ -6,7 +6,7 @@ namespace System.Reflection.Emit
 {
     public struct TypeToken
     {
-        public static readonly TypeToken Empty = new TypeToken();
+        public static readonly TypeToken Empty = default;
 
         internal TypeToken(int typeToken)
         {

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -281,7 +281,7 @@ namespace System.Runtime.CompilerServices
                 TplEventSource innerEtwLog = TplEventSource.Log;
 
                 // ETW event for Task Wait End.
-                Guid prevActivityId = new Guid();
+                Guid prevActivityId = default;
                 bool bEtwLogEnabled = innerEtwLog.IsEnabled();
                 if (bEtwLogEnabled)
                 {

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/YieldAwaitable.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/YieldAwaitable.cs
@@ -40,7 +40,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>Gets an awaiter for this <see cref="YieldAwaitable"/>.</summary>
         /// <returns>An awaiter for this awaitable.</returns>
         /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
-        public YieldAwaiter GetAwaiter() { return new YieldAwaiter(); }
+        public YieldAwaiter GetAwaiter() { return default; }
 
         /// <summary>Provides an awaiter that switches into a target environment.</summary>
         /// <remarks>This type is intended for compiler use only.</remarks>
@@ -163,7 +163,7 @@ namespace System.Runtime.CompilerServices
                     log.TaskWaitContinuationStarted(((Task<int>)continuationIdTask).Result);
 
                     // ETW event for Task Wait End.
-                    Guid prevActivityId = new Guid();
+                    Guid prevActivityId = default;
                     // Ensure the continuation runs under the correlated activity ID generated above
                     if (log.TasksSetActivityIds)
                         EventSource.SetCurrentThreadActivityId(TplEventSource.CreateGuidForTaskID(((Task<int>)continuationIdTask).Result), out prevActivityId);

--- a/src/System.Private.CoreLib/shared/System/Runtime/MemoryFailPoint.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/MemoryFailPoint.Windows.cs
@@ -17,7 +17,7 @@ namespace System.Runtime
         private static bool CheckForAvailableMemory(out ulong availPageFile, out ulong totalAddressSpaceFree)
         {
             bool r;
-            Interop.Kernel32.MEMORYSTATUSEX memory = new Interop.Kernel32.MEMORYSTATUSEX();
+            Interop.Kernel32.MEMORYSTATUSEX memory = default;
             r = Interop.Kernel32.GlobalMemoryStatusEx(ref memory);
             if (!r)
                 throw Win32Marshal.GetExceptionForLastWin32Error();
@@ -61,7 +61,7 @@ namespace System.Runtime
                 return 0;
 
             ulong largestFreeRegion = 0;
-            Interop.Kernel32.MEMORY_BASIC_INFORMATION memInfo = new Interop.Kernel32.MEMORY_BASIC_INFORMATION();
+            Interop.Kernel32.MEMORY_BASIC_INFORMATION memInfo = default;
             UIntPtr sizeOfMemInfo = (UIntPtr)sizeof(Interop.Kernel32.MEMORY_BASIC_INFORMATION);
 
             while (((ulong)address) + size < s_topOfMemory)

--- a/src/System.Private.CoreLib/shared/System/Threading/CancellationTokenSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/CancellationTokenSource.cs
@@ -494,7 +494,7 @@ namespace System.Threading
                 // run the minor risk of having _callbackPartitions reinitialized (after it was cleared to null during Dispose).
                 if (_disposed)
                 {
-                    return new CancellationTokenRegistration();
+                    return default;
                 }
 
                 // Get the partitions...
@@ -792,7 +792,7 @@ namespace System.Threading
         /// </summary>
         internal void WaitForCallbackToComplete(long id)
         {
-            var sw = new SpinWait();
+            SpinWait sw = default;
             while (ExecutingCallback == id)
             {
                 sw.SpinOnce();  // spin, as we assume callback execution is fast and that this situation is rare.

--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -92,7 +92,7 @@ namespace System.Threading
             }
 
             executionContext = executionContext.ShallowClone(isFlowSuppressed: true);
-            var asyncFlowControl = new AsyncFlowControl();
+            AsyncFlowControl asyncFlowControl = default;
             currentThread._executionContext = executionContext;
             asyncFlowControl.Initialize(currentThread);
             return asyncFlowControl;

--- a/src/System.Private.CoreLib/shared/System/Threading/ManualResetEventSlim.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ManualResetEventSlim.cs
@@ -360,7 +360,7 @@ namespace System.Threading
         /// </remarks>
         public void Wait()
         {
-            Wait(Timeout.Infinite, new CancellationToken());
+            Wait(Timeout.Infinite, CancellationToken.None);
         }
 
         /// <summary>
@@ -406,7 +406,7 @@ namespace System.Threading
                 throw new ArgumentOutOfRangeException(nameof(timeout));
             }
 
-            return Wait((int)totalMilliseconds, new CancellationToken());
+            return Wait((int)totalMilliseconds, CancellationToken.None);
         }
 
         /// <summary>
@@ -455,7 +455,7 @@ namespace System.Threading
         /// </exception>
         public bool Wait(int millisecondsTimeout)
         {
-            return Wait(millisecondsTimeout, new CancellationToken());
+            return Wait(millisecondsTimeout, CancellationToken.None);
         }
 
         /// <summary>
@@ -514,7 +514,7 @@ namespace System.Threading
 
                 // Spin
                 int spinCount = SpinCount;
-                var spinner = new SpinWait();
+                SpinWait spinner = default;
                 while (spinner.Count < spinCount)
                 {
                     spinner.SpinOnce(sleep1Threshold: -1);
@@ -670,7 +670,7 @@ namespace System.Threading
         /// <param name="updateBitsMask">The mask used to set the bits</param>
         private void UpdateStateAtomically(int newBits, int updateBitsMask)
         {
-            SpinWait sw = new SpinWait();
+            SpinWait sw = default;
 
             Debug.Assert((newBits | updateBitsMask) == updateBitsMask, "newBits do not fall within the updateBitsMask.");
 

--- a/src/System.Private.CoreLib/shared/System/Threading/SemaphoreSlim.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SemaphoreSlim.cs
@@ -183,7 +183,7 @@ namespace System.Threading
         public void Wait()
         {
             // Call wait with infinite timeout
-            Wait(Timeout.Infinite, new CancellationToken());
+            Wait(Timeout.Infinite, CancellationToken.None);
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace System.Threading
             }
 
             // Call wait with the timeout milliseconds
-            return Wait((int)timeout.TotalMilliseconds, new CancellationToken());
+            return Wait((int)timeout.TotalMilliseconds, CancellationToken.None);
         }
 
         /// <summary>
@@ -270,7 +270,7 @@ namespace System.Threading
         /// negative number other than -1, which represents an infinite time-out.</exception>
         public bool Wait(int millisecondsTimeout)
         {
-            return Wait(millisecondsTimeout, new CancellationToken());
+            return Wait(millisecondsTimeout, CancellationToken.None);
         }
 
         /// <summary>
@@ -331,7 +331,7 @@ namespace System.Threading
                     // lessen that extra expense of doing a proper wait.
                     int spinCount = SpinWait.SpinCountforSpinBeforeWait * 4;
 
-                    var spinner = new SpinWait();
+                    SpinWait spinner = default;
                     while (spinner.Count < spinCount)
                     {
                         spinner.SpinOnce(sleep1Threshold: -1);

--- a/src/System.Private.CoreLib/shared/System/Threading/SpinLock.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SpinLock.cs
@@ -348,7 +348,7 @@ namespace System.Threading
             // lock acquired failed and waiters updated
 
             // *** Step 2, Spinning and Yielding
-            var spinner = new SpinWait();
+            SpinWait spinner = default;
             if (turn > Environment.ProcessorCount)
             {
                 spinner.Count = SpinWait.YieldThreshold;
@@ -388,7 +388,7 @@ namespace System.Threading
         /// </summary>
         private void DecrementWaiters()
         {
-            SpinWait spinner = new SpinWait();
+            SpinWait spinner = default;
             while (true)
             {
                 int observedOwner = _owner;
@@ -419,7 +419,7 @@ namespace System.Threading
                 throw new LockRecursionException(SR.SpinLock_TryEnter_LockRecursionException);
             }
 
-            SpinWait spinner = new SpinWait();
+            SpinWait spinner = default;
 
             // Loop until the lock has been successfully acquired or, if specified, the timeout expires.
             while (true)

--- a/src/System.Private.CoreLib/shared/System/Threading/SpinWait.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SpinWait.cs
@@ -324,7 +324,7 @@ namespace System.Threading
             {
                 startTime = TimeoutHelper.GetTime();
             }
-            SpinWait spinner = new SpinWait();
+            SpinWait spinner = default;
             while (!condition())
             {
                 if (millisecondsTimeout == 0)

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
@@ -2277,7 +2277,7 @@ namespace System.Threading.Tasks
 
             // ETW event for Task Started
             TplEventSource log = TplEventSource.Log;
-            Guid savedActivityID = new Guid();
+            Guid savedActivityID = default;
             bool etwIsEnabled = log.IsEnabled();
             if (etwIsEnabled)
             {
@@ -2566,7 +2566,7 @@ namespace System.Threading.Tasks
         /// </returns>
         public static YieldAwaitable Yield()
         {
-            return new YieldAwaitable();
+            return default;
         }
         #endregion
 
@@ -2885,7 +2885,7 @@ namespace System.Threading.Tasks
             }
 
             int spinCount = Threading.SpinWait.SpinCountforSpinBeforeWait;
-            var spinner = new SpinWait();
+            SpinWait spinner = default;
             while (spinner.Count < spinCount)
             {
                 spinner.SpinOnce(sleep1Threshold: -1);

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskCanceledException.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskCanceledException.cs
@@ -69,7 +69,7 @@ namespace System.Threading.Tasks
         /// </summary>
         /// <param name="task">A task that has been canceled.</param>
         public TaskCanceledException(Task? task) :
-            base(SR.TaskCanceledException_ctor_DefaultMessage, task != null ? task.CancellationToken : new CancellationToken())
+            base(SR.TaskCanceledException_ctor_DefaultMessage, task != null ? task.CancellationToken : CancellationToken.None)
         {
             _canceledTask = task;
         }

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskCompletionSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskCompletionSource.cs
@@ -118,7 +118,7 @@ namespace System.Threading.Tasks
         private void SpinUntilCompleted()
         {
             // Spin wait until the completion is finalized by another thread.
-            var sw = new SpinWait();
+            SpinWait sw = default;
             while (!_task.IsCompleted)
                 sw.SpinOnce();
         }

--- a/src/System.Private.CoreLib/shared/System/ValueTuple.cs
+++ b/src/System.Private.CoreLib/shared/System/ValueTuple.cs
@@ -141,7 +141,7 @@ namespace System
         /// <summary>Creates a new struct 0-tuple.</summary>
         /// <returns>A 0-tuple.</returns>
         public static ValueTuple Create() =>
-            new ValueTuple();
+            default;
 
         /// <summary>Creates a new struct 1-tuple, or singleton.</summary>
         /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>

--- a/src/System.Private.CoreLib/src/Microsoft/Win32/OAVariantLib.cs
+++ b/src/System.Private.CoreLib/src/Microsoft/Win32/OAVariantLib.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Win32
                 throw new ArgumentNullException(nameof(targetClass));
             if (culture == null)
                 throw new ArgumentNullException(nameof(culture));
-            Variant result = new Variant();
+            Variant result = default;
             ChangeTypeEx(ref result, ref source,
                          culture.LCID,
                          targetClass.TypeHandle.Value, GetCVTypeFromClass(targetClass), options);

--- a/src/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -53,7 +53,7 @@ namespace System
         [CLSCompliant(false)]
         public TypedReference GetNextArg()
         {
-            TypedReference result = new TypedReference();
+            TypedReference result = default;
             // reference to TypedReference is banned, so have to pass result as pointer
             unsafe
             {
@@ -87,7 +87,7 @@ namespace System
                 if (ArgPtr == IntPtr.Zero)
                     throw new ArgumentNullException();
 
-                TypedReference result = new TypedReference();
+                TypedReference result = default;
                 // reference to TypedReference is banned, so have to pass result as pointer
                 unsafe
                 {

--- a/src/System.Private.CoreLib/src/System/Array.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Array.CoreCLR.cs
@@ -319,7 +319,7 @@ namespace System
             if (Rank != indices.Length)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_RankIndices);
 
-            TypedReference elemref = new TypedReference();
+            TypedReference elemref = default;
             fixed (int* pIndices = &indices[0])
                 InternalGetReference(&elemref, indices.Length, pIndices);
             return TypedReference.InternalToObject(&elemref);
@@ -330,7 +330,7 @@ namespace System
             if (Rank != 1)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_Need1DArray);
 
-            TypedReference elemref = new TypedReference();
+            TypedReference elemref = default;
             InternalGetReference(&elemref, 1, &index);
             return TypedReference.InternalToObject(&elemref);
         }
@@ -344,7 +344,7 @@ namespace System
             pIndices[0] = index1;
             pIndices[1] = index2;
 
-            TypedReference elemref = new TypedReference();
+            TypedReference elemref = default;
             InternalGetReference(&elemref, 2, pIndices);
             return TypedReference.InternalToObject(&elemref);
         }
@@ -359,7 +359,7 @@ namespace System
             pIndices[1] = index2;
             pIndices[2] = index3;
 
-            TypedReference elemref = new TypedReference();
+            TypedReference elemref = default;
             InternalGetReference(&elemref, 3, pIndices);
             return TypedReference.InternalToObject(&elemref);
         }
@@ -369,7 +369,7 @@ namespace System
             if (Rank != 1)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_Need1DArray);
 
-            TypedReference elemref = new TypedReference();
+            TypedReference elemref = default;
             InternalGetReference(&elemref, 1, &index);
             InternalSetValue(&elemref, value);
         }
@@ -383,7 +383,7 @@ namespace System
             pIndices[0] = index1;
             pIndices[1] = index2;
 
-            TypedReference elemref = new TypedReference();
+            TypedReference elemref = default;
             InternalGetReference(&elemref, 2, pIndices);
             InternalSetValue(&elemref, value);
         }
@@ -398,7 +398,7 @@ namespace System
             pIndices[1] = index2;
             pIndices[2] = index3;
 
-            TypedReference elemref = new TypedReference();
+            TypedReference elemref = default;
             InternalGetReference(&elemref, 3, pIndices);
             InternalSetValue(&elemref, value);
         }
@@ -410,7 +410,7 @@ namespace System
             if (Rank != indices.Length)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_RankIndices);
 
-            TypedReference elemref = new TypedReference();
+            TypedReference elemref = default;
             fixed (int* pIndices = &indices[0])
                 InternalGetReference(&elemref, indices.Length, pIndices);
             InternalSetValue(&elemref, value);

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -273,7 +273,7 @@ namespace System.Reflection
                 }
             }
 
-            return new CustomAttributeTypedArgument();
+            return default;
         }
         #endregion
 
@@ -755,7 +755,7 @@ namespace System.Reflection
             m_fieldOrProperty = fieldOrProperty;
             m_padding = fieldOrProperty;
             m_type = type;
-            m_encodedArgument = new CustomAttributeEncodedArgument();
+            m_encodedArgument = default;
         }
 
         public CustomAttributeEncodedArgument EncodedArgument => m_encodedArgument;
@@ -770,7 +770,7 @@ namespace System.Reflection
         public CustomAttributeCtorParameter(CustomAttributeType type)
         {
             m_type = type;
-            m_encodedArgument = new CustomAttributeEncodedArgument();
+            m_encodedArgument = default;
         }
 
         public CustomAttributeEncodedArgument CustomAttributeEncodedArgument => m_encodedArgument;
@@ -958,7 +958,7 @@ namespace System.Reflection
                 return attributes;
             }
 
-            RuntimeType.ListBuilder<object> result = new RuntimeType.ListBuilder<object>();
+            RuntimeType.ListBuilder<object> result = default;
             bool mustBeInheritable = false;
             bool useObjectArray = (caType.IsValueType || caType.ContainsGenericParameters);
             RuntimeType arrayType = useObjectArray ? (RuntimeType)typeof(object) : caType;
@@ -1001,7 +1001,7 @@ namespace System.Reflection
                 return attributes;
             }
 
-            RuntimeType.ListBuilder<object> result = new RuntimeType.ListBuilder<object>();
+            RuntimeType.ListBuilder<object> result = default;
             bool mustBeInheritable = false;
             bool useObjectArray = (caType.IsValueType || caType.ContainsGenericParameters);
             RuntimeType arrayType = useObjectArray ? (RuntimeType)typeof(object) : caType;
@@ -1146,9 +1146,9 @@ namespace System.Reflection
         private static object[] GetCustomAttributes(
             RuntimeModule decoratedModule, int decoratedMetadataToken, int pcaCount, RuntimeType? attributeFilterType)
         {
-            RuntimeType.ListBuilder<object> attributes = new RuntimeType.ListBuilder<object>();
+            RuntimeType.ListBuilder<object> attributes = default;
 
-            AddCustomAttributes(ref attributes, decoratedModule, decoratedMetadataToken, attributeFilterType, false, new RuntimeType.ListBuilder<object>());
+            AddCustomAttributes(ref attributes, decoratedModule, decoratedMetadataToken, attributeFilterType, false, default);
 
             bool useObjectArray = attributeFilterType == null || attributeFilterType.IsValueType || attributeFilterType.ContainsGenericParameters;
             RuntimeType arrayType = useObjectArray ? (RuntimeType)typeof(object) : attributeFilterType!;
@@ -1349,7 +1349,7 @@ namespace System.Reflection
             }
 
             // Visibility checks
-            MetadataToken tkParent = new MetadataToken();
+            MetadataToken tkParent = default;
 
             if (decoratedToken.IsParamDef)
             {
@@ -1383,7 +1383,7 @@ namespace System.Reflection
             // otherwise we check access against the module.
             RuntimeTypeHandle parentTypeHandle = tkParent.IsTypeDef ?
                                                     decoratedModule.ModuleHandle.ResolveTypeHandle(tkParent) :
-                                                    new RuntimeTypeHandle();
+                                                    default;
 
             RuntimeTypeHandle attributeTypeHandle = attributeType.TypeHandle;
 
@@ -1559,7 +1559,7 @@ namespace System.Reflection
         {
             Debug.Assert(type != null);
             Debug.Assert(caType != null);
-            pcas = new RuntimeType.ListBuilder<Attribute>();
+            pcas = default;
 
             bool all = caType == typeof(object) || caType == typeof(Attribute);
             if (!all && !s_pca.ContainsKey(caType))
@@ -1600,7 +1600,7 @@ namespace System.Reflection
         {
             Debug.Assert(method != null);
             Debug.Assert(caType != null);
-            pcas = new RuntimeType.ListBuilder<Attribute>();
+            pcas = default;
 
             bool all = caType == typeof(object) || caType == typeof(Attribute);
             if (!all && !s_pca.ContainsKey(caType))
@@ -1641,7 +1641,7 @@ namespace System.Reflection
         {
             Debug.Assert(parameter != null);
             Debug.Assert(caType != null);
-            pcas = new RuntimeType.ListBuilder<Attribute>();
+            pcas = default;
 
             bool all = caType == typeof(object) || caType == typeof(Attribute);
             if (!all && !s_pca.ContainsKey(caType))
@@ -1699,7 +1699,7 @@ namespace System.Reflection
             Debug.Assert(field != null);
             Debug.Assert(caType != null);
 
-            pcas = new RuntimeType.ListBuilder<Attribute>();
+            pcas = default;
 
             bool all = caType == typeof(object) || caType == typeof(Attribute);
             if (!all && !s_pca.ContainsKey(caType))

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -767,9 +767,9 @@ namespace System.Reflection.Emit
 
         internal override void ResolveToken(int token, out IntPtr typeHandle, out IntPtr methodHandle, out IntPtr fieldHandle)
         {
-            typeHandle = new IntPtr();
-            methodHandle = new IntPtr();
-            fieldHandle = new IntPtr();
+            typeHandle = default;
+            methodHandle = default;
+            fieldHandle = default;
 
             object? handle = m_scope[token];
 

--- a/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
@@ -434,7 +434,7 @@ namespace System.Reflection
 
         public ConstArray GetSigOfMethodDef(int methodToken)
         {
-            ConstArray signature = new ConstArray();
+            ConstArray signature = default;
 
             _GetSigOfMethodDef(m_metadataImport2, methodToken, ref signature);
 
@@ -448,7 +448,7 @@ namespace System.Reflection
 
         public ConstArray GetSignatureFromToken(int token)
         {
-            ConstArray signature = new ConstArray();
+            ConstArray signature = default;
 
             _GetSignatureFromToken(m_metadataImport2, token, ref signature);
 
@@ -512,7 +512,7 @@ namespace System.Reflection
 
         public ConstArray GetSigOfFieldDef(int fieldToken)
         {
-            ConstArray fieldMarshal = new ConstArray();
+            ConstArray fieldMarshal = default;
 
             _GetSigOfFieldDef(m_metadataImport2, fieldToken, ref fieldMarshal);
 
@@ -526,7 +526,7 @@ namespace System.Reflection
 
         public ConstArray GetFieldMarshal(int fieldToken)
         {
-            ConstArray fieldMarshal = new ConstArray();
+            ConstArray fieldMarshal = default;
 
             _GetFieldMarshal(m_metadataImport2, fieldToken, ref fieldMarshal);
 

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -451,7 +451,7 @@ namespace System.Reflection
             int slot = RuntimeMethodHandle.GetSlot(this);
             RuntimeType declaringType = (RuntimeType)DeclaringType!;
             RuntimeType? baseDeclaringType = declaringType;
-            RuntimeMethodHandleInternal baseMethodHandle = new RuntimeMethodHandleInternal();
+            RuntimeMethodHandleInternal baseMethodHandle = default;
 
             do
             {

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumerableViewOfDispatch.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumerableViewOfDispatch.cs
@@ -27,7 +27,7 @@ namespace System.Runtime.InteropServices.CustomMarshalers
             unsafe
             {
                 void* resultLocal = &result;
-                DISPPARAMS dispParams = new DISPPARAMS();
+                DISPPARAMS dispParams = default;
                 Guid guid = Guid.Empty;
                 Dispatch.Invoke(
                     DISPID_NEWENUM,

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -90,7 +90,7 @@ namespace System.Runtime.InteropServices
                 (int)AsAnyMarshaler.AsAnyFlags.IsAnsi |
                 (int)AsAnyMarshaler.AsAnyFlags.IsBestFit;
 
-            MngdNativeArrayMarshaler.MarshalerState nativeArrayMarshalerState = new MngdNativeArrayMarshaler.MarshalerState();
+            MngdNativeArrayMarshaler.MarshalerState nativeArrayMarshalerState = default;
             AsAnyMarshaler marshaler = new AsAnyMarshaler(new IntPtr(&nativeArrayMarshalerState));
 
             IntPtr pNativeHome = IntPtr.Zero;
@@ -145,7 +145,7 @@ namespace System.Runtime.InteropServices
                 (int)AsAnyMarshaler.AsAnyFlags.IsAnsi |
                 (int)AsAnyMarshaler.AsAnyFlags.IsBestFit;
 
-            MngdNativeArrayMarshaler.MarshalerState nativeArrayMarshalerState = new MngdNativeArrayMarshaler.MarshalerState();
+            MngdNativeArrayMarshaler.MarshalerState nativeArrayMarshalerState = default;
             AsAnyMarshaler marshaler = new AsAnyMarshaler(new IntPtr(&nativeArrayMarshalerState));
 
             IntPtr pNativeHome = IntPtr.Zero;

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/CLRIPropertyValueImpl.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/CLRIPropertyValueImpl.cs
@@ -475,7 +475,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 throw new InvalidCastException(SR.Format(SR.InvalidCast_WinRTIPropertyValueElement, _data.GetType(), expectedBoxedType.Name), HResults.TYPE_E_TYPEMISMATCH);
             }
 
-            T unboxed = new T();
+            T unboxed = default;
 
             fixed (byte* pData = &_data.GetRawData())
             {

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeMarshal.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeMarshal.cs
@@ -664,7 +664,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
                         Log("[WinRT_Eventing] Adding (" + instance + "," + removeMethod.Method + ") into cache\n");
 
-                        eventCacheEntry = new EventCacheEntry();
+                        eventCacheEntry = default;
                         eventCacheEntry.registrationTable = new ConditionalWeakTable<object, EventRegistrationTokenListWithCount>();
                         eventCacheEntry.tokenListCount = new TokenListCount(eventCacheKey);
 

--- a/src/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -623,7 +623,7 @@ namespace System
     // When in doubt, do not use.
     internal struct RuntimeMethodHandleInternal
     {
-        internal static RuntimeMethodHandleInternal EmptyHandle => new RuntimeMethodHandleInternal();
+        internal static RuntimeMethodHandleInternal EmptyHandle => default;
 
         internal bool IsNullHandle()
         {
@@ -1120,7 +1120,7 @@ namespace System
 
         private static ModuleHandle GetEmptyMH()
         {
-            return new ModuleHandle();
+            return default;
         }
 
         #region Private Data Members
@@ -1404,12 +1404,12 @@ namespace System
             m_returnTypeORfieldType = returnType;
             m_managedCallingConventionAndArgIteratorFlags = (byte)callingConvention;
 
-            GetSignature(null, 0, new RuntimeFieldHandleInternal(), method, null);
+            GetSignature(null, 0, default, method, null);
         }
 
         public Signature(IRuntimeMethodInfo methodHandle, RuntimeType declaringType)
         {
-            GetSignature(null, 0, new RuntimeFieldHandleInternal(), methodHandle, declaringType);
+            GetSignature(null, 0, default, methodHandle, declaringType);
         }
 
         public Signature(IRuntimeFieldInfo fieldHandle, RuntimeType declaringType)
@@ -1420,7 +1420,7 @@ namespace System
 
         public Signature(void* pCorSig, int cCorSig, RuntimeType declaringType)
         {
-            GetSignature(pCorSig, cCorSig, new RuntimeFieldHandleInternal(), null, declaringType);
+            GetSignature(pCorSig, cCorSig, default, null, declaringType);
         }
         #endregion
 

--- a/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -519,7 +519,7 @@ namespace System
 
                 private unsafe RuntimeMethodInfo[] PopulateMethods(Filter filter)
                 {
-                    ListBuilder<RuntimeMethodInfo> list = new ListBuilder<RuntimeMethodInfo>();
+                    ListBuilder<RuntimeMethodInfo> list = default;
 
                     RuntimeType declaringType = ReflectedType;
                     Debug.Assert(declaringType != null);
@@ -695,7 +695,7 @@ namespace System
                         return Array.Empty<RuntimeConstructorInfo>();
                     }
 
-                    ListBuilder<RuntimeConstructorInfo> list = new ListBuilder<RuntimeConstructorInfo>();
+                    ListBuilder<RuntimeConstructorInfo> list = default;
 
                     RuntimeType declaringType = ReflectedType;
 
@@ -745,7 +745,7 @@ namespace System
 
                 private RuntimeFieldInfo[] PopulateFields(Filter filter)
                 {
-                    ListBuilder<RuntimeFieldInfo> list = new ListBuilder<RuntimeFieldInfo>();
+                    ListBuilder<RuntimeFieldInfo> list = default;
 
                     RuntimeType declaringType = ReflectedType;
 
@@ -947,7 +947,7 @@ namespace System
 
                 private RuntimeType[] PopulateInterfaces(Filter filter)
                 {
-                    ListBuilder<RuntimeType> list = new ListBuilder<RuntimeType>();
+                    ListBuilder<RuntimeType> list = default;
 
                     RuntimeType declaringType = ReflectedType;
 
@@ -1049,7 +1049,7 @@ namespace System
                     if (MdToken.IsNullToken(tkEnclosingType))
                         return Array.Empty<RuntimeType>();
 
-                    ListBuilder<RuntimeType> list = new ListBuilder<RuntimeType>();
+                    ListBuilder<RuntimeType> list = default;
 
                     RuntimeModule moduleHandle = RuntimeTypeHandle.GetModule(declaringType);
                     MetadataImport scope = ModuleHandle.GetMetadataImport(moduleHandle);
@@ -1093,7 +1093,7 @@ namespace System
                         new Dictionary<string, RuntimeEventInfo>();
 
                     RuntimeType declaringType = ReflectedType;
-                    ListBuilder<RuntimeEventInfo> list = new ListBuilder<RuntimeEventInfo>();
+                    ListBuilder<RuntimeEventInfo> list = default;
 
                     if (!RuntimeTypeHandle.IsInterface(declaringType))
                     {
@@ -1185,7 +1185,7 @@ namespace System
                     RuntimeType declaringType = ReflectedType;
                     Debug.Assert(declaringType != null);
 
-                    ListBuilder<RuntimePropertyInfo> list = new ListBuilder<RuntimePropertyInfo>();
+                    ListBuilder<RuntimePropertyInfo> list = default;
 
                     if (!RuntimeTypeHandle.IsInterface(declaringType))
                     {
@@ -2944,12 +2944,12 @@ namespace System
         {
             if (name is null) throw new ArgumentNullException();
 
-            ListBuilder<MethodInfo> methods = new ListBuilder<MethodInfo>();
-            ListBuilder<ConstructorInfo> constructors = new ListBuilder<ConstructorInfo>();
-            ListBuilder<PropertyInfo> properties = new ListBuilder<PropertyInfo>();
-            ListBuilder<EventInfo> events = new ListBuilder<EventInfo>();
-            ListBuilder<FieldInfo> fields = new ListBuilder<FieldInfo>();
-            ListBuilder<Type> nestedTypes = new ListBuilder<Type>();
+            ListBuilder<MethodInfo> methods = default;
+            ListBuilder<ConstructorInfo> constructors = default;
+            ListBuilder<PropertyInfo> properties = default;
+            ListBuilder<EventInfo> events = default;
+            ListBuilder<FieldInfo> fields = default;
+            ListBuilder<Type> nestedTypes = default;
 
             int totalCount = 0;
 
@@ -3140,7 +3140,7 @@ namespace System
         {
             get
             {
-                Guid result = new Guid();
+                Guid result = default;
                 GetGUID(ref result);
                 return result;
             }

--- a/src/System.Private.CoreLib/src/System/TypedReference.cs
+++ b/src/System.Private.CoreLib/src/System/TypedReference.cs
@@ -54,7 +54,7 @@ namespace System
                 targetType = fieldType;
             }
 
-            TypedReference result = new TypedReference();
+            TypedReference result = default;
 
             // reference to TypedReference is banned, so have to pass result as pointer
             unsafe

--- a/src/System.Private.CoreLib/src/System/Variant.cs
+++ b/src/System.Private.CoreLib/src/System/Variant.cs
@@ -104,7 +104,7 @@ namespace System
             typeof(System.DBNull),
         };
 
-        internal static readonly Variant Empty = new Variant();
+        internal static readonly Variant Empty = default;
         internal static readonly Variant Missing = new Variant(Variant.CV_MISSING, Type.Missing, 0);
         internal static readonly Variant DBNull = new Variant(Variant.CV_NULL, System.DBNull.Value, 0);
 


### PR DESCRIPTION
Related to https://github.com/dotnet/roslyn-analyzers/issues/3000