### PR TITLE
Crossgen2 node size relocation

### DIFF
--- a/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -291,6 +291,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.IMAGE_REL_BASED_HIGHLOW:
                 case RelocType.IMAGE_REL_SECREL:
                 case RelocType.IMAGE_REL_BASED_ADDR32NB:
+                case RelocType.IMAGE_REL_SYMBOL_SIZE:
                     EmitInt(delta);
                     break;
                 case RelocType.IMAGE_REL_BASED_DIR64:

--- a/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -25,6 +25,11 @@ namespace ILCompiler.DependencyAnalysis
         IMAGE_REL_BASED_ARM64_PAGEBASE_REL21 = 0x81,   // ADRP
         IMAGE_REL_BASED_ARM64_PAGEOFFSET_12A = 0x82,   // ADD/ADDS (immediate) with zero shift, for page offset
         IMAGE_REL_BASED_ARM64_PAGEOFFSET_12L = 0x83,   // LDR (indexed, unsigned immediate), for page offset
+
+        //
+        // Relocations for R2R image production
+        //
+        IMAGE_REL_SYMBOL_SIZE = 0x1000,             // The size of data in the image representated by the target symbol node
     }
 
     public struct Relocation
@@ -177,6 +182,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.IMAGE_REL_BASED_HIGHLOW:
                 case RelocType.IMAGE_REL_BASED_REL32:
                 case RelocType.IMAGE_REL_BASED_ADDR32NB:
+                case RelocType.IMAGE_REL_SYMBOL_SIZE:
                     *(int*)location = (int)value;
                     break;
                 case RelocType.IMAGE_REL_BASED_DIR64:
@@ -204,6 +210,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.IMAGE_REL_BASED_REL32:
                 case RelocType.IMAGE_REL_BASED_RELPTR32:
                 case RelocType.IMAGE_REL_SECREL:
+                case RelocType.IMAGE_REL_SYMBOL_SIZE:
                     return *(int*)location;
                 case RelocType.IMAGE_REL_BASED_DIR64:
                     return *(long*)location;

--- a/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -29,7 +29,7 @@ namespace ILCompiler.DependencyAnalysis
         //
         // Relocations for R2R image production
         //
-        IMAGE_REL_SYMBOL_SIZE = 0x1000,             // The size of data in the image representated by the target symbol node
+        IMAGE_REL_SYMBOL_SIZE = 0x1000,             // The size of data in the image represented by the target symbol node
     }
 
     public struct Relocation

--- a/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/SortableDependencyNode.cs
+++ b/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/SortableDependencyNode.cs
@@ -53,6 +53,20 @@ namespace ILCompiler.DependencyAnalysis
             // The ordering of this sequence of nodes is deliberate and currently required for 
             // compiler correctness.
             //
+
+            //
+            // ReadyToRun Nodes
+            //
+            CorHeaderNode,
+            ReadyToRunHeaderNode,
+            ImportSectionsTableNode,
+            ImportSectionNode,
+            MethodEntrypointTableNode,
+
+
+            //
+            // CoreRT Nodes
+            //
             MetadataNode,
             ResourceDataNode,
             ResourceIndexNode,

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/AttributePresenceFilterNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/AttributePresenceFilterNode.cs
@@ -10,7 +10,6 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 
 using Internal.Text;
-using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
@@ -19,15 +18,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     {
         private EcmaModule _module;
 
-        // TODO: Eliminate the cache (https://github.com/dotnet/coreclr/issues/27116)
-        private ObjectData _computedData;
-
         public override int ClassCode => 56456113;
 
         public AttributePresenceFilterNode(EcmaModule module)
             : base(module.Context.Target)
         {
-            this._module = module;
+            _module = module;
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
@@ -307,11 +303,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             if (relocsOnly)
                 return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
 
-            if (_computedData != null)
-            {
-                return _computedData;
-            }
-
             List<CustomAttributeEntry> customAttributeEntries = GetCustomAttributeEntries();
             int countOfEntries = customAttributeEntries.Count;
             if (countOfEntries == 0)
@@ -470,8 +461,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             builder.RequireInitialAlignment(16);
             builder.AddSymbol(this);
             builder.EmitBytes(result);
-            _computedData = builder.ToObjectData();
-            return _computedData;
+            
+            return builder.ToObjectData(); ;
         }
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedCorHeaderNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedCorHeaderNode.cs
@@ -27,7 +27,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override bool IsShareable => false;
 
-        public override int ClassCode => 82124527;
+        protected internal override int Phase => (int)ObjectNodePhase.Ordered;
+
+        public override int ClassCode => (int)ObjectNodeOrder.CorHeaderNode;
 
         public override bool StaticDependenciesAreComputed => true;
 
@@ -124,7 +126,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // Managed Native (ReadyToRun) Header Directory
             ReadDirectoryEntry(ref reader);
             builder.EmitReloc(r2rFactory.Header, RelocType.IMAGE_REL_BASED_ADDR32NB);
-            builder.EmitInt(r2rFactory.Header.GetData(factory, relocsOnly).Data.Length);
+            builder.EmitReloc(r2rFactory.Header, RelocType.IMAGE_REL_SYMBOL_SIZE);
 
             // Did we fully read the header?
             Debug.Assert(reader.Offset - headerSize == _module.PEReader.PEHeaders.CorHeaderStartOffset);

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/HeaderNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/HeaderNode.cs
@@ -134,9 +134,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 builder.EmitInt((int)item.Id);
                 
                 builder.EmitReloc(item.StartSymbol, RelocType.IMAGE_REL_BASED_ADDR32NB);
-
-                if (!relocsOnly)
-                    builder.EmitInt(item.Node.GetData(factory).Data.Length);
+                builder.EmitReloc(item.StartSymbol, RelocType.IMAGE_REL_SYMBOL_SIZE);
                 
                 count++;
             }
@@ -146,6 +144,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             return builder.ToObjectData();
         }
 
-        public override int ClassCode => 627741208;
+        protected internal override int Phase => (int)ObjectNodePhase.Ordered;
+
+        public override int ClassCode => (int)ObjectNodeOrder.ReadyToRunHeaderNode;
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
@@ -14,6 +14,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             public ImportTable(string startSymbol, string endSymbol) : base(startSymbol, endSymbol, nodeSorter: new EmbeddedObjectNodeComparer(new CompilerComparer())) {}
 
             public override bool ShouldSkipEmittingObjectNode(NodeFactory factory) => false;
+
+            public override int ClassCode => (int)ObjectNodeOrder.ImportSectionNode;
         }
 
         private readonly ImportTable _imports;
@@ -88,7 +90,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override bool StaticDependenciesAreComputed => true;
 
-        public override int ClassCode => -62839441;
+        protected internal override int Phase => (int)ObjectNodePhase.Ordered;
+
+        public override int ClassCode => (int)ObjectNodeOrder.ImportSectionNode;
 
         public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
         {
@@ -103,8 +107,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             if (!relocsOnly)
             {
-                dataBuilder.EmitInt(_imports.GetData(factory, false).Data.Length);
-
+                dataBuilder.EmitReloc(_imports.StartSymbol, RelocType.IMAGE_REL_SYMBOL_SIZE);
                 dataBuilder.EmitShort((short)_flags);
                 dataBuilder.EmitByte((byte)_type);
                 dataBuilder.EmitByte(_entrySize);

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionsTableNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionsTableNode.cs
@@ -51,6 +51,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
         }
 
-        public override int ClassCode => 787556329;
+        protected internal override int Phase => (int)ObjectNodePhase.Ordered;
+
+        public override int ClassCode => (int)ObjectNodeOrder.ImportSectionsTableNode;
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
@@ -113,7 +113,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 alignment: 8,
                 definedSymbols: new ISymbolDefinitionNode[] { this });
         }
-
-        public override int ClassCode => 787556329;
+        protected internal override int Phase => (int)ObjectNodePhase.Ordered;
+        public override int ClassCode => (int)ObjectNodeOrder.MethodEntrypointTableNode;
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
@@ -75,7 +75,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             foreach (MethodWithGCInfo method in _methodNodes)
             {
-                int methodOffset = runtimeFunctionsBuilder.CountBytes;
                 int[] funcletOffsets = method.GCInfoNode.CalculateFuncletOffsets(factory);
 
                 for (int frameIndex = 0; frameIndex < method.FrameInfos.Length; frameIndex++)

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/RelocationHelper.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/RelocationHelper.cs
@@ -155,6 +155,7 @@ namespace ILCompiler.PEWriter
                     }
 
                 case RelocType.IMAGE_REL_BASED_ADDR32NB:
+                case RelocType.IMAGE_REL_SYMBOL_SIZE:
                     {
                         relocationLength = 4;
                         delta = targetRVA;


### PR DESCRIPTION
* Add a new relocation (`IMAGE_REL_SYMBOL_SIZE`) to Crossgen2 which is fixed up with the size of the object node being relocated to.
* Crossgen2 needs to encode the size of another ObjectNode in several places
  * The COR header emits offset and size of the ready-to-run header
  * The ready-to-run header itself emits the sizes of the various data tables it points at
  * `ImportSectionsTable` points to the RVA / size of `ImportTable`
* Currently we call `Getdata().Data.Length` on the node we want to know the size of which is wasteful, causing us to regenerate data for all the header nodes multiple times.
* Fix some implicit node emission ordering dependencies we were unaware of. `MethodEntryPoint` table needs to be generated after the import section nodes since it encodes index and offsets of imports within their tables which are only finalized when the import tables are emitted.

Fixes https://github.com/dotnet/coreclr/issues/27116

cc @dotnet/crossgen-contrib 