### PR TITLE
Fix sequential layout for classes

### DIFF
--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -758,7 +758,7 @@ namespace ILCompiler
                 return ComputeExplicitFieldLayout(type, numInstanceFields);
             }
             else
-            if (type.IsValueType && (MarshalUtils.IsBlittableType(type) || IsManagedSequentialType(type)))
+            if (MarshalUtils.IsBlittableType(type) || IsManagedSequentialType(type))
             {
                 return ComputeSequentialFieldLayout(type, numInstanceFields);
             }


### PR DESCRIPTION
This fixes 15 pri 1 coreclr tests in JIT\Methodical\explicit\coverage\seq_gc_*
These tests are using the StructLayout(LayoutKind.Sequential) attribute on a class and
crossgen2 was willing to generate sequential layout on value types only.

This change fixes it.