### PR TITLE
Fix exclusion of the Common folder in runtest.proj

### DIFF
--- a/tests/src/runtest.proj
+++ b/tests/src/runtest.proj
@@ -26,7 +26,8 @@
       <AllTestDirsPaths Include="@(AllTestDirsNonCanonicalPaths)" >
         <Path>$([System.IO.Path]::GetFullPath(%(Identity)))</Path>
       </AllTestDirsPaths>
-      <NonExcludedTestDirectories Include="@(AllTestDirsPaths -> '%(Path)')" Exclude="@(_SkipTestDir -> '$(XunitTestBinBase)%(Identity)')" />
+      <SkipTestDirsPaths Include="$([System.IO.Path]::GetFullPath('$(XunitTestBinBase)%(_SkipTestDir.Identity)'))" />
+      <NonExcludedTestDirectories Include="@(AllTestDirsPaths -> '%(Path)')" Exclude="@(SkipTestDirsPaths)" />
       <TopLevelDirectories Include="@(NonExcludedTestDirectories)" />
       <SecondLevel Include="$([System.IO.Directory]::GetDirectories(%(TopLevelDirectories.Identity)))" />
       <SecondLevelDirectories Include="@(SecondLevel)">


### PR DESCRIPTION
As XunitTestBinBase is not required to be canonical - in fact,
it is based on BaseOutputPath which is defined in
tests/Directory.Build.props as $(ProjectDir)..\bin\tests -
we must canonicalize the constructed paths to exclusion folders
(_SkipTestDir) before excluding them from the list of all test
dirs canonicalized in the same manner, otherwise the two lists
get out of sync and we end up not exluding Common from the test
folders. This in turn causes repeated build of Coreclr.TestWrapper
under Common, causing various race conditions in parallel wrapper
build.

Thanks

Tomas