### PR TITLE
Fixing an assert in card stealing.

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -30474,8 +30474,13 @@ bool card_marking_enumerator::move_next(heap_segment* seg, uint8_t*& low, uint8_
             {
                 // we found the correct segment, but it's not the segment our caller is in
 
-                // our caller should still be in the previous segment
-                assert(heap_segment_next_in_range(seg) == segment);
+                // our caller should still be in one of the previous segments
+#if DEBUG
+                for (heap_segment* curSeg = seg; curSeg != segment; curSeg = heap_segment_next_in_range(curSeg))
+                {                    
+                    assert(curSeg);
+                }
+#endif
 
                 // keep the chunk index for later
                 old_chunk_index = chunk_index;

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -30475,12 +30475,12 @@ bool card_marking_enumerator::move_next(heap_segment* seg, uint8_t*& low, uint8_
                 // we found the correct segment, but it's not the segment our caller is in
 
                 // our caller should still be in one of the previous segments
-#ifdef DEBUG
-                for (heap_segment* curSeg = seg; curSeg != segment; curSeg = heap_segment_next_in_range(curSeg))
+#ifdef _DEBUG
+                for (heap_segment* cur_seg = seg; cur_seg != segment; cur_seg = heap_segment_next_in_range(cur_seg))
                 {                    
-                    assert(curSeg);
+                    assert(cur_seg);
                 }
-#endif //DEBUG
+#endif //_DEBUG
 
                 // keep the chunk index for later
                 old_chunk_index = chunk_index;

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -30475,12 +30475,12 @@ bool card_marking_enumerator::move_next(heap_segment* seg, uint8_t*& low, uint8_
                 // we found the correct segment, but it's not the segment our caller is in
 
                 // our caller should still be in one of the previous segments
-#if DEBUG
+#ifdef DEBUG
                 for (heap_segment* curSeg = seg; curSeg != segment; curSeg = heap_segment_next_in_range(curSeg))
                 {                    
                     assert(curSeg);
                 }
-#endif
+#endif //DEBUG
 
                 // keep the chunk index for later
                 old_chunk_index = chunk_index;


### PR DESCRIPTION
The assert assumes that the caller is never more than one segment behind the stealing action.
It seems ok to lag by more than one segment.
