### PR TITLE
Add tracing for Resolving/AssemblyResolve event handler invocation

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -704,6 +704,16 @@ namespace System.Runtime.Loader
             foreach (ResolveEventHandler handler in eventHandler.GetInvocationList())
             {
                 Assembly? asm = handler(AppDomain.CurrentDomain, args);
+#if CORECLR
+                if (eventHandler == AssemblyResolve && AssemblyLoadContext.IsTracingEnabled())
+                {
+                    AssemblyLoadContext.TraceAssemblyResolveHandlerInvoked(
+                        name,
+                        handler.Method.Name,
+                        asm?.FullName,
+                        asm != null && !asm.IsDynamic ? asm.Location : null);
+                }
+#endif // CORECLR
                 RuntimeAssembly? ret = GetRuntimeAssembly(asm);
                 if (ret != null)
                     return ret;

--- a/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -582,18 +582,29 @@ namespace System.Runtime.Loader
             return context.ResolveSatelliteAssembly(assemblyName);
         }
 
-        private Assembly? GetFirstResolvedAssembly(AssemblyName assemblyName)
+        private Assembly? GetFirstResolvedAssemblyFromResolvingEvent(AssemblyName assemblyName)
         {
             Assembly? resolvedAssembly = null;
 
-            Func<AssemblyLoadContext, AssemblyName, Assembly>? assemblyResolveHandler = _resolving;
+            Func<AssemblyLoadContext, AssemblyName, Assembly>? resolvingHandler = _resolving;
 
-            if (assemblyResolveHandler != null)
+            if (resolvingHandler != null)
             {
                 // Loop through the event subscribers and return the first non-null Assembly instance
-                foreach (Func<AssemblyLoadContext, AssemblyName, Assembly> handler in assemblyResolveHandler.GetInvocationList())
+                foreach (Func<AssemblyLoadContext, AssemblyName, Assembly> handler in resolvingHandler.GetInvocationList())
                 {
                     resolvedAssembly = handler(this, assemblyName);
+#if CORECLR
+                    if (AssemblyLoadContext.IsTracingEnabled())
+                    {
+                        AssemblyLoadContext.TraceResolvingHandlerInvoked(
+                            assemblyName.FullName,
+                            handler.Method.Name,
+                            this != AssemblyLoadContext.Default ? ToString() : Name,
+                            resolvedAssembly?.FullName,
+                            resolvedAssembly != null && !resolvedAssembly.IsDynamic ? resolvedAssembly.Location : null);
+                    }
+#endif // CORECLR
                     if (resolvedAssembly != null)
                     {
                         return resolvedAssembly;
@@ -606,6 +617,11 @@ namespace System.Runtime.Loader
 
         private static Assembly ValidateAssemblyNameWithSimpleName(Assembly assembly, string? requestedSimpleName)
         {
+            if (string.IsNullOrEmpty(requestedSimpleName))
+            {
+                throw new ArgumentException(SR.ArgumentNull_AssemblyNameName);
+            }
+
             // Get the name of the loaded assembly
             string? loadedSimpleName = null;
 
@@ -619,10 +635,6 @@ namespace System.Runtime.Loader
             }
 
             // The simple names should match at the very least
-            if (string.IsNullOrEmpty(requestedSimpleName))
-            {
-                throw new ArgumentException(SR.ArgumentNull_AssemblyNameName);
-            }
             if (string.IsNullOrEmpty(loadedSimpleName) || !requestedSimpleName.Equals(loadedSimpleName, StringComparison.InvariantCultureIgnoreCase))
             {
                 throw new InvalidOperationException(SR.Argument_CustomAssemblyLoadContextRequestedNameMismatch);
@@ -648,8 +660,8 @@ namespace System.Runtime.Loader
         {
             string? simpleName = assemblyName.Name;
 
-            // Invoke the AssemblyResolve event callbacks if wired up
-            Assembly? assembly = GetFirstResolvedAssembly(assemblyName);
+            // Invoke the Resolving event callbacks if wired up
+            Assembly? assembly = GetFirstResolvedAssemblyFromResolvingEvent(assemblyName);
             if (assembly != null)
             {
                 assembly = ValidateAssemblyNameWithSimpleName(assembly, simpleName);

--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -35,6 +35,9 @@ namespace System.Runtime.Loader
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern bool IsTracingEnabled();
 
+        [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
+        internal static extern bool TraceResolvingHandlerInvoked(string assemblyName, string handlerName, string? alcName, string? resultAssemblyName, string? resultAssemblyPath);
+
         private Assembly InternalLoadFromPath(string? assemblyPath, string? nativeImagePath)
         {
             RuntimeAssembly? loadedAssembly = null;

--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -38,6 +38,9 @@ namespace System.Runtime.Loader
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
         internal static extern bool TraceResolvingHandlerInvoked(string assemblyName, string handlerName, string? alcName, string? resultAssemblyName, string? resultAssemblyPath);
 
+        [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
+        internal static extern bool TraceAssemblyResolveHandlerInvoked(string assemblyName, string handlerName, string? resultAssemblyName, string? resultAssemblyPath);
+
         private Assembly InternalLoadFromPath(string? assemblyPath, string? nativeImagePath)
         {
             RuntimeAssembly? loadedAssembly = null;

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -394,6 +394,7 @@
                           value="32" eventGUID="{BCF2339E-B0A6-452D-966C-33AC9DD82573}"
                           message="$(string.RuntimePublisher.AssemblyLoaderTaskMessage)">
                         <opcodes>
+                            <opcode name="ALCResolvingHandlerInvoked" message="$(string.RuntimePublisher.ALCResolvingHandlerInvokedOpcodeMessage)" symbol="CLR_ALC_RESOLVING_HANDLER_INVOKED_OPCODE" value="12"/>
                         </opcodes>
                     </task>
                 <!--Next available ID is 33-->
@@ -1702,6 +1703,25 @@
                                 <TypeParameterCount> %4 </TypeParameterCount>
                                 <LoaderModuleID> %5 </LoaderModuleID>
                             </MethodDetails>
+                        </UserData>
+                    </template>
+
+                    <template tid="ALCResolvingHandlerInvoked">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="AssemblyName" inType="win:UnicodeString" />
+                        <data name="HandlerName" inType="win:UnicodeString" />
+                        <data name="AssemblyLoadContext" inType="win:UnicodeString" />
+                        <data name="ResultAssemblyName" inType="win:UnicodeString" />
+                        <data name="ResultAssemblyPath" inType="win:UnicodeString" />
+                        <UserData>
+                            <ALCResolvingHandlerInvoked xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <AssemblyName> %2 </AssemblyName>
+                                <HandlerName> %3 </HandlerName>
+                                <AssemblyLoadContext> %4 </AssemblyLoadContext>
+                                <ResultAssemblyName> %5 </ResultAssemblyName>
+                                <ResultAssemblyPath> %6 </ResultAssemblyPath>
+                            </ALCResolvingHandlerInvoked>
                         </UserData>
                     </template>
 
@@ -3501,6 +3521,11 @@
                            keywords ="AssemblyLoaderKeyword" opcode="win:Stop"
                            task="AssemblyLoader"
                            symbol="AssemblyLoadStop" message="$(string.RuntimePublisher.AssemblyLoadStopEventMessage)"/>
+
+                    <event value="293" version="0" level="win:Informational"  template="ALCResolvingHandlerInvoked"
+                           keywords ="AssemblyLoaderKeyword" opcode="ALCResolvingHandlerInvoked"
+                           task="AssemblyLoader"
+                           symbol="ALCResolvingHandlerInvoked" message="$(string.RuntimePublisher.ALCResolvingHandlerInvokedEventMessage)"/>
 
                 </events>
             </provider>
@@ -6699,6 +6724,7 @@
                 <string id="RuntimePublisher.AppDomainUnload_V1EventMessage" value="AppDomainID=%1;%nAppDomainFlags=%2;%nAppDomainName=%3;%nAppDomainIndex=%4;%nClrInstanceID=%5" />
                 <string id="RuntimePublisher.AssemblyLoadStartEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nAssemblyPath=%3;%nRequestingAssembly=%4;%nAssemblyLoadContext=%5;%nRequestingAssemblyLoadContext=%6" />
                 <string id="RuntimePublisher.AssemblyLoadStopEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nAssemblyPath=%3;%nRequestingAssembly=%4;%nAssemblyLoadContext=%5;%nRequestingAssemblyLoadContext=%6;%nSuccess=%7;%nResultAssemblyName=%8;%nResultAssemblyPath=%9;%nCached=%10" />
+                <string id="RuntimePublisher.ALCResolvingHandlerInvokedEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nHandlerName=%3;%nAssemblyLoadContext=%4;%nResultAssemblyName=%5;%nResultAssemblyPath=%6" />
                 <string id="RuntimePublisher.StackEventMessage" value="ClrInstanceID=%1;%nReserved1=%2;%nReserved2=%3;%nFrameCount=%4;%nStack=%5" />
                 <string id="RuntimePublisher.AppDomainMemAllocatedEventMessage" value="AppDomainID=%1;%nAllocated=%2;%nClrInstanceID=%3" />
                 <string id="RuntimePublisher.AppDomainMemSurvivedEventMessage" value="AppDomainID=%1;%nSurvived=%2;%nProcessSurvived=%3;%nClrInstanceID=%4" />
@@ -7326,6 +7352,8 @@
                 <string id="RuntimePublisher.TieredCompilationSettingsOpcodeMessage" value="Settings" />
                 <string id="RuntimePublisher.TieredCompilationPauseOpcodeMessage" value="Pause" />
                 <string id="RuntimePublisher.TieredCompilationResumeOpcodeMessage" value="Resume" />
+
+                <string id="RuntimePublisher.ALCResolvingHandlerInvokedOpcodeMessage" value="ALCResolvingHandlerInvoked" />
 
                 <string id="RundownPublisher.MethodDCStartOpcodeMessage" value="DCStart" />
                 <string id="RundownPublisher.MethodDCEndOpcodeMessage" value="DCStop" />

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -394,7 +394,7 @@
                           value="32" eventGUID="{BCF2339E-B0A6-452D-966C-33AC9DD82573}"
                           message="$(string.RuntimePublisher.AssemblyLoaderTaskMessage)">
                         <opcodes>
-                            <opcode name="ALCResolvingHandlerInvoked" message="$(string.RuntimePublisher.ALCResolvingHandlerInvokedOpcodeMessage)" symbol="CLR_ALC_RESOLVING_HANDLER_INVOKED_OPCODE" value="12"/>
+                            <opcode name="AssemblyLoadContextResolvingHandlerInvoked" message="$(string.RuntimePublisher.AssemblyLoadContextResolvingHandlerInvokedOpcodeMessage)" symbol="CLR_ALC_RESOLVING_HANDLER_INVOKED_OPCODE" value="12"/>
                             <opcode name="AppDomainAssemblyResolveHandlerInvoked" message="$(string.RuntimePublisher.AppDomainAssemblyResolveHandlerInvokedOpcodeMessage)" symbol="CLR_APPDOMAIN_ASSEMBLY_RESOLVE_HANDLER_INVOKED_OPCODE" value="13"/>
                         </opcodes>
                     </task>
@@ -1707,7 +1707,7 @@
                         </UserData>
                     </template>
 
-                    <template tid="ALCResolvingHandlerInvoked">
+                    <template tid="AssemblyLoadContextResolvingHandlerInvoked">
                         <data name="ClrInstanceID" inType="win:UInt16" />
                         <data name="AssemblyName" inType="win:UnicodeString" />
                         <data name="HandlerName" inType="win:UnicodeString" />
@@ -1715,14 +1715,14 @@
                         <data name="ResultAssemblyName" inType="win:UnicodeString" />
                         <data name="ResultAssemblyPath" inType="win:UnicodeString" />
                         <UserData>
-                            <ALCResolvingHandlerInvoked xmlns="myNs">
+                            <AssemblyLoadContextResolvingHandlerInvoked xmlns="myNs">
                                 <ClrInstanceID> %1 </ClrInstanceID>
                                 <AssemblyName> %2 </AssemblyName>
                                 <HandlerName> %3 </HandlerName>
                                 <AssemblyLoadContext> %4 </AssemblyLoadContext>
                                 <ResultAssemblyName> %5 </ResultAssemblyName>
                                 <ResultAssemblyPath> %6 </ResultAssemblyPath>
-                            </ALCResolvingHandlerInvoked>
+                            </AssemblyLoadContextResolvingHandlerInvoked>
                         </UserData>
                     </template>
 
@@ -3540,10 +3540,10 @@
                            task="AssemblyLoader"
                            symbol="AssemblyLoadStop" message="$(string.RuntimePublisher.AssemblyLoadStopEventMessage)"/>
 
-                    <event value="293" version="0" level="win:Informational"  template="ALCResolvingHandlerInvoked"
-                           keywords ="AssemblyLoaderKeyword" opcode="ALCResolvingHandlerInvoked"
+                    <event value="293" version="0" level="win:Informational"  template="AssemblyLoadContextResolvingHandlerInvoked"
+                           keywords ="AssemblyLoaderKeyword" opcode="AssemblyLoadContextResolvingHandlerInvoked"
                            task="AssemblyLoader"
-                           symbol="ALCResolvingHandlerInvoked" message="$(string.RuntimePublisher.ALCResolvingHandlerInvokedEventMessage)"/>
+                           symbol="AssemblyLoadContextResolvingHandlerInvoked" message="$(string.RuntimePublisher.AssemblyLoadContextResolvingHandlerInvokedEventMessage)"/>
 
                     <event value="294" version="0" level="win:Informational"  template="AppDomainAssemblyResolveHandlerInvoked"
                            keywords ="AssemblyLoaderKeyword" opcode="AppDomainAssemblyResolveHandlerInvoked"
@@ -6747,7 +6747,7 @@
                 <string id="RuntimePublisher.AppDomainUnload_V1EventMessage" value="AppDomainID=%1;%nAppDomainFlags=%2;%nAppDomainName=%3;%nAppDomainIndex=%4;%nClrInstanceID=%5" />
                 <string id="RuntimePublisher.AssemblyLoadStartEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nAssemblyPath=%3;%nRequestingAssembly=%4;%nAssemblyLoadContext=%5;%nRequestingAssemblyLoadContext=%6" />
                 <string id="RuntimePublisher.AssemblyLoadStopEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nAssemblyPath=%3;%nRequestingAssembly=%4;%nAssemblyLoadContext=%5;%nRequestingAssemblyLoadContext=%6;%nSuccess=%7;%nResultAssemblyName=%8;%nResultAssemblyPath=%9;%nCached=%10" />
-                <string id="RuntimePublisher.ALCResolvingHandlerInvokedEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nHandlerName=%3;%nAssemblyLoadContext=%4;%nResultAssemblyName=%5;%nResultAssemblyPath=%6" />
+                <string id="RuntimePublisher.AssemblyLoadContextResolvingHandlerInvokedEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nHandlerName=%3;%nAssemblyLoadContext=%4;%nResultAssemblyName=%5;%nResultAssemblyPath=%6" />
                 <string id="RuntimePublisher.AppDomainAssemblyResolveHandlerInvokedEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nHandlerName=%3;%nResultAssemblyName=%4;%nResultAssemblyPath=%5" />
                 <string id="RuntimePublisher.StackEventMessage" value="ClrInstanceID=%1;%nReserved1=%2;%nReserved2=%3;%nFrameCount=%4;%nStack=%5" />
                 <string id="RuntimePublisher.AppDomainMemAllocatedEventMessage" value="AppDomainID=%1;%nAllocated=%2;%nClrInstanceID=%3" />
@@ -7377,7 +7377,7 @@
                 <string id="RuntimePublisher.TieredCompilationPauseOpcodeMessage" value="Pause" />
                 <string id="RuntimePublisher.TieredCompilationResumeOpcodeMessage" value="Resume" />
 
-                <string id="RuntimePublisher.ALCResolvingHandlerInvokedOpcodeMessage" value="ALCResolvingHandlerInvoked" />
+                <string id="RuntimePublisher.AssemblyLoadContextResolvingHandlerInvokedOpcodeMessage" value="AssemblyLoadContextResolvingHandlerInvoked" />
                 <string id="RuntimePublisher.AppDomainAssemblyResolveHandlerInvokedOpcodeMessage" value="AppDomainAssemblyResolveHandlerInvoked" />
 
                 <string id="RundownPublisher.MethodDCStartOpcodeMessage" value="DCStart" />

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -395,6 +395,7 @@
                           message="$(string.RuntimePublisher.AssemblyLoaderTaskMessage)">
                         <opcodes>
                             <opcode name="ALCResolvingHandlerInvoked" message="$(string.RuntimePublisher.ALCResolvingHandlerInvokedOpcodeMessage)" symbol="CLR_ALC_RESOLVING_HANDLER_INVOKED_OPCODE" value="12"/>
+                            <opcode name="AppDomainAssemblyResolveHandlerInvoked" message="$(string.RuntimePublisher.AppDomainAssemblyResolveHandlerInvokedOpcodeMessage)" symbol="CLR_APPDOMAIN_ASSEMBLY_RESOLVE_HANDLER_INVOKED_OPCODE" value="13"/>
                         </opcodes>
                     </task>
                 <!--Next available ID is 33-->
@@ -1722,6 +1723,23 @@
                                 <ResultAssemblyName> %5 </ResultAssemblyName>
                                 <ResultAssemblyPath> %6 </ResultAssemblyPath>
                             </ALCResolvingHandlerInvoked>
+                        </UserData>
+                    </template>
+
+                    <template tid="AppDomainAssemblyResolveHandlerInvoked">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="AssemblyName" inType="win:UnicodeString" />
+                        <data name="HandlerName" inType="win:UnicodeString" />
+                        <data name="ResultAssemblyName" inType="win:UnicodeString" />
+                        <data name="ResultAssemblyPath" inType="win:UnicodeString" />
+                        <UserData>
+                            <AppDomainAssemblyResolveHandlerInvoked xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <AssemblyName> %2 </AssemblyName>
+                                <HandlerName> %3 </HandlerName>
+                                <ResultAssemblyName> %4 </ResultAssemblyName>
+                                <ResultAssemblyPath> %5 </ResultAssemblyPath>
+                            </AppDomainAssemblyResolveHandlerInvoked>
                         </UserData>
                     </template>
 
@@ -3526,6 +3544,11 @@
                            keywords ="AssemblyLoaderKeyword" opcode="ALCResolvingHandlerInvoked"
                            task="AssemblyLoader"
                            symbol="ALCResolvingHandlerInvoked" message="$(string.RuntimePublisher.ALCResolvingHandlerInvokedEventMessage)"/>
+
+                    <event value="294" version="0" level="win:Informational"  template="AppDomainAssemblyResolveHandlerInvoked"
+                           keywords ="AssemblyLoaderKeyword" opcode="AppDomainAssemblyResolveHandlerInvoked"
+                           task="AssemblyLoader"
+                           symbol="AppDomainAssemblyResolveHandlerInvoked" message="$(string.RuntimePublisher.AppDomainAssemblyResolveHandlerInvokedEventMessage)"/>
 
                 </events>
             </provider>
@@ -6725,6 +6748,7 @@
                 <string id="RuntimePublisher.AssemblyLoadStartEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nAssemblyPath=%3;%nRequestingAssembly=%4;%nAssemblyLoadContext=%5;%nRequestingAssemblyLoadContext=%6" />
                 <string id="RuntimePublisher.AssemblyLoadStopEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nAssemblyPath=%3;%nRequestingAssembly=%4;%nAssemblyLoadContext=%5;%nRequestingAssemblyLoadContext=%6;%nSuccess=%7;%nResultAssemblyName=%8;%nResultAssemblyPath=%9;%nCached=%10" />
                 <string id="RuntimePublisher.ALCResolvingHandlerInvokedEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nHandlerName=%3;%nAssemblyLoadContext=%4;%nResultAssemblyName=%5;%nResultAssemblyPath=%6" />
+                <string id="RuntimePublisher.AppDomainAssemblyResolveHandlerInvokedEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nHandlerName=%3;%nResultAssemblyName=%4;%nResultAssemblyPath=%5" />
                 <string id="RuntimePublisher.StackEventMessage" value="ClrInstanceID=%1;%nReserved1=%2;%nReserved2=%3;%nFrameCount=%4;%nStack=%5" />
                 <string id="RuntimePublisher.AppDomainMemAllocatedEventMessage" value="AppDomainID=%1;%nAllocated=%2;%nClrInstanceID=%3" />
                 <string id="RuntimePublisher.AppDomainMemSurvivedEventMessage" value="AppDomainID=%1;%nSurvived=%2;%nProcessSurvived=%3;%nClrInstanceID=%4" />
@@ -7354,6 +7378,7 @@
                 <string id="RuntimePublisher.TieredCompilationResumeOpcodeMessage" value="Resume" />
 
                 <string id="RuntimePublisher.ALCResolvingHandlerInvokedOpcodeMessage" value="ALCResolvingHandlerInvoked" />
+                <string id="RuntimePublisher.AppDomainAssemblyResolveHandlerInvokedOpcodeMessage" value="AppDomainAssemblyResolveHandlerInvoked" />
 
                 <string id="RundownPublisher.MethodDCStartOpcodeMessage" value="DCStart" />
                 <string id="RundownPublisher.MethodDCEndOpcodeMessage" value="DCStop" />

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -1436,7 +1436,7 @@ void QCALLTYPE AssemblyNative::TraceResolvingHandlerInvoked(LPCWSTR assemblyName
 
     BEGIN_QCALL;
 
-    FireEtwALCResolvingHandlerInvoked(GetClrInstanceId(), assemblyName, handlerName, alcName, resultAssemblyName, resultAssemblyPath);
+    FireEtwAssemblyLoadContextResolvingHandlerInvoked(GetClrInstanceId(), assemblyName, handlerName, alcName, resultAssemblyName, resultAssemblyPath);
 
     END_QCALL;
 }

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -1440,3 +1440,15 @@ void QCALLTYPE AssemblyNative::TraceResolvingHandlerInvoked(LPCWSTR assemblyName
 
     END_QCALL;
 }
+
+// static
+void QCALLTYPE AssemblyNative::TraceAssemblyResolveHandlerInvoked(LPCWSTR assemblyName, LPCWSTR handlerName, LPCWSTR resultAssemblyName, LPCWSTR resultAssemblyPath)
+{
+    QCALL_CONTRACT;
+
+    BEGIN_QCALL;
+
+    FireEtwAppDomainAssemblyResolveHandlerInvoked(GetClrInstanceId(), assemblyName, handlerName, resultAssemblyName, resultAssemblyPath);
+
+    END_QCALL;
+}

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -1428,3 +1428,15 @@ FCIMPL0(FC_BOOL_RET, AssemblyNative::IsTracingEnabled)
     FC_RETURN_BOOL(BinderTracing::IsEnabled());
 }
 FCIMPLEND
+
+// static
+void QCALLTYPE AssemblyNative::TraceResolvingHandlerInvoked(LPCWSTR assemblyName, LPCWSTR handlerName, LPCWSTR alcName, LPCWSTR resultAssemblyName, LPCWSTR resultAssemblyPath)
+{
+    QCALL_CONTRACT;
+
+    BEGIN_QCALL;
+
+    FireEtwALCResolvingHandlerInvoked(GetClrInstanceId(), assemblyName, handlerName, alcName, resultAssemblyName, resultAssemblyPath);
+
+    END_QCALL;
+}

--- a/src/vm/assemblynative.hpp
+++ b/src/vm/assemblynative.hpp
@@ -133,6 +133,7 @@ public:
     static INT_PTR QCALLTYPE GetLoadContextForAssembly(QCall::AssemblyHandle pAssembly);
 
     static BOOL QCALLTYPE InternalTryGetRawMetadata(QCall::AssemblyHandle assembly, UINT8 **blobRef, INT32 *lengthRef);
+    static void QCALLTYPE TraceResolvingHandlerInvoked(LPCWSTR assemblyName, LPCWSTR handlerName, LPCWSTR alcName, LPCWSTR resultAssemblyName, LPCWSTR resultAssemblyPath);
 };
 
 #endif

--- a/src/vm/assemblynative.hpp
+++ b/src/vm/assemblynative.hpp
@@ -134,6 +134,7 @@ public:
 
     static BOOL QCALLTYPE InternalTryGetRawMetadata(QCall::AssemblyHandle assembly, UINT8 **blobRef, INT32 *lengthRef);
     static void QCALLTYPE TraceResolvingHandlerInvoked(LPCWSTR assemblyName, LPCWSTR handlerName, LPCWSTR alcName, LPCWSTR resultAssemblyName, LPCWSTR resultAssemblyPath);
+    static void QCALLTYPE TraceAssemblyResolveHandlerInvoked(LPCWSTR assemblyName, LPCWSTR handlerName, LPCWSTR resultAssemblyName, LPCWSTR resultAssemblyPath);
 };
 
 #endif

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -515,6 +515,7 @@ FCFuncStart(gAssemblyLoadContextFuncs)
     QCFuncElement("InternalStartProfile",   MultiCoreJITNative::InternalStartProfile)
 #endif // defined(FEATURE_MULTICOREJIT)
     FCFuncElement("IsTracingEnabled", AssemblyNative::IsTracingEnabled)
+    QCFuncElement("TraceResolvingHandlerInvoked", AssemblyNative::TraceResolvingHandlerInvoked)
 FCFuncEnd()
 
 FCFuncStart(gAssemblyNameFuncs)

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -516,6 +516,7 @@ FCFuncStart(gAssemblyLoadContextFuncs)
 #endif // defined(FEATURE_MULTICOREJIT)
     FCFuncElement("IsTracingEnabled", AssemblyNative::IsTracingEnabled)
     QCFuncElement("TraceResolvingHandlerInvoked", AssemblyNative::TraceResolvingHandlerInvoked)
+    QCFuncElement("TraceAssemblyResolveHandlerInvoked", AssemblyNative::TraceAssemblyResolveHandlerInvoked)
 FCFuncEnd()
 
 FCFuncStart(gAssemblyNameFuncs)

--- a/tests/src/Loader/binding/tracing/AssemblyToLoad.csproj
+++ b/tests/src/Loader/binding/tracing/AssemblyToLoad.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <CLRTestKind>BuildOnly</CLRTestKind>
+    <AssemblyName Condition="'$(AssemblyNameSuffix)'!=''">$(AssemblyName)_$(AssemblyNameSuffix)</AssemblyName>
+    <CleanFile>$(AssemblyName).FileListAbsolute.txt</CleanFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyToLoad.cs" />

--- a/tests/src/Loader/binding/tracing/BinderEventListener.cs
+++ b/tests/src/Loader/binding/tracing/BinderEventListener.cs
@@ -134,21 +134,7 @@ namespace BinderTracingTests
             {
                 case "AssemblyLoadStart":
                 {
-                    var bindOperation = new BindOperation()
-                    {
-                        AssemblyName = new AssemblyName(GetDataString("AssemblyName")),
-                        AssemblyPath = GetDataString("AssemblyPath"),
-                        AssemblyLoadContext = GetDataString("AssemblyLoadContext"),
-                        RequestingAssemblyLoadContext = GetDataString("RequestingAssemblyLoadContext"),
-                        ActivityId = data.ActivityId,
-                        ParentActivityId = data.RelatedActivityId,
-                    };
-                    string requestingAssembly = GetDataString("RequestingAssembly");
-                    if (!string.IsNullOrEmpty(requestingAssembly))
-                    {
-                        bindOperation.RequestingAssembly = new AssemblyName(requestingAssembly);
-                    }
-
+                    BindOperation bindOperation = ParseAssemblyLoadStartEvent(data, GetDataString);
                     lock (eventsLock)
                     {
                         Assert.IsTrue(!bindOperations.ContainsKey(data.ActivityId), "AssemblyLoadStart should not exist for same activity ID ");
@@ -202,6 +188,26 @@ namespace BinderTracingTests
                     break;
                 }
             }
+        }
+
+        private BindOperation ParseAssemblyLoadStartEvent(EventWrittenEventArgs data, Func<string, string> getDataString)
+        {
+            var bindOperation = new BindOperation()
+            {
+                AssemblyName = new AssemblyName(getDataString("AssemblyName")),
+                AssemblyPath = getDataString("AssemblyPath"),
+                AssemblyLoadContext = getDataString("AssemblyLoadContext"),
+                RequestingAssemblyLoadContext = getDataString("RequestingAssemblyLoadContext"),
+                ActivityId = data.ActivityId,
+                ParentActivityId = data.RelatedActivityId,
+            };
+            string requestingAssembly = getDataString("RequestingAssembly");
+            if (!string.IsNullOrEmpty(requestingAssembly))
+            {
+                bindOperation.RequestingAssembly = new AssemblyName(requestingAssembly);
+            }
+
+            return bindOperation;
         }
 
         private HandlerInvocation ParseHandlerInvokedEvent(Func<string, string> getDataString)

--- a/tests/src/Loader/binding/tracing/BinderEventListener.cs
+++ b/tests/src/Loader/binding/tracing/BinderEventListener.cs
@@ -15,37 +15,53 @@ namespace BinderTracingTests
 {
     internal class BindOperation
     {
-        internal AssemblyName AssemblyName;
-        internal string AssemblyPath;
-        internal AssemblyName RequestingAssembly;
-        internal string AssemblyLoadContext;
-        internal string RequestingAssemblyLoadContext;
+        public AssemblyName AssemblyName { get; internal set; }
+        public string AssemblyPath { get; internal set; }
+        public AssemblyName RequestingAssembly { get; internal set; }
+        public string AssemblyLoadContext { get; internal set; }
+        public string RequestingAssemblyLoadContext { get; internal set; }
 
-        internal bool Success;
-        internal AssemblyName ResultAssemblyName;
-        internal string ResultAssemblyPath;
-        internal bool Cached;
+        public bool Success { get; internal set; }
+        public AssemblyName ResultAssemblyName { get; internal set; }
+        public string ResultAssemblyPath { get; internal set; }
+        public bool Cached { get; internal set; }
 
-        internal Guid ActivityId;
-        internal Guid ParentActivityId;
+        public Guid ActivityId { get; internal set; }
+        public Guid ParentActivityId { get; internal set; }
 
-        internal bool Completed;
-        internal bool Nested;
+        public bool Completed { get; internal set; }
+        public bool Nested { get; internal set; }
 
-        internal List<HandlerInvocation> ALCResolvingHandlers = new List<HandlerInvocation>();
-        internal List<HandlerInvocation> AppDomainAssemblyResolveHandlers = new List<HandlerInvocation>();
+        public List<HandlerInvocation> ALCResolvingHandlers { get; internal set; }
+        public List<HandlerInvocation> AppDomainAssemblyResolveHandlers { get; internal set; }
 
-        internal List<BindOperation> NestedBinds = new List<BindOperation>();
+        public List<BindOperation> NestedBinds { get; internal set; }
+
+        public BindOperation()
+        {
+            ALCResolvingHandlers = new List<HandlerInvocation>();
+            AppDomainAssemblyResolveHandlers = new List<HandlerInvocation>();
+            NestedBinds = new List<BindOperation>();
+        }
+
+        public override string ToString()
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.Append(AssemblyName);
+            sb.Append($" - Request: Path={AssemblyPath}, ALC={AssemblyLoadContext}, RequestingAssembly={RequestingAssembly}, RequestingALC={RequestingAssemblyLoadContext}");
+            sb.Append($" - Result: Success={Success}, Name={ResultAssemblyName}, Path={ResultAssemblyPath}, Cached={Cached}");
+            return sb.ToString();
+        }
     }
 
     internal class HandlerInvocation
     {
-        internal AssemblyName AssemblyName;
-        internal string HandlerName;
-        internal string AssemblyLoadContext;
+        public AssemblyName AssemblyName { get; internal set; }
+        public string HandlerName { get; internal set; }
+        public string AssemblyLoadContext { get; internal set; }
 
-        internal AssemblyName ResultAssemblyName;
-        internal string ResultAssemblyPath;
+        public AssemblyName ResultAssemblyName { get; internal set; }
+        public string ResultAssemblyPath { get; internal set; }
 
         public override string ToString()
         {

--- a/tests/src/Loader/binding/tracing/BinderEventListener.cs
+++ b/tests/src/Loader/binding/tracing/BinderEventListener.cs
@@ -32,14 +32,14 @@ namespace BinderTracingTests
         public bool Completed { get; internal set; }
         public bool Nested { get; internal set; }
 
-        public List<HandlerInvocation> ALCResolvingHandlers { get; internal set; }
+        public List<HandlerInvocation> AssemblyLoadContextResolvingHandlers { get; internal set; }
         public List<HandlerInvocation> AppDomainAssemblyResolveHandlers { get; internal set; }
 
         public List<BindOperation> NestedBinds { get; internal set; }
 
         public BindOperation()
         {
-            ALCResolvingHandlers = new List<HandlerInvocation>();
+            AssemblyLoadContextResolvingHandlers = new List<HandlerInvocation>();
             AppDomainAssemblyResolveHandlers = new List<HandlerInvocation>();
             NestedBinds = new List<BindOperation>();
         }
@@ -179,14 +179,14 @@ namespace BinderTracingTests
                     }
                     break;
                 }
-                case "ALCResolvingHandlerInvoked":
+                case "AssemblyLoadContextResolvingHandlerInvoked":
                 {
                     HandlerInvocation handlerInvocation = ParseHandlerInvokedEvent(GetDataString);
                     lock (eventsLock)
                     {
-                        Assert.IsTrue(bindOperations.ContainsKey(data.ActivityId), "ALCResolvingHandlerInvoked should have a matching AssemblyBindStart");
+                        Assert.IsTrue(bindOperations.ContainsKey(data.ActivityId), "AssemblyLoadContextResolvingHandlerInvoked should have a matching AssemblyBindStart");
                         BindOperation bind = bindOperations[data.ActivityId];
-                        bind.ALCResolvingHandlers.Add(handlerInvocation);
+                        bind.AssemblyLoadContextResolvingHandlers.Add(handlerInvocation);
                     }
                     break;
                 }

--- a/tests/src/Loader/binding/tracing/BinderTracingTest.EventHandlers.cs
+++ b/tests/src/Loader/binding/tracing/BinderTracingTest.EventHandlers.cs
@@ -17,7 +17,7 @@ namespace BinderTracingTests
     partial class BinderTracingTest
     {
         [BinderTest]
-        public static BindOperation ALCResolvingEvent_ReturnNull()
+        public static BindOperation AssemblyLoadContextResolving_ReturnNull()
         {
             var assemblyName = new AssemblyName(SubdirectoryAssemblyName);
             using (var handlers = new Handlers(HandlerReturn.Null, AssemblyLoadContext.Default))
@@ -38,17 +38,17 @@ namespace BinderTracingTests
                     RequestingAssemblyLoadContext = DefaultALC,
                     Success = false,
                     Cached = false,
-                    ALCResolvingHandlers = handlers.Invocations,
+                    AssemblyLoadContextResolvingHandlers = handlers.Invocations,
                     NestedBinds = handlers.Binds
                 };
             }
         }
 
         [BinderTest]
-        public static BindOperation ALCResolvingEvent_LoadAssembly()
+        public static BindOperation AssemblyLoadContextResolving_LoadAssembly()
         {
             var assemblyName = new AssemblyName(SubdirectoryAssemblyName);
-            CustomALC alc = new CustomALC(nameof(ALCResolvingEvent_LoadAssembly));
+            CustomALC alc = new CustomALC(nameof(AssemblyLoadContextResolving_LoadAssembly));
             using (var handlers = new Handlers(HandlerReturn.RequestedAssembly, alc))
             {
                 Assembly asm = alc.LoadFromAssemblyName(assemblyName);
@@ -63,17 +63,17 @@ namespace BinderTracingTests
                     ResultAssemblyName = asm.GetName(),
                     ResultAssemblyPath = asm.Location,
                     Cached = false,
-                    ALCResolvingHandlers = handlers.Invocations,
+                    AssemblyLoadContextResolvingHandlers = handlers.Invocations,
                     NestedBinds = handlers.Binds
                 };
             }
         }
 
         [BinderTest]
-        public static BindOperation ALCResolvingEvent_NameMismatch()
+        public static BindOperation AssemblyLoadContextResolving_NameMismatch()
         {
             var assemblyName = new AssemblyName(SubdirectoryAssemblyName);
-            CustomALC alc = new CustomALC(nameof(ALCResolvingEvent_NameMismatch));
+            CustomALC alc = new CustomALC(nameof(AssemblyLoadContextResolving_NameMismatch));
             using (var handlers = new Handlers(HandlerReturn.NameMismatch, alc))
             {
                 Assert.Throws<FileLoadException>(() => alc.LoadFromAssemblyName(assemblyName));
@@ -86,17 +86,17 @@ namespace BinderTracingTests
                     AssemblyLoadContext = alc.ToString(),
                     Success = false,
                     Cached = false,
-                    ALCResolvingHandlers = handlers.Invocations,
+                    AssemblyLoadContextResolvingHandlers = handlers.Invocations,
                     NestedBinds = handlers.Binds
                 };
             }
         }
 
         [BinderTest]
-        public static BindOperation ALCResolvingEvent_MultipleHandlers()
+        public static BindOperation AssemblyLoadContextResolving_MultipleHandlers()
         {
             var assemblyName = new AssemblyName(SubdirectoryAssemblyName);
-            CustomALC alc = new CustomALC(nameof(ALCResolvingEvent_NameMismatch));
+            CustomALC alc = new CustomALC(nameof(AssemblyLoadContextResolving_NameMismatch));
             using (var handlerNull = new Handlers(HandlerReturn.Null, alc))
             using (var handlerLoad = new Handlers(HandlerReturn.RequestedAssembly, alc))
             {
@@ -114,7 +114,7 @@ namespace BinderTracingTests
                     ResultAssemblyName = asm.GetName(),
                     ResultAssemblyPath = asm.Location,
                     Cached = false,
-                    ALCResolvingHandlers = handlerNull.Invocations.Concat(handlerLoad.Invocations).ToList(),
+                    AssemblyLoadContextResolvingHandlers = handlerNull.Invocations.Concat(handlerLoad.Invocations).ToList(),
                     NestedBinds = handlerNull.Binds.Concat(handlerLoad.Binds).ToList()
                 };
             }
@@ -252,23 +252,23 @@ namespace BinderTracingTests
             {
                 this.handlerReturn = handlerReturn;
                 this.alc = alc;
-                this.alc.Resolving += OnALCResolving;
+                this.alc.Resolving += OnAssemblyLoadContextResolving;
             }
 
             public void Dispose()
             {
                 AppDomain.CurrentDomain.AssemblyResolve -= OnAppDomainAssemblyResolve;
                 if (alc != null)
-                    alc.Resolving -= OnALCResolving;
+                    alc.Resolving -= OnAssemblyLoadContextResolving;
             }
 
-            private Assembly OnALCResolving(AssemblyLoadContext context, AssemblyName assemblyName)
+            private Assembly OnAssemblyLoadContextResolving(AssemblyLoadContext context, AssemblyName assemblyName)
             {
                 Assembly asm = ResolveAssembly(context, assemblyName);
                 var invocation = new HandlerInvocation()
                 {
                     AssemblyName = assemblyName,
-                    HandlerName = nameof(OnALCResolving),
+                    HandlerName = nameof(OnAssemblyLoadContextResolving),
                     AssemblyLoadContext = context == AssemblyLoadContext.Default ? context.Name : context.ToString(),
                 };
                 if (asm != null)

--- a/tests/src/Loader/binding/tracing/BinderTracingTest.EventHandlers.cs
+++ b/tests/src/Loader/binding/tracing/BinderTracingTest.EventHandlers.cs
@@ -29,6 +29,7 @@ namespace BinderTracingTests
                 catch { }
 
                 Assert.AreEqual(1, handlers.Invocations.Count);
+                Assert.AreEqual(0, handlers.Binds.Count);
                 return new BindOperation()
                 {
                     AssemblyName = assemblyName,
@@ -37,7 +38,8 @@ namespace BinderTracingTests
                     RequestingAssemblyLoadContext = DefaultALC,
                     Success = false,
                     Cached = false,
-                    ALCResolvingHandlers = handlers.Invocations
+                    ALCResolvingHandlers = handlers.Invocations,
+                    NestedBinds = handlers.Binds
                 };
             }
         }
@@ -52,6 +54,7 @@ namespace BinderTracingTests
                 Assembly asm = alc.LoadFromAssemblyName(assemblyName);
 
                 Assert.AreEqual(1, handlers.Invocations.Count);
+                Assert.AreEqual(1, handlers.Binds.Count);
                 return new BindOperation()
                 {
                     AssemblyName = assemblyName,
@@ -60,7 +63,8 @@ namespace BinderTracingTests
                     ResultAssemblyName = asm.GetName(),
                     ResultAssemblyPath = asm.Location,
                     Cached = false,
-                    ALCResolvingHandlers = handlers.Invocations
+                    ALCResolvingHandlers = handlers.Invocations,
+                    NestedBinds = handlers.Binds
                 };
             }
         }
@@ -75,13 +79,15 @@ namespace BinderTracingTests
                 Assert.Throws<FileLoadException>(() => alc.LoadFromAssemblyName(assemblyName));
 
                 Assert.AreEqual(1, handlers.Invocations.Count);
+                Assert.AreEqual(1, handlers.Binds.Count);
                 return new BindOperation()
                 {
                     AssemblyName = assemblyName,
                     AssemblyLoadContext = alc.ToString(),
                     Success = false,
                     Cached = false,
-                    ALCResolvingHandlers = handlers.Invocations
+                    ALCResolvingHandlers = handlers.Invocations,
+                    NestedBinds = handlers.Binds
                 };
             }
         }
@@ -97,7 +103,9 @@ namespace BinderTracingTests
                 Assembly asm = alc.LoadFromAssemblyName(assemblyName);
 
                 Assert.AreEqual(1, handlerNull.Invocations.Count);
+                Assert.AreEqual(0, handlerNull.Binds.Count);
                 Assert.AreEqual(1, handlerLoad.Invocations.Count);
+                Assert.AreEqual(1, handlerLoad.Binds.Count);
                 return new BindOperation()
                 {
                     AssemblyName = assemblyName,
@@ -106,7 +114,8 @@ namespace BinderTracingTests
                     ResultAssemblyName = asm.GetName(),
                     ResultAssemblyPath = asm.Location,
                     Cached = false,
-                    ALCResolvingHandlers = handlerNull.Invocations.Concat(handlerLoad.Invocations).ToList()
+                    ALCResolvingHandlers = handlerNull.Invocations.Concat(handlerLoad.Invocations).ToList(),
+                    NestedBinds = handlerNull.Binds.Concat(handlerLoad.Binds).ToList()
                 };
             }
         }
@@ -124,6 +133,7 @@ namespace BinderTracingTests
                 catch { }
 
                 Assert.AreEqual(1, handlers.Invocations.Count);
+                Assert.AreEqual(0, handlers.Binds.Count);
                 return new BindOperation()
                 {
                     AssemblyName = assemblyName,
@@ -132,7 +142,8 @@ namespace BinderTracingTests
                     RequestingAssemblyLoadContext = DefaultALC,
                     Success = false,
                     Cached = false,
-                    AppDomainAssemblyResolveHandlers = handlers.Invocations
+                    AppDomainAssemblyResolveHandlers = handlers.Invocations,
+                    NestedBinds = handlers.Binds
                 };
             }
         }
@@ -147,6 +158,7 @@ namespace BinderTracingTests
                 Assembly asm = alc.LoadFromAssemblyName(assemblyName);
 
                 Assert.AreEqual(1, handlers.Invocations.Count);
+                Assert.AreEqual(1, handlers.Binds.Count);
                 return new BindOperation()
                 {
                     AssemblyName = assemblyName,
@@ -155,7 +167,8 @@ namespace BinderTracingTests
                     ResultAssemblyName = asm.GetName(),
                     ResultAssemblyPath = asm.Location,
                     Cached = false,
-                    AppDomainAssemblyResolveHandlers = handlers.Invocations
+                    AppDomainAssemblyResolveHandlers = handlers.Invocations,
+                    NestedBinds = handlers.Binds
                 };
             }
         }
@@ -171,6 +184,7 @@ namespace BinderTracingTests
                 Assembly asm = alc.LoadFromAssemblyName(assemblyName);
 
                 Assert.AreEqual(1, handlers.Invocations.Count);
+                Assert.AreEqual(1, handlers.Binds.Count);
                 return new BindOperation()
                 {
                     AssemblyName = assemblyName,
@@ -179,7 +193,8 @@ namespace BinderTracingTests
                     ResultAssemblyName = asm.GetName(),
                     ResultAssemblyPath = asm.Location,
                     Cached = false,
-                    AppDomainAssemblyResolveHandlers = handlers.Invocations
+                    AppDomainAssemblyResolveHandlers = handlers.Invocations,
+                    NestedBinds = handlers.Binds
                 };
             }
         }
@@ -195,7 +210,9 @@ namespace BinderTracingTests
                 Assembly asm = alc.LoadFromAssemblyName(assemblyName);
 
                 Assert.AreEqual(1, handlerNull.Invocations.Count);
+                Assert.AreEqual(0, handlerNull.Binds.Count);
                 Assert.AreEqual(1, handlerLoad.Invocations.Count);
+                Assert.AreEqual(1, handlerLoad.Binds.Count);
                 return new BindOperation()
                 {
                     AssemblyName = assemblyName,
@@ -204,7 +221,8 @@ namespace BinderTracingTests
                     ResultAssemblyName = asm.GetName(),
                     ResultAssemblyPath = asm.Location,
                     Cached = false,
-                    AppDomainAssemblyResolveHandlers = handlerNull.Invocations.Concat(handlerLoad.Invocations).ToList()
+                    AppDomainAssemblyResolveHandlers = handlerNull.Invocations.Concat(handlerLoad.Invocations).ToList(),
+                    NestedBinds = handlerNull.Binds.Concat(handlerLoad.Binds).ToList()
                 };
             }
         }
@@ -222,6 +240,7 @@ namespace BinderTracingTests
             private AssemblyLoadContext alc;
 
             internal readonly List<HandlerInvocation> Invocations = new List<HandlerInvocation>();
+            internal readonly List<BindOperation> Binds = new List<BindOperation>();
 
             public Handlers(HandlerReturn handlerReturn)
             {
@@ -250,7 +269,7 @@ namespace BinderTracingTests
                 {
                     AssemblyName = assemblyName,
                     HandlerName = nameof(OnALCResolving),
-                    AssemblyLoadContext = context == AssemblyLoadContext.Default ? "Default" : context.ToString(),
+                    AssemblyLoadContext = context == AssemblyLoadContext.Default ? context.Name : context.ToString(),
                 };
                 if (asm != null)
                 {
@@ -290,9 +309,25 @@ namespace BinderTracingTests
                 string appPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
                 string fileName = handlerReturn == HandlerReturn.RequestedAssembly ? $"{assemblyName.Name}.dll" : $"{assemblyName.Name}Mismatch.dll";
                 string assemblyPath = Path.Combine(appPath, "DependentAssemblies", fileName);
-                return File.Exists(assemblyPath)
-                    ? context.LoadFromAssemblyPath(assemblyPath)
-                    : null;
+
+                if (!File.Exists(assemblyPath))
+                    return null;
+
+                Assembly asm = context.LoadFromAssemblyPath(assemblyPath);
+                var bind = new BindOperation()
+                {
+                    AssemblyName = asm.GetName(),
+                    AssemblyPath = assemblyPath,
+                    AssemblyLoadContext = context == AssemblyLoadContext.Default ? context.Name : context.ToString(),
+                    RequestingAssembly = CoreLibName,
+                    RequestingAssemblyLoadContext = DefaultALC,
+                    Success = true,
+                    ResultAssemblyName = asm.GetName(),
+                    ResultAssemblyPath = asm.Location,
+                    Cached = false
+                };
+                Binds.Add(bind);
+                return asm;
             }
         }
     }

--- a/tests/src/Loader/binding/tracing/BinderTracingTest.EventHandlers.cs
+++ b/tests/src/Loader/binding/tracing/BinderTracingTest.EventHandlers.cs
@@ -1,0 +1,170 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+
+using TestLibrary;
+
+namespace BinderTracingTests
+{
+    partial class BinderTracingTest
+    {
+        [BinderTest]
+        public static BindOperation ALCResolvingEvent_ReturnNull()
+        {
+            var assemblyName = new AssemblyName(SubdirectoryAssemblyName);
+            using (var handlers = new Handlers(HandlerReturn.Null, AssemblyLoadContext.Default))
+            {
+                try
+                {
+                    Assembly.Load(assemblyName);
+                }
+                catch { }
+
+                Assert.AreEqual(1, handlers.Invocations.Count);
+                return new BindOperation()
+                {
+                    AssemblyName = assemblyName,
+                    AssemblyLoadContext = DefaultALC,
+                    RequestingAssembly = Assembly.GetExecutingAssembly().GetName(),
+                    RequestingAssemblyLoadContext = DefaultALC,
+                    Success = false,
+                    Cached = false,
+                    ALCResolvingHandlers = handlers.Invocations
+                };
+            }
+        }
+
+        [BinderTest]
+        public static BindOperation ALCResolvingEvent_LoadAssembly()
+        {
+            var assemblyName = new AssemblyName(SubdirectoryAssemblyName);
+            CustomALC alc = new CustomALC(nameof(ALCResolvingEvent_LoadAssembly));
+            using (var handlers = new Handlers(HandlerReturn.RequestedAssembly, alc))
+            {
+                Assembly asm = alc.LoadFromAssemblyName(assemblyName);
+
+                Assert.AreEqual(1, handlers.Invocations.Count);
+                return new BindOperation()
+                {
+                    AssemblyName = assemblyName,
+                    AssemblyLoadContext = alc.ToString(),
+                    Success = true,
+                    ResultAssemblyName = asm.GetName(),
+                    ResultAssemblyPath = asm.Location,
+                    Cached = false,
+                    ALCResolvingHandlers = handlers.Invocations
+                };
+            }
+        }
+
+        [BinderTest]
+        public static BindOperation ALCResolvingEvent_NameMismatch()
+        {
+            var assemblyName = new AssemblyName(SubdirectoryAssemblyName);
+            CustomALC alc = new CustomALC(nameof(ALCResolvingEvent_NameMismatch));
+            using (var handlers = new Handlers(HandlerReturn.MismatchAssembly, alc))
+            {
+                Assert.Throws<FileLoadException>(() => alc.LoadFromAssemblyName(assemblyName));
+
+                Assert.AreEqual(1, handlers.Invocations.Count);
+                return new BindOperation()
+                {
+                    AssemblyName = assemblyName,
+                    AssemblyLoadContext = alc.ToString(),
+                    Success = false,
+                    Cached = false,
+                    ALCResolvingHandlers = handlers.Invocations
+                };
+            }
+        }
+
+        [BinderTest]
+        public static BindOperation ALCResolvingEvent_MultipleHandlers()
+        {
+            var assemblyName = new AssemblyName(SubdirectoryAssemblyName);
+            CustomALC alc = new CustomALC(nameof(ALCResolvingEvent_NameMismatch));
+            using (var handlerNull = new Handlers(HandlerReturn.Null, alc))
+            using (var handlerLoad = new Handlers(HandlerReturn.RequestedAssembly, alc))
+            {
+                Assembly asm = alc.LoadFromAssemblyName(assemblyName);
+
+                Assert.AreEqual(1, handlerNull.Invocations.Count);
+                Assert.AreEqual(1, handlerLoad.Invocations.Count);
+                return new BindOperation()
+                {
+                    AssemblyName = assemblyName,
+                    AssemblyLoadContext = alc.ToString(),
+                    Success = true,
+                    ResultAssemblyName = asm.GetName(),
+                    ResultAssemblyPath = asm.Location,
+                    Cached = false,
+                    ALCResolvingHandlers = handlerNull.Invocations.Concat(handlerLoad.Invocations).ToList()
+                };
+            }
+        }
+
+        private enum HandlerReturn
+        {
+            Null,
+            RequestedAssembly,
+            MismatchAssembly
+        }
+
+        private class Handlers : IDisposable
+        {
+            private HandlerReturn handlerReturn;
+            private AssemblyLoadContext alc;
+
+            internal readonly List<HandlerInvocation> Invocations = new List<HandlerInvocation>();
+
+            public Handlers(HandlerReturn handlerReturn, AssemblyLoadContext alc)
+            {
+                this.handlerReturn = handlerReturn;
+                this.alc = alc;
+                this.alc.Resolving += OnALCResolving;
+            }
+
+            public void Dispose()
+            {
+                this.alc.Resolving -= OnALCResolving;
+            }
+
+            private Assembly OnALCResolving(AssemblyLoadContext context, AssemblyName assemblyName)
+            {
+                Assembly asm = null;
+                if (handlerReturn != HandlerReturn.Null)
+                {
+                    string appPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                    string fileName = handlerReturn == HandlerReturn.RequestedAssembly ? $"{assemblyName.Name}.dll" : $"{assemblyName.Name}Mismatch.dll";
+                    string assemblyPath = Path.Combine(appPath, "DependentAssemblies", fileName);
+                    asm = File.Exists(assemblyPath)
+                        ? context.LoadFromAssemblyPath(assemblyPath)
+                        : null;
+                }
+
+                var invocation = new HandlerInvocation()
+                {
+                    AssemblyName = assemblyName,
+                    HandlerName = nameof(OnALCResolving),
+                    AssemblyLoadContext = context == AssemblyLoadContext.Default ? "Default" : context.ToString(),
+                };
+                if (asm != null)
+                {
+                    invocation.ResultAssemblyName = asm.GetName();
+                    invocation.ResultAssemblyPath = asm.Location;
+                }
+
+                Invocations.Add(invocation);
+                return asm;
+            }
+        }
+    }
+}

--- a/tests/src/Loader/binding/tracing/BinderTracingTest.cs
+++ b/tests/src/Loader/binding/tracing/BinderTracingTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -25,7 +26,7 @@ namespace BinderTracingTests
         }
     }
 
-    class BinderTracingTest
+    partial class BinderTracingTest
     {
         public class CustomALC : AssemblyLoadContext
         {
@@ -35,6 +36,9 @@ namespace BinderTracingTests
 
         private const string DefaultALC = "Default";
         private const string DependentAssemblyName = "AssemblyToLoad";
+        private const string SubdirectoryAssemblyName = "AssemblyToLoad_Subdirectory";
+
+        private static readonly AssemblyName CoreLibName = typeof(object).Assembly.GetName();
 
         [BinderTest]
         public static BindOperation LoadFile()
@@ -47,6 +51,7 @@ namespace BinderTracingTests
                 AssemblyName = executingAssembly.GetName(),
                 AssemblyPath = executingAssembly.Location,
                 AssemblyLoadContext = AssemblyLoadContext.GetLoadContext(asm).ToString(),
+                RequestingAssembly = CoreLibName,
                 RequestingAssemblyLoadContext = DefaultALC,
                 Success = true,
                 ResultAssemblyName = asm.GetName(),
@@ -66,6 +71,7 @@ namespace BinderTracingTests
             {
                 AssemblyName = executingAssembly.GetName(),
                 AssemblyLoadContext = AssemblyLoadContext.GetLoadContext(asm).ToString(),
+                RequestingAssembly = CoreLibName,
                 RequestingAssemblyLoadContext = DefaultALC,
                 Success = true,
                 ResultAssemblyName = asm.GetName(),
@@ -86,6 +92,7 @@ namespace BinderTracingTests
             {
                 AssemblyName = executingAssembly.GetName(),
                 AssemblyLoadContext = alc.ToString(),
+                RequestingAssembly = CoreLibName,
                 RequestingAssemblyLoadContext = DefaultALC,
                 Success = true,
                 ResultAssemblyName = asm.GetName(),
@@ -106,6 +113,7 @@ namespace BinderTracingTests
                 AssemblyName = executingAssembly.GetName(),
                 AssemblyPath = executingAssembly.Location,
                 AssemblyLoadContext = alc.ToString(),
+                RequestingAssembly = CoreLibName,
                 RequestingAssemblyLoadContext = DefaultALC,
                 Success = true,
                 ResultAssemblyName = asm.GetName(),
@@ -143,6 +151,7 @@ namespace BinderTracingTests
                 AssemblyName = executingAssembly.GetName(),
                 AssemblyPath = executingAssembly.Location,
                 AssemblyLoadContext = DefaultALC,
+                RequestingAssembly = CoreLibName,
                 RequestingAssemblyLoadContext = DefaultALC,
                 Success = true,
                 ResultAssemblyName = asm.GetName(),
@@ -154,13 +163,14 @@ namespace BinderTracingTests
         [BinderTest(isolate: true)]
         public static BindOperation PlatformAssembly()
         {
-            string assemblyName = "System.Xml";
+            var assemblyName = new AssemblyName("System.Xml");
             Assembly asm = Assembly.Load(assemblyName);
 
             return new BindOperation()
             {
-                AssemblyName = new AssemblyName(assemblyName),
+                AssemblyName = assemblyName,
                 AssemblyLoadContext = DefaultALC,
+                RequestingAssembly = Assembly.GetExecutingAssembly().GetName(),
                 RequestingAssemblyLoadContext = DefaultALC,
                 Success = true,
                 ResultAssemblyName = asm.GetName(),
@@ -191,6 +201,7 @@ namespace BinderTracingTests
             {
                 AssemblyName = new AssemblyName(assemblyName),
                 AssemblyLoadContext = DefaultALC,
+                RequestingAssembly = Assembly.GetExecutingAssembly().GetName(),
                 RequestingAssemblyLoadContext = DefaultALC,
                 Success = false,
                 Cached = false
@@ -206,8 +217,8 @@ namespace BinderTracingTests
             {
                 AssemblyName = new AssemblyName(DependentAssemblyName),
                 AssemblyLoadContext = DefaultALC,
-                RequestingAssemblyLoadContext = DefaultALC,
                 RequestingAssembly = Assembly.GetExecutingAssembly().GetName(),
+                RequestingAssemblyLoadContext = DefaultALC,
                 Success = true,
                 ResultAssemblyName = t.Assembly.GetName(),
                 ResultAssemblyPath = t.Assembly.Location,
@@ -368,7 +379,7 @@ namespace BinderTracingTests
                     // Run specific test - first argument should be the test method name
                     MethodInfo method = typeof(BinderTracingTest)
                         .GetMethod(args[0], BindingFlags.Public | BindingFlags.Static);
-                    Assert.IsTrue(method != null && method.GetCustomAttribute<BinderTestAttribute>() != null && method.ReturnType == typeof(BindOperation));
+                    Assert.IsTrue(method != null && method.GetCustomAttribute<BinderTestAttribute>() != null && method.ReturnType == typeof(BindOperation), "Invalid test muthod specified");
                     success = RunSingleTest(method);
                 }
             }
@@ -462,29 +473,45 @@ namespace BinderTracingTests
             ValidateAssemblyName(expected.AssemblyName, actual.AssemblyName, nameof(BindOperation.AssemblyName));
             Assert.AreEqual(expected.AssemblyPath ?? string.Empty, actual.AssemblyPath, $"Unexpected value for {nameof(BindOperation.AssemblyPath)} on event");
             Assert.AreEqual(expected.AssemblyLoadContext, actual.AssemblyLoadContext, $"Unexpected value for {nameof(BindOperation.AssemblyLoadContext)} on event");
-            ValidateAssemblyName(expected.RequestingAssembly, actual.RequestingAssembly, nameof(BindOperation.RequestingAssembly));
             Assert.AreEqual(expected.RequestingAssemblyLoadContext ?? string.Empty, actual.RequestingAssemblyLoadContext, $"Unexpected value for {nameof(BindOperation.RequestingAssemblyLoadContext)} on event");
+            ValidateAssemblyName(expected.RequestingAssembly, actual.RequestingAssembly, nameof(BindOperation.RequestingAssembly));
 
             Assert.AreEqual(expected.Success, actual.Success, $"Unexpected value for {nameof(BindOperation.Success)} on event");
             Assert.AreEqual(expected.ResultAssemblyPath ?? string.Empty, actual.ResultAssemblyPath, $"Unexpected value for {nameof(BindOperation.ResultAssemblyPath)} on event");
             Assert.AreEqual(expected.Cached, actual.Cached, $"Unexpected value for {nameof(BindOperation.Cached)} on event");
             ValidateAssemblyName(expected.ResultAssemblyName, actual.ResultAssemblyName, nameof(BindOperation.ResultAssemblyName));
+
+            ValidateHandlerInvocations(expected.ALCResolvingHandlers, actual.ALCResolvingHandlers, "ALCResolving");
+        }
+
+        private static bool AssemblyNamesMatch(AssemblyName name1, AssemblyName name2)
+        {
+            if (name1 == null || name2 == null)
+                return name1 == null && name2 == null;
+
+            return name1.Name == name2.Name
+                && ((name1.Version == null && name2.Version == null) || name1.Version == name2.Version)
+                && ((string.IsNullOrEmpty(name1.CultureName) && string.IsNullOrEmpty(name1.CultureName)) || name1.CultureName == name2.CultureName);
         }
 
         private static void ValidateAssemblyName(AssemblyName expected, AssemblyName actual, string propertyName)
         {
-            if (expected == null)
-            {
-                return;
-            }
+            Assert.IsTrue(AssemblyNamesMatch(expected, actual), $"Unexpected value for {propertyName} on event - expected: {expected}, actual: {actual}");
+        }
 
-            if (expected.Version != null)
+        private static void ValidateHandlerInvocations(List<HandlerInvocation> expected, List<HandlerInvocation> actual, string eventName)
+        {
+            Assert.AreEqual(expected.Count, actual.Count, $"Unexpected handler invocation count for {eventName}");
+
+            foreach (var match in expected)
             {
-                Assert.AreEqual(expected.FullName, actual.FullName, $"Unexpected value for {propertyName} on event");
-            }
-            else
-            {
-                Assert.AreEqual(expected.Name, actual.Name, $"Unexpected value for {propertyName} on event");
+                Predicate<HandlerInvocation> pred = h =>
+                    AssemblyNamesMatch(h.AssemblyName, match.AssemblyName)
+                        && h.HandlerName == match.HandlerName
+                        && h.AssemblyLoadContext == match.AssemblyLoadContext
+                        && AssemblyNamesMatch(h.ResultAssemblyName, match.ResultAssemblyName)
+                        && h.ResultAssemblyPath == match.ResultAssemblyPath;
+                Assert.IsTrue(actual.Exists(pred), $"Handler invocation not found: {match.ToString()}");
             }
         }
     }

--- a/tests/src/Loader/binding/tracing/BinderTracingTest.cs
+++ b/tests/src/Loader/binding/tracing/BinderTracingTest.cs
@@ -486,7 +486,7 @@ namespace BinderTracingTests
             Assert.AreEqual(expected.Cached, actual.Cached, $"Unexpected value for {nameof(BindOperation.Cached)} on event");
             ValidateAssemblyName(expected.ResultAssemblyName, actual.ResultAssemblyName, nameof(BindOperation.ResultAssemblyName));
 
-            ValidateHandlerInvocations(expected.ALCResolvingHandlers, actual.ALCResolvingHandlers, "ALCResolving");
+            ValidateHandlerInvocations(expected.AssemblyLoadContextResolvingHandlers, actual.AssemblyLoadContextResolvingHandlers, "AssemblyLoadContextResolving");
             ValidateHandlerInvocations(expected.AppDomainAssemblyResolveHandlers, actual.AppDomainAssemblyResolveHandlers, "AppDomainAssemblyResolve");
 
             ValidateNestedBinds(expected.NestedBinds, actual.NestedBinds);

--- a/tests/src/Loader/binding/tracing/BinderTracingTest.cs
+++ b/tests/src/Loader/binding/tracing/BinderTracingTest.cs
@@ -482,6 +482,7 @@ namespace BinderTracingTests
             ValidateAssemblyName(expected.ResultAssemblyName, actual.ResultAssemblyName, nameof(BindOperation.ResultAssemblyName));
 
             ValidateHandlerInvocations(expected.ALCResolvingHandlers, actual.ALCResolvingHandlers, "ALCResolving");
+            ValidateHandlerInvocations(expected.AppDomainAssemblyResolveHandlers, actual.AppDomainAssemblyResolveHandlers, "AppDomainAssemblyResolve");
         }
 
         private static bool AssemblyNamesMatch(AssemblyName name1, AssemblyName name2)

--- a/tests/src/Loader/binding/tracing/BinderTracingTest.csproj
+++ b/tests/src/Loader/binding/tracing/BinderTracingTest.csproj
@@ -4,10 +4,34 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BinderTracingTest.cs" />
+    <Compile Include="BinderTracingTest.EventHandlers.cs" />
     <Compile Include="BinderEventListener.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="AssemblyToLoad.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- Build the same AssemblyToLoad project with a different assembly name. These will be moved to a subdirectory
+         by the MoveDependentAssembliesToSubdirectory target, such that they will not be on the test's app path -->
+    <ProjectReference Include="AssemblyToLoad.csproj">
+      <Properties>AssemblyNameSuffix=Subdirectory</Properties>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </ProjectReference>
+    <ProjectReference Include="AssemblyToLoad.csproj">
+      <Properties>AssemblyNameSuffix=SubdirectoryMismatch</Properties>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Target Name="MoveDependentAssembliesToSubdirectory" AfterTargets="CopyFilesToOutputDirectory">
+    <ItemGroup>
+      <AssembliesToMove Include="$(OutDir)/AssemblyToLoad_*.*" />
+    </ItemGroup>
+    <Move SourceFiles="@(AssembliesToMove)" DestinationFolder="$(OutDir)/DependentAssemblies" />
+  </Target>
 </Project>


### PR DESCRIPTION
- Add `ALCResolvingHandlerInvoked` and `AppDomainAssemblyResolveHandlerInvoked` events
- Fire after each handler is invoked
- Add tests to validate new events and nesting of events when handlers trigger another load.
- Make `BinderTracingTest.csproj` build `AssemblyToLoad.csproj` with different assembly names for use in tests