### PR TITLE
Create a simple minimal MSBuild front-end

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -74,9 +74,6 @@ initTargetDistroRid()
     # Only pass ROOTFS_DIR if cross is specified.
     if (( ${__CrossBuild} == 1 )); then
         passedRootfsDir=${ROOTFS_DIR}
-    elif [ "${__BuildArch}" != "${__HostArch}" ]; then
-        echo "Error, you are building a cross scenario without passing -cross."
-        exit 1
     fi
 
     initDistroRidGlobal ${__BuildOS} ${__BuildArch} ${__PortableBuild} ${passedRootfsDir}
@@ -1035,6 +1032,10 @@ while :; do
 
     shift
 done
+
+if [ "${__BuildArch}" != "${__HostArch}" ]; then
+    __CrossBuild=1
+fi
 
 __CommonMSBuildArgs="/p:__BuildArch=$__BuildArch /p:__BuildType=$__BuildType /p:__BuildOS=$__BuildOS /nodeReuse:false $__OfficialBuildIdArg $__SignTypeArg $__SkipRestoreArg"
 

--- a/coreclr.proj
+++ b/coreclr.proj
@@ -1,0 +1,20 @@
+<Project>
+  <Import Project="Directory.Build.props" />
+  <Import Project="Directory.Build.targets" />
+
+  <Target Name="Build">
+    <ItemGroup>
+      <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows))" Include="-skiptests" />
+      <_CoreClrBuildArg Include="-$(Platform)" />
+      <_CoreClrBuildArg Include="-$(Configuration.ToLower())" />
+      <_CoreClrBuildArg Condition="'$(ContinuousIntegrationBuild)' == 'true'" Include="-ci" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_CoreClrBuildScript Condition="$([MSBuild]::IsOsPlatform(Windows))">build.cmd</_CoreClrBuildScript>
+      <_CoreClrBuildScript Condition="!$([MSBuild]::IsOsPlatform(Windows))">build.sh</_CoreClrBuildScript>
+    </PropertyGroup>
+
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')" />
+  </Target>
+</Project>

--- a/coreclr.proj
+++ b/coreclr.proj
@@ -9,7 +9,7 @@
       <_CoreClrBuildArg Include="-$(Configuration.ToLower())" />
       <_CoreClrBuildArg Condition="'$(ContinuousIntegrationBuild)' == 'true'" Include="-ci" />
       <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and ('$(Platform)' == 'x86' or '$(Platform)' = 'x64') and '$(Configuration)' == 'Release'" Include="-enforcepgo" />
-      <_CoreClrBuildArg Condition="!$([MSBuild]::IsOsPlatform(Windows)) and '$(Configuration)' == 'Release'" Include="-stripsymbols" />
+      <_CoreClrBuildArg Condition="'$(Configuration)' == 'Release'" Include="-stripsymbols" />
       <_CoreClrBuildArg Condition="'$(OfficialBuildId)' == ''" Include="-officialbuildid=$(OfficialBuildId)" />
     </ItemGroup>
 

--- a/coreclr.proj
+++ b/coreclr.proj
@@ -8,6 +8,7 @@
       <_CoreClrBuildArg Include="-$(Platform)" />
       <_CoreClrBuildArg Include="-$(Configuration.ToLower())" />
       <_CoreClrBuildArg Condition="'$(ContinuousIntegrationBuild)' == 'true'" Include="-ci" />
+      <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and ('$(Platform)' == 'x86' or '$(Platform)' = 'x64')" Include="-enforcepgo" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -17,4 +18,8 @@
 
     <Exec Command="&quot;$(MSBuildThisFileDirectory)$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')" />
   </Target>
+
+  <Target Name="Restore" />
+  <Target Name="Test" />
+  <Target Name="Pack" />
 </Project>

--- a/coreclr.proj
+++ b/coreclr.proj
@@ -8,7 +8,9 @@
       <_CoreClrBuildArg Include="-$(Platform)" />
       <_CoreClrBuildArg Include="-$(Configuration.ToLower())" />
       <_CoreClrBuildArg Condition="'$(ContinuousIntegrationBuild)' == 'true'" Include="-ci" />
-      <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and ('$(Platform)' == 'x86' or '$(Platform)' = 'x64')" Include="-enforcepgo" />
+      <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and ('$(Platform)' == 'x86' or '$(Platform)' = 'x64') and '$(Configuration)' == 'Release'" Include="-enforcepgo" />
+      <_CoreClrBuildArg Condition="!$([MSBuild]::IsOsPlatform(Windows)) and '$(Configuration)' == 'Release'" Include="-stripsymbols" />
+      <_CoreClrBuildArg Condition="'$(OfficialBuildId)' == ''" Include="-officialbuildid=$(OfficialBuildId)" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Implement simple coreclr.proj msbuild entrypoint for building the coreclr product in the common configuration as part of a root build script in the dotnet/runtime repository.

Also, automatically assume a cross-build on non-Windows when building for one architecture on another instead of explicitly requiring the user to pass the cross flag in that case.