### PR TITLE
Make GC longrunning tests (and reliability framework) run with ServerGC.

### DIFF
--- a/eng/pipelines/templates/run-test-job.yml
+++ b/eng/pipelines/templates/run-test-job.yml
@@ -85,7 +85,9 @@ jobs:
       timeoutInMinutes: 150
     ${{ if in(parameters.testGroup, 'outerloop') }}:
       timeoutInMinutes: 270
-    ${{ if in(parameters.testGroup, 'gc-longrunning', 'gc-simulator') }}:
+    ${{ if in(parameters.testGroup, 'gc-longrunning') }}:
+      timeoutInMinutes: 540
+    ${{ if in(parameters.testGroup, 'gc-simulator') }}:
       timeoutInMinutes: 480
     ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'gcstress0x3-gcstress0xc') }}:
       timeoutInMinutes: 390
@@ -232,9 +234,9 @@ jobs:
           timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 10
         ${{ if in(parameters.testGroup, 'gc-longrunning', 'gc-simulator') }}:
-          timeoutPerTestCollectionInMinutes: 360
+          timeoutPerTestCollectionInMinutes: 480
           # gc reliability may take up to 2 hours to shutdown. Some scenarios have very long iteration times.
-          timeoutPerTestInMinutes: 240
+          timeoutPerTestInMinutes: 360
         ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstress-isas-x86', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'jitelthookenabled' ) }}:
           timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 30

--- a/eng/pipelines/templates/run-test-job.yml
+++ b/eng/pipelines/templates/run-test-job.yml
@@ -364,7 +364,7 @@ jobs:
         ${{ if in(parameters.testGroup, 'gc-longrunning') }}:
           longRunningGcTests: true
           scenarios:
-          - normal
+          - gcServer
         ${{ if in(parameters.testGroup, 'gc-simulator') }}:
           gcSimulatorTests: true
           scenarios:

--- a/tests/testenvironment.proj
+++ b/tests/testenvironment.proj
@@ -40,7 +40,8 @@
       COMPlus_JitStressRegs;
       COMPlus_TailcallStress;
       COMPlus_ReadyToRun;
-      COMPlus_ZapDisable
+      COMPlus_ZapDisable;
+      COMPlus_gcServer
     </COMPlusVariables>
   </PropertyGroup>
   <ItemGroup>
@@ -126,6 +127,7 @@
     <TestEnvironment Include="gcstress0xc_jitstress1" GCStress="0xC" JitStress="1" />
     <TestEnvironment Include="gcstress0xc_jitstress2" GCStress="0xC" JitStress="2" />
     <TestEnvironment Include="gcstress0xc_jitminopts_heapverify1" GCStress="0xC" JITMinOpts="1" HeapVerify="1" />
+    <TestEnvironment Include="gcServer" gcServer="1" />
   </ItemGroup>
 
   <!-- We use target batching on the COMPlusVariable items to iterate over the all COMPlus_* environment variables


### PR DESCRIPTION
We would get more value from running this with Server GC.

Note: GC simulator pipeline still uses WKS.