### PR TITLE
Vectorise string.Replace(char, char)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
@@ -1051,7 +1051,7 @@ namespace System
 
         // Replaces all instances of oldChar with newChar.
         //
-        public unsafe string Replace(char oldChar, char newChar)
+        public string Replace(char oldChar, char newChar)
         {
             if (oldChar == newChar)
                 return this;

--- a/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
@@ -1076,12 +1076,12 @@ namespace System
             ref ushort pSrc = ref Unsafe.Add(ref Unsafe.As<char, ushort>(ref _firstChar), copyLength);
             ref ushort pDst = ref Unsafe.Add(ref Unsafe.As<char, ushort>(ref result._firstChar), copyLength);
 
-            if (Vector.IsHardwareAccelerated)
+            if (Vector.IsHardwareAccelerated && remainingLength >= Vector<ushort>.Count)
             {
                 Vector<ushort> oldChars = new Vector<ushort>(oldChar);
                 Vector<ushort> newChars = new Vector<ushort>(newChar);
 
-                for (; (remainingLength - Vector<ushort>.Count) >= 0; remainingLength -= Vector<ushort>.Count)
+                do
                 {
                     Vector<ushort> original = Unsafe.ReadUnaligned<Vector<ushort>>(ref Unsafe.As<ushort, byte>(ref pSrc));
                     Vector<ushort> equals = Vector.Equals(original, oldChars);
@@ -1090,7 +1090,9 @@ namespace System
 
                     pSrc = ref Unsafe.Add(ref pSrc, Vector<ushort>.Count);
                     pDst = ref Unsafe.Add(ref pDst, Vector<ushort>.Count);
+                    remainingLength -= Vector<ushort>.Count;
                 }
+                while (remainingLength - Vector<ushort>.Count >= 0);
             }
 
             for (; remainingLength > 0; remainingLength--)

--- a/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
@@ -1105,19 +1105,17 @@ namespace System
                     }
                 }
 
-                do
+                for (; remainingLength > 0; remainingLength--)
                 {
                     char currentChar = *pSrc;
                     if (currentChar == oldChar)
                         currentChar = newChar;
                     *pDst = currentChar;
 
-                    remainingLength--;
                     pSrc++;
                     pDst++;
-                } while (remainingLength > 0);
+                }
             }
-
             return result;
         }
 

--- a/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
@@ -1092,12 +1092,13 @@ namespace System
                     pDst = ref Unsafe.Add(ref pDst, Vector<ushort>.Count);
                     remainingLength -= Vector<ushort>.Count;
                 }
-                while (remainingLength - Vector<ushort>.Count >= 0);
+                while (remainingLength >= Vector<ushort>.Count);
             }
 
             for (; remainingLength > 0; remainingLength--)
             {
-                pDst = pSrc == oldChar ? newChar : pSrc;
+                ushort currentChar = pSrc;
+                pDst = currentChar == oldChar ? newChar : currentChar;
 
                 pSrc = ref Unsafe.Add(ref pSrc, 1);
                 pDst = ref Unsafe.Add(ref pDst, 1);


### PR DESCRIPTION
* Replace bits of existing unsafe code to IndexOf, which is already vectorised
* Vectorise the replacement bit

I will PR more tests/benchmarks that test both the non-vectorised and vectorised paths in corefx/performance repo. (In the meantime, I have verified that the tests pass locally.)

Also, I am aware that the closure of the repo for consolidation is due; I am happy to open the PR again once the repo is open, if this cannot be merged before the closure.

Tested with four cases (no characters replaced / some characters replaced, with two different strings), and the results seem to suggest slight slowdown for strings that are too small to be vectorised & has something to be replaced (here it appears to be around 20% slower), but for longer strings it seems to be better:
```
summary:
better: 2, geomean: 1.293
worse: 1, geomean: 1.193
total diff: 3
```

| Slower                                                                           | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Tests.Perf_String.Replace_Char(text: "Hello", oldChar: 'l', newChar: '!') |      1.19 |             9.44 |            11.27 |         |

| Faster                                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| -------- |
| System.Tests.Perf_String.Replace_Char(text: "This is a very nice sentence", oldChar: 'i', newChar: 'I') |      1.33 |             9.36 |             7.05 |         |
| System.Tests.Perf_String.Replace_Char(text: "This is a very nice sentence", oldChar: 'z', newChar: 'y') |      1.26 |            22.62 |            17.95 | several?|