### PR TITLE
Revert "[Release/3.1] stablize package version"

### DIFF
--- a/dir.common.props
+++ b/dir.common.props
@@ -68,7 +68,7 @@
     <PackageVersion Condition="'$(PackageVersion)' == ''">3.1.0</PackageVersion>
 
     <!-- Set the boolean below to true to generate packages with stabilized versions -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
 
     <PreReleaseLabel>alpha1</PreReleaseLabel>


### PR DESCRIPTION
Reverts dotnet/coreclr#27740

Not needed for CoreClr