### PR TITLE
Port IsBlittable fix and related changes from single-exe

### DIFF
--- a/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaField.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaField.cs
@@ -259,6 +259,20 @@ namespace Internal.TypeSystem.Ecma
             return !MetadataReader.GetCustomAttributeHandle(MetadataReader.GetFieldDefinition(_handle).GetCustomAttributes(),
                 attributeNamespace, attributeName).IsNil;
         }
+
+        public override MarshalAsDescriptor GetMarshalAsDescriptor()
+        {
+            MetadataReader reader = MetadataReader;
+            FieldDefinition definition = reader.GetFieldDefinition(_handle);
+            if ((definition.Attributes & FieldAttributes.HasFieldMarshal) != 0)
+            {
+                BlobReader marshalAsReader = reader.GetBlobReader(definition.GetMarshallingDescriptor());
+                EcmaSignatureParser parser = new EcmaSignatureParser(_type.EcmaModule, marshalAsReader);
+                return parser.ParseMarshalAsDescriptor();
+            }
+
+            return null;
+        }
     }
 
     public static class EcmaFieldExtensions

--- a/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -295,7 +295,7 @@ namespace Internal.TypeSystem.Ecma
             Debug.Assert(_reader.RemainingBytes != 0);
 
             NativeTypeKind type = (NativeTypeKind)_reader.ReadByte();
-            NativeTypeKind arraySubType = NativeTypeKind.Invalid;
+            NativeTypeKind arraySubType = NativeTypeKind.Default;
             uint? paramNum = null, numElem = null;
 
             switch (type)

--- a/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaType.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaType.cs
@@ -539,40 +539,6 @@ namespace Internal.TypeSystem.Ecma
             return result;
         }
 
-        public override MarshalAsDescriptor[] GetFieldMarshalAsDescriptors()
-        {
-            var fieldDefinitionHandles = _typeDefinition.GetFields();
-
-            MarshalAsDescriptor[] marshalAsDescriptors = new MarshalAsDescriptor[fieldDefinitionHandles.Count];
-            int index = 0;
-            foreach (var handle in fieldDefinitionHandles)
-            {
-                var fieldDefinition = MetadataReader.GetFieldDefinition(handle);
-
-                if ((fieldDefinition.Attributes & FieldAttributes.Static) != 0)
-                    continue;
-
-                MarshalAsDescriptor marshalAsDescriptor = GetMarshalAsDescriptor(fieldDefinition);
-                marshalAsDescriptors[index++] = marshalAsDescriptor;
-            }
-
-            return marshalAsDescriptors;
-        }
-
-        private MarshalAsDescriptor GetMarshalAsDescriptor(FieldDefinition fieldDefinition)
-        {
-            if ((fieldDefinition.Attributes & FieldAttributes.HasFieldMarshal) == FieldAttributes.HasFieldMarshal)
-            {
-                MetadataReader metadataReader = MetadataReader;
-                BlobReader marshalAsReader = metadataReader.GetBlobReader(fieldDefinition.GetMarshallingDescriptor());
-                EcmaSignatureParser parser = new EcmaSignatureParser(EcmaModule, marshalAsReader);
-                MarshalAsDescriptor marshalAs =  parser.ParseMarshalAsDescriptor();
-                Debug.Assert(marshalAs != null);
-                return marshalAs;
-            }
-            return null;
-        }
-
         public override bool IsExplicitLayout
         {
             get

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/FieldDesc.Interop.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/FieldDesc.Interop.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    partial class FieldDesc
+    {
+        /// <summary>
+        /// Returns description of how the field should be marshalled to native code.
+        /// </summary>
+        public virtual MarshalAsDescriptor GetMarshalAsDescriptor()
+        {
+            return null;
+        }
+    }
+
+    partial class FieldForInstantiatedType
+    {
+        public override MarshalAsDescriptor GetMarshalAsDescriptor()
+        {
+            return _fieldDef.GetMarshalAsDescriptor();
+        }
+    }
+}

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/IL/MarshalUtils.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/IL/MarshalUtils.cs
@@ -9,51 +9,53 @@ namespace Internal.TypeSystem.Interop
     public static class MarshalUtils
     {
         /// <summary>
-        /// Returns true if this is a type that doesn't require marshalling.
+        /// Returns true if this type has a common representation in both managed and unmanaged memory
+        /// and does not require special handling by the interop marshaler.
         /// </summary>
         public static bool IsBlittableType(TypeDesc type)
         {
-            type = type.UnderlyingType;
-
-            if (type.IsValueType)
+            if (!type.IsDefType)
             {
-                if (type.IsPrimitive)
-                {
-                    // All primitive types except char and bool are blittable
-                    TypeFlags category = type.Category;
-                    if (category == TypeFlags.Boolean || category == TypeFlags.Char)
-                        return false;
-
-                    return true;
-                }
-
-                foreach (FieldDesc field in type.GetFields())
-                {
-                    if (field.IsStatic)
-                        continue;
-
-                    TypeDesc fieldType = field.FieldType;
-
-                    // TODO: we should also reject fields that specify custom marshalling
-                    if (!MarshalUtils.IsBlittableType(fieldType))
-                    {
-                        // This field can still be blittable if it's a Char and marshals as Unicode
-                        var owningType = field.OwningType as MetadataType;
-                        if (owningType == null)
-                            return false;
-
-                        if (fieldType.Category != TypeFlags.Char ||
-                            owningType.PInvokeStringFormat == PInvokeStringFormat.AnsiClass)
-                            return false;
-                    }
-                }
-                return true;
+                return false;
             }
 
-            if (type.IsPointer || type.IsFunctionPointer)
-                return true;
+            TypeDesc baseType = type.BaseType;
+            bool hasNonTrivialParent = baseType != null
+                && !baseType.IsWellKnownType(WellKnownType.Object)
+                && !baseType.IsWellKnownType(WellKnownType.ValueType);
 
-            return false;
+            if (hasNonTrivialParent && !IsBlittableType(baseType))
+            {
+                return false;
+            }
+
+            var mdType = (MetadataType)type;
+
+            foreach (FieldDesc field in type.GetFields())
+            {
+                if (field.IsStatic)
+                {
+                    continue;
+                }
+
+                MarshallerKind marshallerKind = MarshalHelpers.GetMarshallerKind(
+                    field.FieldType,
+                    field.GetMarshalAsDescriptor(),
+                    isReturn: false,
+                    isAnsi: mdType.PInvokeStringFormat == PInvokeStringFormat.AnsiClass,
+                    MarshallerType.Field,
+                    elementMarshallerKind: out var _);
+
+                if (marshallerKind != MarshallerKind.Enum
+                    && marshallerKind != MarshallerKind.BlittableValue
+                    && marshallerKind != MarshallerKind.BlittableStruct
+                    && marshallerKind != MarshallerKind.UnicodeChar)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/InteropTypes.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/InteropTypes.cs
@@ -45,6 +45,11 @@ namespace Internal.TypeSystem.Interop
             return context.SystemModule.GetKnownType("System.Runtime.InteropServices", "Marshal");
         }
 
+        public static MetadataType GetRuntimeHelpers(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System.Runtime.CompilerServices", "RuntimeHelpers");
+        }
+
         public static MetadataType GetStubHelpers(TypeSystemContext context)
         {
             return context.SystemModule.GetKnownType("System.StubHelpers", "StubHelpers");
@@ -96,6 +101,11 @@ namespace Internal.TypeSystem.Interop
         public static bool IsSystemGuid(TypeSystemContext context, TypeDesc type)
         {
             return IsCoreNamedType(context, type, "System", "Guid");
+        }
+
+        public static bool IsSystemArgIterator(TypeSystemContext context, TypeDesc type)
+        {
+            return IsCoreNamedType(context, type, "System", "ArgIterator");
         }
 
         private static bool IsOrDerivesFromType(TypeDesc type, MetadataType targetType)

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
@@ -36,7 +36,7 @@ namespace Internal.TypeSystem
         Array = 0x2a,
         LPStruct = 0x2b,    // This is not  defined in Ecma-335(II.23.4)
         LPUTF8Str = 0x30,
-        Invalid = 0x50,      // This is the default value
+        Default = 0x50,      // This is the default value
         Variant = 0x51,
     }
 

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/MetadataType.Interop.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/MetadataType.Interop.cs
@@ -33,13 +33,5 @@ namespace Internal.TypeSystem
         {
             get;
         }
-
-        /// <summary>
-        /// Retrieves the MarshalAsDescriptor of each field of the type
-        /// </summary>
-        public virtual MarshalAsDescriptor[] GetFieldMarshalAsDescriptors()
-        {
-            return Array.Empty<MarshalAsDescriptor>();
-        }
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -43,6 +43,7 @@
     <Compile Include="..\Common\TypeSystem\IL\Stubs\PInvokeILCodeStreams.cs" Link="IL\Stubs\PInvokeILCodeStreams.cs" />
     <Compile Include="..\Common\TypeSystem\Interop\IL\Marshaller.cs" Link="Interop\IL\Marshaller.cs" />
     <Compile Include="..\Common\TypeSystem\Interop\IL\MarshalHelpers.cs" Link="Interop\IL\MarshalHelpers.cs" />
+    <Compile Include="..\Common\TypeSystem\Interop\IL\MarshalUtils.cs" Link="Interop\IL\MarshalUtils.cs" />
     <Compile Include="..\Common\Compiler\CodeGenerationFailedException.cs" Link="Compiler\CodeGenerationFailedException.cs" />
     <Compile Include="..\Common\Compiler\CompilationBuilder.cs" Link="Compiler\CompilationBuilder.cs" />
     <Compile Include="..\Common\Compiler\CompilationModuleGroup.cs" Link="Compiler\CompilationModuleGroup.cs" />

--- a/src/tools/crossgen2/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
+++ b/src/tools/crossgen2/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
@@ -438,9 +438,6 @@
     <Compile Include="..\Common\TypeSystem\IL\ILOpcodeHelper.cs">
       <Link>IL\ILOpcodeHelper.cs</Link>
     </Compile>
-    <Compile Include="..\Common\TypeSystem\Interop\IL\MarshalUtils.cs">
-      <Link>Interop\IL\MarshalUtils.cs</Link>
-    </Compile>
     <Compile Include="..\Common\TypeSystem\IL\Stubs\ILEmitter.cs">
       <Link>IL\Stubs\ILEmitter.cs</Link>
     </Compile>
@@ -464,6 +461,9 @@
     </Compile>
     <Compile Include="..\Common\TypeSystem\Sorting\MethodForInstantiatedType.Sorting.cs">
       <Link>TypeSystem\Sorting\MethodForInstantiatedType.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\Common\TypeSystem\Interop\FieldDesc.Interop.cs">
+      <Link>TypeSystem\Interop\FieldDesc.Interop.cs</Link>
     </Compile>
     <Compile Include="..\Common\TypeSystem\Interop\InstantiatedType.Interop.cs">
       <Link>TypeSystem\Interop\InstantiatedType.Interop.cs</Link>


### PR DESCRIPTION
I've tried to port the IsBlittable fix from single-exe branch, but I                                                                      ended up having to add cherry picks of two other PRs to that.                                                                             

I've also found that the fix had issues - it was causing stack overflow                                                                   during compilation of a couple of runtime assemblies. After I've                                                                          fixed that, there was about 15 tests failing at runtime failing with                                                                      assert failure: m_alignpad == 0. This is a well known indication of a                                                                     problem where JIT and crossgen get different field offsets, resulting in                                                                  writing beyond the end of an object.                                                                                                      The problem was caused by incorrect usage of sequential layout for class                                                                  without LayoutSequential attribute.                                                                                                       I've added a commit with fix for those to this PR.