### PR TITLE
Leftover changes after rebasing my runtime changes against CoreCLR

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -35,7 +35,7 @@ set ghprbCommentBody=
 ::      __ProjectDir        -- default: directory of the dir.props file
 ::      __RepoRootDir       -- default: directory two levels above the dir.props file
 ::      __SourceDir         -- default: %__ProjectDir%\src\
-::      __RootBinDir        -- default: %__ProjectDir%\artifacts\
+::      __RootBinDir        -- default: %__RepoRootDir%\artifacts\
 ::      __BinDir            -- default: %__RootBinDir%\%__BuildOS%.%__BuildArch.%__BuildType%\
 ::      __IntermediatesDir
 ::      __PackagesBinDir    -- default: %__BinDir%\.nuget
@@ -308,7 +308,7 @@ if %__PgoOptimize%==0 (
 
 set "__BinDir=%__RootBinDir%\Product\%__BuildOS%.%__BuildArch%.%__BuildType%"
 set "__IntermediatesDir=%__RootBinDir%\obj\%__BuildOS%.%__BuildArch%.%__BuildType%"
-set "__ArtifactsIntermediatesDir=%__ProjectDir%\artifacts\obj\"
+set "__ArtifactsIntermediatesDir=%__RepoRootDir%\artifacts\obj\"
 if "%__NMakeMakefiles%"=="1" (set "__IntermediatesDir=%__RootBinDir%\nmakeobj\%__BuildOS%.%__BuildArch%.%__BuildType%")
 set "__PackagesBinDir=%__BinDir%\.nuget"
 set "__CrossComponentBinDir=%__BinDir%"
@@ -374,7 +374,7 @@ REM ============================================================================
 @if defined _echo @echo on
 
 powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__RepoRootDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
-    %__ProjectDir%\eng\empty.csproj /p:NativeVersionFile="%__RootBinDir%\obj\_version.h"^
+    %__RepoRootDir%\eng\empty.csproj /p:NativeVersionFile="%__RootBinDir%\obj\_version.h"^
     /t:GenerateNativeVersionFile /restore^
     %__CommonMSBuildArgs% %__UnprocessedBuildArgs%
 if not !errorlevel! == 0 (

--- a/dotnet.cmd
+++ b/dotnet.cmd
@@ -17,7 +17,6 @@ set DOTNET_MULTILEVEL_LOOKUP=0
 :: Disable first run since we do not need all ASP.NET packages restored.
 set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
-echo Installing dotnet using Arcade...
 set PS_DOTNET_INSTALL_SCRIPT=". %__RepoRootDir%eng\common\tools.ps1; InitializeDotNetCli($true)"
 set "PS_COMMAND=powershell -NoProfile -ExecutionPolicy unrestricted -Command %PS_DOTNET_INSTALL_SCRIPT%"
 

--- a/eng/pipelines/templates/send-to-helix-step.yml
+++ b/eng/pipelines/templates/send-to-helix-step.yml
@@ -24,7 +24,7 @@ parameters:
 steps:
 - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
   # TODO: Remove and consolidate this when we move to arcade via init-tools.cmd.
-  - powershell: $(Build.SourcesDirectory)\eng\common\build.ps1 /p:DotNetPublishToBlobFeed=true -ci -restore -projects ${{ parameters.coreClrRepoRoot }}\eng\empty.csproj
+  - powershell: $(Build.SourcesDirectory)\eng\common\build.ps1 /p:DotNetPublishToBlobFeed=true -ci -restore -projects $(Build.SourcesDirectory)\eng\empty.csproj
     displayName: Restore blob feed tasks
     ${{ if ne(parameters.condition, '') }}:
       condition: ${{ parameters.condition }}
@@ -58,7 +58,7 @@ steps:
 
 - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
   # TODO: Remove and consolidate this when we move to arcade via init-tools.sh.
-  - script: $(Build.SourcesDirectory)/eng/common/build.sh /p:DotNetPublishToBlobFeed=true --ci --restore --projects ${{ parameters.coreClrRepoRoot }}/eng/empty.csproj
+  - script: $(Build.SourcesDirectory)/eng/common/build.sh /p:DotNetPublishToBlobFeed=true --ci --restore --projects $(Build.SourcesDirectory)/eng/empty.csproj
     displayName: Restore blob feed tasks
     ${{ if ne(parameters.condition, '') }}:
       condition: ${{ parameters.condition }}

--- a/eng/pipelines/templates/xplat-pipeline-job.yml
+++ b/eng/pipelines/templates/xplat-pipeline-job.yml
@@ -82,7 +82,13 @@ jobs:
         value: '/'
 
     - name: coreClrRepoRoot
-      value: '$(Build.SourcesDirectory)'
+      value: '$(Build.SourcesDirectory)/src/coreclr'
+
+    # BEGIN SECTION to remove after repo consolidation
+    - ${{ not(startsWith(variables['Build.DefinitionName'], 'runtime')) }}:
+      - name: coreClrRepoRoot
+        value: '$(Build.SourcesDirectory)'
+    # END SECTION to remove after repo consolidation
 
     - name: coreClrRepoRootDir
       value: '$(coreClrRepoRoot)$(dir)'

--- a/eng/pipelines/templates/xplat-pipeline-job.yml
+++ b/eng/pipelines/templates/xplat-pipeline-job.yml
@@ -84,11 +84,10 @@ jobs:
     - name: coreClrRepoRoot
       value: '$(Build.SourcesDirectory)/src/coreclr'
 
-    # BEGIN SECTION to remove after repo consolidation
-    - ${{ not(startsWith(variables['Build.DefinitionName'], 'runtime')) }}:
+    - ${{ if not(startsWith(variables['Build.DefinitionName'], 'runtime')) }}:
+
       - name: coreClrRepoRoot
         value: '$(Build.SourcesDirectory)'
-    # END SECTION to remove after repo consolidation
 
     - name: coreClrRepoRootDir
       value: '$(coreClrRepoRoot)$(dir)'

--- a/tests/setup-stress-dependencies.sh
+++ b/tests/setup-stress-dependencies.sh
@@ -90,7 +90,7 @@ fi
 # This script must be located in coreclr/tests.
 scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-dotnet=$"${scriptDir}"/../.dotnet/dotnet
+dotnet=$"${scriptDir}"/../dotnet.sh
 csprojPath="${scriptDir}"/stress_dependencies/stress_dependencies.csproj
 
 if [ ! -e $dotnetCmd ]; then


### PR DESCRIPTION
1) Viktor moved the empty.csproj script to the repo root, reflect
the change;

2) In xplat-pipeline-job, pick coreClrRepoRoot dynamically based on
pipeline name (thanks Viktor for the suggestion!);

3) Some fixes to call dotnet through the scripts we recently fixed.

4) Remove superfluous echo in dotnet.cmd per Viktor's feedback.

Thanks

Tomas