### PR TITLE
Add NativeLibrary.Free null check to managed

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/NativeLibrary.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/NativeLibrary.cs
@@ -130,6 +130,8 @@ namespace System.Runtime.InteropServices
         /// <param name="handle">The native library handle to be freed</param>
         public static void Free(IntPtr handle)
         {
+            if (handle == IntPtr.Zero)
+                return;
             FreeLib(handle);
         }
 

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -6519,11 +6519,7 @@ NATIVE_LIBRARY_HANDLE NDirect::LoadLibraryModuleBySearch(NDirectMethodDesc * pMD
 void NDirect::FreeNativeLibrary(NATIVE_LIBRARY_HANDLE handle)
 {
     STANDARD_VM_CONTRACT;
-
-    // FreeLibrary doesn't throw if the input is null.
-    // This avoids further null propagation/check while freeing resources (ex: in finally blocks)
-    if (handle == NULL)
-        return;
+    _ASSERTE(handle != NULL);
 
 #ifndef FEATURE_PAL
     BOOL retVal = FreeLibrary(handle);


### PR DESCRIPTION
The rest of this file seems to include these checks in managed, and I'd prefer to keep that consistent instead of having a single function relying on the runtime-specific implementation to do it.