### PR TITLE
[release/3.1] Fix use of ilasm during test builds when using a 3.0 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview6-012264"
+    "dotnet": "3.0.100"
   },
   "native-tools": {
     "cmake": "3.11.1",

--- a/tests/ilasm-restore/Directory.Build.props
+++ b/tests/ilasm-restore/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- 
+    This project works around a restore issue in buildtools for musl distros. It shouldn't use any
+    other properties in the test tree. This file prevents any imports.
+  -->
+</Project>

--- a/tests/ilasm-restore/Directory.Build.targets
+++ b/tests/ilasm-restore/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <!-- 
+    This project works around a restore issue in buildtools for musl distros. It shouldn't use any
+    other properties in the test tree. This file prevents any imports.
+  -->
+</Project>

--- a/tests/ilasm-restore/ilasm.depproj
+++ b/tests/ilasm-restore/ilasm.depproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- This file is largely a copy of the BuildTools equivalent -->
+  <PropertyGroup>
+    <!-- suppress the attempt to copy build output. -->
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <Target Name="CoreCompile">
+    <Copy SourceFiles="@(NativeCopyLocalItems)" DestinationFolder="$(ExpectedILAsmPath)" />
+  </Target>
+
+  <!-- Required by Common.Targets -->
+  <Target Name="CreateManifestResourceNames" />
+
+  <PropertyGroup>
+    <NuGetTargetMoniker>.NETCoreApp,Version=v3.0</NuGetTargetMoniker>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RidSpecificAssets>true</RidSpecificAssets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.ILAsm" Version="$(ILAsmPackageVersion)" />
+    <PackageReference Include="Microsoft.NETCore.ILDAsm" Version="$(ILAsmPackageVersion)" />
+
+    <!-- ILAsm has a very unfortunate runtime dependency on CoreCLR, so we need to grab that too -->
+    <!-- https://github.com/dotnet/coreclr/issues/15059 -->
+    <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR" Version="$(ILAsmPackageVersion)" />
+  </ItemGroup>
+</Project> 


### PR DESCRIPTION
The restore logic in buildtools tried to use a netcoreapp2.1 TFM for Linux-musl.
This ended up restoring Linux-x64 binaries which then broke the test build.
This change works around this by saving a copy of the depproj that BuildTools used into
the tree and restore it as a 3.0 app manually in init-tools on our side of the build.
