### PR TITLE
Avoid promoting over-sized intrinsic

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1978,13 +1978,16 @@ Compiler::lvaStructFieldInfo Compiler::StructPromotionHelper::GetFieldInfo(CORIN
     {
         unsigned  simdSize;
         var_types simdBaseType = compiler->getBaseTypeAndSizeOfSIMDType(fieldInfo.fldTypeHnd, &simdSize);
-        if (simdBaseType != TYP_UNKNOWN)
+        if ((simdSize >= compiler->minSIMDStructBytes()) && (simdSize <= compiler->maxSIMDStructBytes()))
         {
-            fieldInfo.fldType = compiler->getSIMDTypeForSize(simdSize);
-            fieldInfo.fldSize = simdSize;
-#ifdef DEBUG
-            retypedFieldsMap.Set(fieldInfo.fldHnd, fieldInfo.fldType, RetypedAsScalarFieldsMap::Overwrite);
-#endif // DEBUG
+            if (simdBaseType != TYP_UNKNOWN)
+            {
+                fieldInfo.fldType = compiler->getSIMDTypeForSize(simdSize);
+                fieldInfo.fldSize = simdSize;
+    #ifdef DEBUG
+                retypedFieldsMap.Set(fieldInfo.fldHnd, fieldInfo.fldType, RetypedAsScalarFieldsMap::Overwrite);
+    #endif // DEBUG
+            }
         }
     }
 #endif // FEATURE_SIMD

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1980,13 +1980,14 @@ Compiler::lvaStructFieldInfo Compiler::StructPromotionHelper::GetFieldInfo(CORIN
         var_types simdBaseType = compiler->getBaseTypeAndSizeOfSIMDType(fieldInfo.fldTypeHnd, &simdSize);
         if ((simdSize >= compiler->minSIMDStructBytes()) && (simdSize <= compiler->maxSIMDStructBytes()))
         {
+            // We will only promote fields of SIMD types that fit into a SIMD register.
             if (simdBaseType != TYP_UNKNOWN)
             {
                 fieldInfo.fldType = compiler->getSIMDTypeForSize(simdSize);
                 fieldInfo.fldSize = simdSize;
-    #ifdef DEBUG
+#ifdef DEBUG
                 retypedFieldsMap.Set(fieldInfo.fldHnd, fieldInfo.fldType, RetypedAsScalarFieldsMap::Overwrite);
-    #endif // DEBUG
+#endif // DEBUG
             }
         }
     }


### PR DESCRIPTION
This PR is meant to fix an assert in `src\jit\morph.cpp:16898` when `JIT\HardwareIntrinsics\X86\Avx\Avx_r\CPAOT-ret.out\Avx_r.dll` is compiled under `crossgen2`

Here is my understanding on what is going on:

When we attempt to promote a struct, we obtain information about the struct though `Compiler::StructPromotionHelper::GetFieldInfo`, without the size check, that code believes `Vector256<Double>` is `TYP_SIMD32` but it actually cannot be because we turned off `Avx`.

Then `Compiler::StructPromotionHelper::TryPromoteStructField` confused, it thinks `Vector256<Double>` is not a `TYP_STRUCT` and let the promotion happen.

Downstream, we failed, `Compiler::fgMorphStructField` discovered that we are promoting a struct field which is also a struct.

My confidence in this code change is just around 30%. It is very possible that something in `crossgen2` is wrong instead.

@dotnet/crossgen-contrib 