### PR TITLE
Use cross-module R2R generics from main module with version bubble

### DIFF
--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
@@ -29,6 +29,13 @@ namespace ILCompiler
         /// <returns>True if the given method versions with the current compilation module group</returns>
         public virtual bool VersionsWithMethodBody(MethodDesc methodDesc) => ContainsMethodBody(methodDesc, unboxingStub: false);
 
+        /// <summary>
+        /// Returns true when a given module belongs to the same version bubble as the compilation module group.
+        /// </summary>
+        /// <param name="module">Module to check</param>
+        /// <returns>True if the given module versions with the current compilation module group</returns>
+        public abstract bool VersionsWithModule(ModuleDesc module);
+
         public abstract bool GeneratesPInvoke(MethodDesc method);
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
@@ -96,8 +96,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public int ModuleToIndex(EcmaModule module)
         {
             AssemblyName assemblyName = module.Assembly.GetName();
-            int assemblyRefIndex;
-            if (!_assemblyRefToModuleIdMap.TryGetValue(assemblyName.Name, out assemblyRefIndex))
+
+            if (!_manifestAssemblies.Contains(assemblyName))
             {
                 if (_emissionCompleted)
                 {
@@ -108,22 +108,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 // the verification logic would be broken at runtime.
                 Debug.Assert(_nodeFactory.CompilationModuleGroup.VersionsWithModule(module));
 
-                assemblyRefIndex = _nextModuleId++;
                 _manifestAssemblies.Add(assemblyName);
-                _assemblyRefToModuleIdMap.Add(assemblyName.Name, assemblyRefIndex);
-            }
-            else if (_nodeFactory.CompilationModuleGroup.VersionsWithModule(module))
-            {
-                // This is one of the modules already referenced by the current module, and also part of the version
-                // bubble, so it needs to be emitted in the manifest.
-                if (!_manifestAssemblies.Contains(assemblyName))
-                {
-                    _nextModuleId++;
-                    _manifestAssemblies.Add(assemblyName);
-                }
+                if (!_assemblyRefToModuleIdMap.ContainsKey(assemblyName.Name))
+                    _assemblyRefToModuleIdMap.Add(assemblyName.Name, _nextModuleId);
+
+                _nextModuleId++;
             }
 
-            return assemblyRefIndex;
+            return _assemblyRefToModuleIdMap[assemblyName.Name];
         }
 
         public override int ClassCode => 791828335;

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -567,7 +567,7 @@ namespace ILCompiler.DependencyAnalysis
             MethodEntryPointTable = new MethodEntryPointTableNode(Target);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.MethodDefEntryPoints, MethodEntryPointTable, MethodEntryPointTable);
 
-            ManifestMetadataTable = new ManifestMetadataTableNode(InputModuleContext.GlobalContext);
+            ManifestMetadataTable = new ManifestMetadataTableNode(InputModuleContext.GlobalContext, this);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.ManifestMetadata, ManifestMetadataTable, ManifestMetadataTable);
 
             Resolver.SetModuleIndexLookup(ManifestMetadataTable.ModuleToIndex);

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
@@ -161,6 +161,11 @@ namespace ILCompiler
             return true;
         }
 
+        public override bool VersionsWithModule(ModuleDesc module)
+        {
+            return _versionBubbleModuleSet.Contains(module);
+        }
+
         public override bool VersionsWithType(TypeDesc typeDesc)
         {
             return typeDesc.GetTypeDefinition() is EcmaType ecmaType &&

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -33,7 +33,7 @@ namespace ILCompiler
 
         public override bool VersionsWithModule(ModuleDesc module)
         {
-            return ((EcmaMethod)_method).Module == module;
+            return ((EcmaMethod)_method.GetTypicalMethodDefinition()).Module == module;
         }
 
         public override bool GeneratesPInvoke(MethodDesc method)

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+using System.Reflection.Metadata.Ecma335;
 
 namespace ILCompiler
 {
@@ -27,6 +29,11 @@ namespace ILCompiler
         public override bool ContainsType(TypeDesc type)
         {
             return type == _method.OwningType;
+        }
+
+        public override bool VersionsWithModule(ModuleDesc module)
+        {
+            return ((EcmaMethod)_method).Module == module;
         }
 
         public override bool GeneratesPInvoke(MethodDesc method)

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -557,6 +557,18 @@ PCODE MethodDesc::GetPrecompiledR2RCode(PrepareCodeConfig* pConfig)
     {
         pCode = pModule->GetReadyToRunInfo()->GetEntryPoint(this, pConfig, TRUE /* fFixups */);
     }
+
+    // Lookup in the entry point assembly for a R2R entrypoint (generics with large version bubble enabled)
+    if (pCode == NULL && HasClassOrMethodInstantiation() && SystemDomain::System()->DefaultDomain()->GetRootAssembly() != NULL)
+    {
+        pModule = SystemDomain::System()->DefaultDomain()->GetRootAssembly()->GetManifestModule();
+        _ASSERT(pModule != NULL);
+
+        if (pModule->IsReadyToRun() && pModule->IsInSameVersionBubble(GetModule()))
+        {
+            pCode = pModule->GetReadyToRunInfo()->GetEntryPoint(this, pConfig, TRUE /* fFixups */);
+        }
+    }
 #endif
     return pCode;
 }


### PR DESCRIPTION
Porting the changes from the single-exe branch, and fixing a bug with the native assembly manifest where we had missing entries (any module directly referenced by the current module).

cc @dotnet/crossgen-contrib 