### PR TITLE
Minor cleanup in download-artifact-step / upload-artifact-step

### DIFF
--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -160,9 +160,9 @@ jobs:
       parameters:
         rootFolder: $(buildProductRootFolderPath)
         includeRootFolder: false
-        archiveFile: $(Build.StagingDirectory)/$(buildProductArtifactName)$(archiveExtension)
         archiveType: $(archiveType)
         tarCompression: $(tarCompression)
+        archiveExtension: $(archiveExtension)
         artifactName: $(buildProductArtifactName)
         displayName: 'product build'
 
@@ -171,9 +171,9 @@ jobs:
       parameters:
         rootFolder: $(testNativeRootFolderPath)
         includeRootFolder: false
-        archiveFile: $(Build.StagingDirectory)/$(testNativeArtifactName)$(archiveExtension)
         archiveType: $(archiveType)
         tarCompression: $(tarCompression)
+        archiveExtension: $(archiveExtension)
         artifactName: $(testNativeArtifactName)
         displayName: 'native test components'
 
@@ -182,9 +182,9 @@ jobs:
       parameters:
         rootFolder: $(testBuildRootFolderPath)
         includeRootFolder: false
-        archiveFile: $(Build.StagingDirectory)/$(testBuildArtifactName)$(archiveExtension)
         archiveType: $(archiveType)
         tarCompression: $(tarCompression)
+        archiveExtension: $(archiveExtension)
         artifactName: $(testBuildArtifactName)
         displayName: 'test build tree'
 

--- a/eng/pipelines/templates/build-test-job.yml
+++ b/eng/pipelines/templates/build-test-job.yml
@@ -74,7 +74,6 @@ jobs:
     # Download product binaries directory
     - template: download-artifact-step.yml
       parameters:
-        downloadFolder: $(binTestsPath)/tmp
         unpackFolder: $(buildProductRootFolderPath)
         artifactFileName: '$(buildProductArtifactName)$(archiveExtension)'
         artifactName: '$(buildProductArtifactName)'
@@ -95,9 +94,9 @@ jobs:
       parameters:
         rootFolder: $(testRootFolderPath)
         includeRootFolder: false
-        archiveFile: '$(Build.StagingDirectory)/$(testArtifactName)$(archiveExtension)'
         archiveType: $(archiveType)
         tarCompression: $(tarCompression)
+        archiveExtension: $(archiveExtension)
         artifactName: $(testArtifactName)
         displayName: 'managed test components'
 
@@ -108,9 +107,9 @@ jobs:
       parameters:
         rootFolder: $(microsoftNetSdkIlFolderPath)
         includeRootFolder: false
-        archiveFile: $(Build.StagingDirectory)/$(microsoftNetSdkIlArtifactName)$(archiveExtension)
         archiveType: $(archiveType)
         tarCompression: $(tarCompression)
+        archiveExtension: $(archiveExtension)
         artifactName: $(microsoftNetSdkIlArtifactName)
         displayName: 'Microsoft.NET.Sdk.IL package'
 

--- a/eng/pipelines/templates/checkout-job.yml
+++ b/eng/pipelines/templates/checkout-job.yml
@@ -29,9 +29,9 @@ jobs:
       displayName: 'GIT repository (Windows)'
       rootFolder: $(Build.SourcesDirectory)
       includeRootFolder: false
-      archiveFile: $(Build.StagingDirectory)/repo_windows.zip
       archiveType: 'zip'
       tarCompression: ''
+      archiveExtension: '.zip'
       artifactName: repo_windows
 
 - job: 'checkout_unix'
@@ -58,7 +58,7 @@ jobs:
       displayName: 'GIT repository (Unix)'
       rootFolder: $(Build.SourcesDirectory)
       includeRootFolder: false
-      archiveFile: $(Build.StagingDirectory)/repo_unix.tar.gz
       archiveType: 'tar'
       tarCompression: 'gz'
+      archiveExtension: '.tar.gz'
       artifactName: repo_unix

--- a/eng/pipelines/templates/crossgen-comparison-job.yml
+++ b/eng/pipelines/templates/crossgen-comparison-job.yml
@@ -64,7 +64,6 @@ jobs:
     # Download product build
     - template: download-artifact-step.yml
       parameters:
-        downloadFolder: $(binTestsPath)/tmp
         unpackFolder: $(buildProductRootFolderPath)
         artifactFileName: '$(buildProductArtifactName)$(archiveExtension)'
         artifactName: '$(buildProductArtifactName)'

--- a/eng/pipelines/templates/download-artifact-step.yml
+++ b/eng/pipelines/templates/download-artifact-step.yml
@@ -1,5 +1,4 @@
 parameters:
-  downloadFolder: ''
   unpackFolder: ''
   cleanUnpackFolder: true
   artifactFileName: ''
@@ -13,13 +12,13 @@ steps:
     inputs:
       buildType: current
       downloadType: single
-      downloadPath: '${{ parameters.downloadFolder }}'
+      downloadPath: '$(Build.SourcesDirectory)/__download__'
       artifactName: '${{ parameters.artifactName }}'
 
   # Unzip artifact
   - task: ExtractFiles@1
     displayName: 'Unzip ${{ parameters.displayName }}'
     inputs:
-      archiveFilePatterns: ${{ parameters.downloadFolder }}/${{ parameters.artifactName }}/${{ parameters.artifactFileName }}
+      archiveFilePatterns: $(Build.SourcesDirectory)/__download__/${{ parameters.artifactName }}/${{ parameters.artifactFileName }}
       destinationFolder: ${{ parameters.unpackFolder }}
       cleanDestinationFolder: ${{ parameters.cleanUnpackFolder }}

--- a/eng/pipelines/templates/perf-job.yml
+++ b/eng/pipelines/templates/perf-job.yml
@@ -47,7 +47,6 @@ jobs:
     # Download product binaries directory
     - template: download-artifact-step.yml
       parameters:
-        downloadFolder: $(binTestsPath)/tmp
         unpackFolder: $(buildProductRootFolderPath)
         artifactFileName: '$(buildProductArtifactName)$(archiveExtension)'
         artifactName: '$(buildProductArtifactName)'

--- a/eng/pipelines/templates/run-test-job.yml
+++ b/eng/pipelines/templates/run-test-job.yml
@@ -98,7 +98,6 @@ jobs:
     - ${{ if ne(parameters.corefxTests, true) }}:
       - template: download-artifact-step.yml
         parameters:
-          downloadFolder: '$(binTestsPath)/tmp'
           unpackFolder: '$(testRootFolderPath)'
           artifactFileName: '$(testArtifactName)$(archiveExtension)'
           artifactName: '$(testArtifactName)'
@@ -109,7 +108,6 @@ jobs:
     - ${{ if ne(parameters.corefxTests, true) }}:
       - template: download-artifact-step.yml
         parameters:
-          downloadFolder: '$(binTestsPath)/tmp'
           unpackFolder: '$(testBuildRootFolderPath)'
           cleanUnpackFolder: false
           artifactFileName: '$(testBuildArtifactName)$(archiveExtension)'
@@ -120,7 +118,6 @@ jobs:
     # Download product binaries directory
     - template: download-artifact-step.yml
       parameters:
-        downloadFolder: $(binTestsPath)/tmp
         unpackFolder: $(buildProductRootFolderPath)
         artifactFileName: '$(buildProductArtifactName)$(archiveExtension)'
         artifactName: '$(buildProductArtifactName)'
@@ -132,7 +129,6 @@ jobs:
     - ${{ if ne(parameters.corefxTests, true) }}:
       - template: download-artifact-step.yml
         parameters:
-          downloadFolder: '$(binTestsPath)/tmp'
           unpackFolder: '$(microsoftNetSdkIlFolderPath)'
           artifactFileName: '$(microsoftNetSdkIlArtifactName)$(archiveExtension)'
           artifactName: '$(microsoftNetSdkIlArtifactName)'
@@ -143,7 +139,6 @@ jobs:
     - ${{ if ne(parameters.corefxTests, true) }}:
       - template: download-artifact-step.yml
         parameters:
-          downloadFolder: '$(binTestsPath)/tmp'
           unpackFolder: '$(testNativeRootFolderPath)'
           artifactFileName: '$(testNativeArtifactName)$(archiveExtension)'
           artifactName: '$(testNativeArtifactName)'

--- a/eng/pipelines/templates/upload-artifact-step.yml
+++ b/eng/pipelines/templates/upload-artifact-step.yml
@@ -1,9 +1,9 @@
 parameters:
   rootFolder: ''
   includeRootFolder: false
-  archiveFile: ''
   archiveType: ''
   tarCompression: ''
+  archiveExtension: ''
   artifactName: ''
   displayName: ''
 
@@ -13,7 +13,7 @@ steps:
     displayName: 'Zip ${{ parameters.displayName }}'
     inputs:
       rootFolderOrFile:  ${{ parameters.rootFolder }}
-      archiveFile:       ${{ parameters.archiveFile }}
+      archiveFile:       $(Build.StagingDirectory)/${{ parameters.artifactName }}${{ parameters.archiveExtension }}
       archiveType:       ${{ parameters.archiveType }}
       tarCompression:    ${{ parameters.tarCompression }}
       includeRootFolder: ${{ parameters.includeRootFolder }}
@@ -21,5 +21,5 @@ steps:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish ${{ parameters.displayName }}'
     inputs:
-      pathtoPublish: ${{ parameters.archiveFile }}
+      pathtoPublish: $(Build.StagingDirectory)/${{ parameters.artifactName }}${{ parameters.archiveExtension }}
       artifactName:  ${{ parameters.artifactName }}

--- a/eng/pipelines/templates/xplat-job.yml
+++ b/eng/pipelines/templates/xplat-job.yml
@@ -168,7 +168,6 @@ jobs:
     - template: download-artifact-step.yml
       parameters:
         displayName: 'GIT repository'
-        downloadFolder: $(Build.SourcesDirectory)/download/
         cleanUnpackFolder: false
         unpackFolder: $(Build.SourcesDirectory)
         ${{ if eq(parameters.osGroup, 'Windows_NT') }}:


### PR DESCRIPTION
I have noticed this some time ago. We don't actually need to
explicitly specify the "upload / download folder" as we can easily
synthesize them in the step templates.

Thanks

Tomas