### PR TITLE
[WIP/Test pr] Fix GTF_ASG flag on call nodes.

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21309,35 +21309,18 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
                 {
                     fgDebugCheckFlags(call->gtCallThisArg->GetNode());
                     chkFlags |= (call->gtCallThisArg->GetNode()->gtFlags & GTF_SIDE_EFFECT);
-
-                    if ((call->gtCallThisArg->GetNode()->gtFlags & GTF_ASG) != 0)
-                    {
-                        treeFlags |= GTF_ASG;
-                    }
                 }
 
                 for (GenTreeCall::Use& use : call->Args())
                 {
                     fgDebugCheckFlags(use.GetNode());
-
                     chkFlags |= (use.GetNode()->gtFlags & GTF_SIDE_EFFECT);
-
-                    if ((use.GetNode()->gtFlags & GTF_ASG) != 0)
-                    {
-                        treeFlags |= GTF_ASG;
-                    }
                 }
 
                 for (GenTreeCall::Use& use : call->LateArgs())
                 {
                     fgDebugCheckFlags(use.GetNode());
-
                     chkFlags |= (use.GetNode()->gtFlags & GTF_SIDE_EFFECT);
-
-                    if ((use.GetNode()->gtFlags & GTF_ASG) != 0)
-                    {
-                        treeFlags |= GTF_ASG;
-                    }
                 }
 
                 if ((call->gtCallType == CT_INDIRECT) && (call->gtCallCookie != nullptr))

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21110,7 +21110,7 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
 {
     const genTreeOps oper      = tree->OperGet();
     const unsigned   kind      = tree->OperKind();
-    unsigned         treeFlags = tree->gtFlags & GTF_ALL_EFFECT;
+    const unsigned   treeFlags = tree->gtFlags & GTF_ALL_EFFECT;
     unsigned         chkFlags  = 0;
 
     if (tree->OperMayThrow(this))
@@ -21282,14 +21282,6 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
         if (tree->OperRequiresAsgFlag())
         {
             chkFlags |= GTF_ASG;
-        }
-
-        if (oper == GT_ADDR && (op1->OperIsLocal() || op1->gtOper == GT_CLS_VAR ||
-                                (op1->gtOper == GT_IND && op1->AsOp()->gtOp1->gtOper == GT_CLS_VAR_ADDR)))
-        {
-            /* &aliasedVar doesn't need GTF_GLOB_REF, though alisasedVar does.
-               Similarly for clsVar */
-            treeFlags |= GTF_GLOB_REF;
         }
     }
 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -11285,9 +11285,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                  */
                 op1 = gtNewOperNode(GT_ADDR, TYP_BYREF, op1);
 
-                // &aliasedVar doesnt need GTF_GLOB_REF, though alisasedVar does
-                assert((op1->gtFlags & GTF_GLOB_REF) == 0);
-
                 tiRetVal = lvaTable[lclNum].lvVerTypeInfo;
                 if (tiVerificationNeeded)
                 {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2267,6 +2267,7 @@ void fgArgInfo::EvalArgsToTemps()
         {
             noway_assert(curArgTabEntry->use->GetNode() == argx);
             curArgTabEntry->use->SetNode(setupArg);
+            callTree->gtFlags |= setupArg->gtFlags & GTF_ALL_EFFECT;
         }
 
         /* deferred arg goes into the late argument list */

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -11566,13 +11566,6 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
 
         /* Propagate the new flags */
         tree->gtFlags |= (op1->gtFlags & GTF_ALL_EFFECT);
-
-        // &aliasedVar doesn't need GTF_GLOB_REF, though alisasedVar does
-        // Similarly for clsVar
-        if (oper == GT_ADDR && (op1->gtOper == GT_LCL_VAR || op1->gtOper == GT_CLS_VAR))
-        {
-            tree->gtFlags &= ~GTF_GLOB_REF;
-        }
     } // if (op1)
 
     /*-------------------------------------------------------------------------


### PR DESCRIPTION
We were artificially added `GTF_ASG` flag into  `treeFlags ` in `fgDebugCheckFlags` to avoid asserts about missing flags.
However, it created an inconsistency with `gtUpdateSideEffects`. It correctly propagated `ASG` flag so  we had a situation when calling  `gtUpdateSideEffects(tree, stmt)` for an unchanged tree could result in changed flags:
before calling `gtUpdateSideEffects(000055, stmt)`:
```
N019 ( 51, 40) [000068] --CXG-------              *  JTRUE     void
N018 ( 49, 38) [000067] J-CXG--N----              \--*  LT        int    $148
N016 ( 47, 36) [000065] --CXG------- HERE            +--*  CALLV stub int    System.Collections.IComparer.Compare $383
N010 ( 18, 11) [000131] -ACXG---R-L- arg2 SETUP      |  +--*  ASG       ref    $346
N009 (  1,  1) [000130] D------N----                 |  |  +--*  LCL_VAR   ref    V12 tmp5         d:2 $346
N008 ( 18, 11) [000059] --CXG-------                 |  |  \--*  CALL r2r_ind ref    System.Array.GetValue $346
N006 (  3,  2) [000049] *--XG------- this in rcx     |  |     +--*  IND       ref    <l:$286, c:$285>
N005 (  1,  1) [000048] ------------                 |  |     |  \--*  LCL_VAR   byref  V00 this         u:1 Zero Fseq[keys] $80
N007 (  1,  1) [000055] ------------ arg1 in rdx     |  |     \--*  LCL_VAR   int    V05 loc2         u:5 (last use) $147
N012 (  1,  1) [000132] ------------ arg2 in rdx     |  +--*  LCL_VAR   ref    V12 tmp5         u:2 (last use) $346
N013 (  1,  1) [000064] ------------ arg3 in r8      |  +--*  LCL_VAR   ref    V04 loc1         u:2 $205
N014 (  1,  1) [000062] ------------ this in rcx     |  +--*  LCL_VAR   ref    V09 tmp2         u:2 (last use) <l:$241, c:$341>
N015 (  3, 10) [000127] ------------ arg1 in r11     |  \--*  CNS_INT(h) long   0xd1ffab1e ftn REG r11 $480
N017 (  1,  1) [000066] ------------                 \--*  CNS_INT   int    0 $40
```
after:
```
N019 ( 51, 40) [000068] -ACXG-------              *  JTRUE     void
N018 ( 49, 38) [000067] JACXG--N----              \--*  LT        int    $148
N016 ( 47, 36) [000065] -ACXG------- HERE                        +--*  CALLV stub int    System.Collections.IComparer.Compare $383
N010 ( 18, 11) [000131] -ACXG---R-L- arg2 SETUP      |  +--*  ASG       ref    $346
N009 (  1,  1) [000130] D------N----                 |  |  +--*  LCL_VAR   ref    V12 tmp5         d:2 $346
N008 ( 18, 11) [000059] --CXG-------                 |  |  \--*  CALL r2r_ind ref    System.Array.GetValue $346
N006 (  3,  2) [000049] *--XG------- this in rcx     |  |     +--*  IND       ref    <l:$286, c:$285>
N005 (  1,  1) [000048] ------------                 |  |     |  \--*  LCL_VAR   byref  V00 this         u:1 Zero Fseq[keys] $80
N007 (  1,  1) [000055] ------------ arg1 in rdx     |  |     \--*  LCL_VAR   int    V05 loc2         u:5 (last use) $147
N012 (  1,  1) [000132] ------------ arg2 in rdx     |  +--*  LCL_VAR   ref    V12 tmp5         u:2 (last use) $346
N013 (  1,  1) [000064] ------------ arg3 in r8      |  +--*  LCL_VAR   ref    V04 loc1         u:2 $205
N014 (  1,  1) [000062] ------------ this in rcx     |  +--*  LCL_VAR   ref    V09 tmp2         u:2 (last use) <l:$241, c:$341>
N015 (  3, 10) [000127] ------------ arg1 in r11     |  \--*  CNS_INT(h) long   0xd1ffab1e ftn REG r11 $480
N017 (  1,  1) [000066] ------------                 \--*  CNS_INT   int    0 $40
```
see that flags on [000065] have changed, but they should not.


Of course, there are many asm diffs from that change that should not exist.