### PR TITLE
WIP: Handle spaces in package cache path.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -417,6 +417,7 @@ if not exist "!PgoDataPackagePathOutputFile!" (
 )
 
 set /p __PgoOptDataPath=<"!PgoDataPackagePathOutputFile!"
+set __PgoOptDataPath="%__PgoOptDataPath%"
 
 powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__RepoRootDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
     "%OptDataProjectFilePath%" /t:DumpIbcDataPackagePath /nologo %__CommonMSBuildArgs% /p:IbcDataPackagePathOutputFile="!IbcDataPackagePathOutputFile!"
@@ -432,6 +433,7 @@ if not exist "!IbcDataPackagePathOutputFile!" (
 )
 
 set /p __IbcOptDataPath=<"!IbcDataPackagePathOutputFile!"
+set __IbcOptDataPath="%__IbcOptDataPath%"
 
 REM =========================================================================================
 REM ===

--- a/build.cmd
+++ b/build.cmd
@@ -433,7 +433,6 @@ if not exist "!IbcDataPackagePathOutputFile!" (
 )
 
 set /p __IbcOptDataPath=<"!IbcDataPackagePathOutputFile!"
-set __IbcOptDataPath="%__IbcOptDataPath%"
 
 REM =========================================================================================
 REM ===
@@ -696,14 +695,14 @@ if %__BuildCoreLib% EQU 1 (
         set /p __IbcMergePath=<"!IbcMergePackagePathOutputFile!"
 
         set IbcMergePath=!__IbcMergePath!\tools\netcoreapp2.0\ibcmerge.dll
-        if exist !IbcMergePath! (
+        if exist "!IbcMergePath!" (
             echo %__MsgPrefix%Optimizing using IBC training data
             set OptimizationDataDir=!__IbcOptDataPath!\data\System.Private.CoreLib.dll\
             set InputAssemblyFile=!OptimizationDataDir!System.Private.CoreLib.dll
             set TargetOptimizationDataFile=!OptimizationDataDir!System.Private.CoreLib.pgo
 
             if exist "!InputAssemblyFile!" (
-                set RawOptimizationDataFilePattern=!OptimizationDataDir!*.ibc
+                set RawOptimizationDataFilePattern="!OptimizationDataDir!*.ibc"
                 set RawOptimizationDataFile=
                 for %%x in (!RawOptimizationDataFilePattern!) do @(
                   if [!RawOptimizationDataFile!] == [] (
@@ -738,7 +737,7 @@ if %__BuildCoreLib% EQU 1 (
                 )
 
                 REM Save the module as *.pgo to match the convention expected
-                copy /y !InputAssemblyFile! !TargetOptimizationDataFile!
+                copy /y !InputAssemblyFile! "!TargetOptimizationDataFile!"
             )
 
             if exist "!TargetOptimizationDataFile!" (

--- a/tests/setup-stress-dependencies.cmd
+++ b/tests/setup-stress-dependencies.cmd
@@ -90,7 +90,7 @@ set /p __PkgDir=<"%CoreDisToolsPackagePathOutputFile%"
 
 REM Get downloaded dll path
 echo Locating coredistools.dll
-FOR /F "delims=" %%i IN ('dir "%__PkgDir%"\coredistools.dll /b/s ^| findstr /R "win-%__Arch%"') DO set __LibPath=%%i
+FOR /F "delims=" %%i IN ('dir "%__PkgDir%\coredistools.dll" /b/s ^| findstr /R "win-%__Arch%"') DO set __LibPath=%%i
 echo CoreDisTools library path: %__LibPath%
 if not exist "%__LibPath%" (
     echo Failed to locate the downloaded library: %__LibPath%

--- a/tests/setup-stress-dependencies.cmd
+++ b/tests/setup-stress-dependencies.cmd
@@ -90,7 +90,7 @@ set /p __PkgDir=<"%CoreDisToolsPackagePathOutputFile%"
 
 REM Get downloaded dll path
 echo Locating coredistools.dll
-FOR /F "delims=" %%i IN ('dir %__PkgDir%\coredistools.dll /b/s ^| findstr /R "win-%__Arch%"') DO set __LibPath=%%i
+FOR /F "delims=" %%i IN ('dir "%__PkgDir%"\coredistools.dll /b/s ^| findstr /R "win-%__Arch%"') DO set __LibPath=%%i
 echo CoreDisTools library path: %__LibPath%
 if not exist "%__LibPath%" (
     echo Failed to locate the downloaded library: %__LibPath%


### PR DESCRIPTION
This fixes an issue with the PGO/IBC/stress package paths not being correctly resolved when there are spaces in the path to the package cache.

@PeterSolMS can you see if this works for you?