### PR TITLE
Fixing an assert around Avx.ExtractVector128 and Avx2.ExtractVector128

### DIFF
--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -2901,6 +2901,12 @@ bool Lowering::IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* containingNode, Ge
             return supportsUnalignedSIMDLoads;
         }
 
+        case NI_AVX_ExtractVector128:
+        case NI_AVX2_ExtractVector128:
+        {
+            return false;
+        }
+
         default:
         {
             assert(!node->isContainableHWIntrinsic());


### PR DESCRIPTION
`Avx.ExtractVector128` and `Avx2.ExtractVector128` are marked containable and so they need to be explicitly handled in the `Lowering::IsContainableHWIntrinsicOp` to avoid a failure on `assert(!node->isContainableHWIntrinsic());`