### PR TITLE
Fix r2r-extra job definition (incorrect placement of testGroup)

### DIFF
--- a/eng/pipelines/r2r-extra.yml
+++ b/eng/pipelines/r2r-extra.yml
@@ -30,7 +30,8 @@ jobs:
     buildConfig: checked
     platformGroup: gcstress # r2r-extra testGroup runs gcstress15 scenario
     helixQueueGroup: ci
-    testGroup: r2r-extra
+    managedOsxBuild: false
     jobParameters:
+      testGroup: r2r-extra
       readyToRun: true
       displayNameArgs: R2R


### PR DESCRIPTION
This was so inconspicuous it took me quite a while to spot where the problem is.

Thanks

Tomas