### PR TITLE
fix sysctlt compilation error on FreeBSD

### DIFF
--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -31,9 +31,12 @@ Revision History:
 
 #if HAVE_SYSCONF
 // <unistd.h> already included above
-#elif HAVE_SYSCTL
+#endif
+#if HAVE_SYSCTL && not defined(__linux__)
+// glibc is deprecating sysctl so we should not use it even if it exist.
 #include <sys/sysctl.h>
-#else
+#endif
+#if not HAVE_SYSCONF && not HAVE_SYSCTL
 #error Either sysctl or sysconf is required for GetSystemInfo.
 #endif
 


### PR DESCRIPTION
This is regression caused by #27048 and build fails like:
```
[ 28%] Built target utilcodestaticnohost
/home/furt/git/coreclr/src/pal/src/misc/sysinfo.cpp:382:10: error: use of undeclared identifier 'sysctlnametomib'
    rc = sysctlnametomib("vm.swap_info", mib, &length);
         ^
[ 35%] Built target cee_dac
/home/furt/git/coreclr/src/pal/src/misc/sysinfo.cpp:390:18: error: use of undeclared identifier 'sysctl'
            rc = sysctl(mib, 3, &xsw, &length, NULL, 0);
                 ^
/home/furt/git/coreclr/src/pal/src/misc/sysinfo.cpp:599:30: error: use of undeclared identifier 'sysctlbyname'
        const bool success = sysctlbyname("hw.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
                             ^
/home/furt/git/coreclr/src/pal/src/misc/sysinfo.cpp:600:16: error: use of undeclared identifier 'sysctlbyname'
            || sysctlbyname("hw.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
               ^
/home/furt/git/coreclr/src/pal/src/misc/sysinfo.cpp:601:16: error: use of undeclared identifier 'sysctlbyname'
            || sysctlbyname("hw.l1dcachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0;
[ 35%] Generating eventpipe/eventpipehelpers.cpp, eventpipe/dotnetruntime.cpp, eventpipe/dotnetruntimerundown.cpp, eventpipe/dotnetruntimestress.cpp, eventpipe/dotnetruntimeprivate.cpp

```

The problem is that FreeBSD has HAVE_SYSCONF and that seems mutually elusive in includes but later on used with different guard.  Maybe it would be better to set HAVE_SYSCONF=0 on Linux if we want to avoid usage of it.

This is minimal change to fix compilation while preserving spirit of #27048.
Note that FreeBSD does not have vm.swap_info. We will probably need separate effort to find some equivalent. 

cc: @omajid 

