### PR TITLE
StackTrace.GetFrames should return an array of non-nullable frames

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
@@ -25,7 +25,7 @@ namespace System.Diagnostics
         /// <summary>
         /// Stack frames comprising this stack trace.
         /// </summary>
-        private StackFrame?[]? _stackFrames;
+        private StackFrame[]? _stackFrames;
 
         /// <summary>
         /// Constructs a stack trace from the current location.
@@ -156,7 +156,7 @@ namespace System.Diagnostics
         /// The nth element of this array is the same as GetFrame(n).
         /// The length of the array is the same as FrameCount.
         /// </summary>
-        public virtual StackFrame?[] GetFrames()
+        public virtual StackFrame[] GetFrames()
         {
             if (_stackFrames == null || _numOfFrames <= 0)
                 return Array.Empty<StackFrame>();


### PR DESCRIPTION
Accompanies https://github.com/dotnet/corefx/pull/42490, fixes dotnet/corefx#42422