### PR TITLE
Move AssemblyLoadContext.GetResolvedUnmanagedDll to shared

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -737,6 +737,28 @@ namespace System.Runtime.Loader
 
             return null;
         }
+
+        private IntPtr GetResolvedUnmanagedDll(Assembly assembly, string unmanagedDllName)
+        {
+            IntPtr resolvedDll = IntPtr.Zero;
+
+            Func<Assembly, string, IntPtr>? dllResolveHandler = _resolvingUnmanagedDll;
+
+            if (dllResolveHandler != null)
+            {
+                // Loop through the event subscribers and return the first non-null native library handle
+                foreach (Func<Assembly, string, IntPtr> handler in dllResolveHandler.GetInvocationList())
+                {
+                    resolvedDll = handler(assembly, unmanagedDllName);
+                    if (resolvedDll != IntPtr.Zero)
+                    {
+                        return resolvedDll;
+                    }
+                }
+            }
+
+            return IntPtr.Zero;
+        }
     }
 
     internal sealed class DefaultAssemblyLoadContext : AssemblyLoadContext

--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -99,28 +99,6 @@ namespace System.Runtime.Loader
             return context.GetResolvedUnmanagedDll(assembly, unmanagedDllName);
         }
 
-        private IntPtr GetResolvedUnmanagedDll(Assembly assembly, string unmanagedDllName)
-        {
-            IntPtr resolvedDll = IntPtr.Zero;
-
-            Func<Assembly, string, IntPtr>? dllResolveHandler = _resolvingUnmanagedDll;
-
-            if (dllResolveHandler != null)
-            {
-                // Loop through the event subscribers and return the first non-null native library handle
-                foreach (Func<Assembly, string, IntPtr> handler in dllResolveHandler.GetInvocationList())
-                {
-                    resolvedDll = handler(assembly, unmanagedDllName);
-                    if (resolvedDll != IntPtr.Zero)
-                    {
-                        return resolvedDll;
-                    }
-                }
-            }
-
-            return IntPtr.Zero;
-        }
-
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
         private static extern void LoadTypeForWinRTTypeNameInContextInternal(IntPtr ptrNativeAssemblyLoadContext, string typeName, ObjectHandleOnStack loadedType);
 


### PR DESCRIPTION
Now that https://github.com/mono/mono/pull/17369 is in, we can move this to shared.

Not sure if I need to wrap this in `!CORERT`.