### PR TITLE
Include sys/sysctl.h in sysinfo.cpp for FreeBSD

### DIFF
--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -37,6 +37,10 @@ Revision History:
 #error Either sysctl or sysconf is required for GetSystemInfo.
 #endif
 
+#if HAVE_SYSCTLBYNAME
+#include <sys/sysctl.h>
+#endif
+
 #if HAVE_SYSINFO
 #include <sys/sysinfo.h>
 #endif


### PR DESCRIPTION
Regressed since https://github.com/dotnet/coreclr/pull/27048.

While this header is not required for `GetSystemInfo` by FreeBSD either, it is required for `sysctl`, `sysctlnametomib` and `sysctlbyname`:

https://www.freebsd.org/cgi/man.cgi?query=sysctlnametomib&apropos=0&sektion=0&manpath=FreeBSD+12.1-RELEASE&arch=default&format=html

build error:

```
[  5%] Building CXX object src/pal/src/CMakeFiles/coreclrpal.dir/misc/sysinfo.cpp.o
[  6%] Building CXX object src/md/compiler/CMakeFiles/mdcompiler_dac.dir/helper.cpp.o
[  6%] Building CXX object src/md/compiler/CMakeFiles/mdcompiler_crossgen.dir/emit.cpp.o
/home/am11/projects/dotnet/coreclr/src/pal/src/misc/sysinfo.cpp:382:10: error: use of undeclared identifier 'sysctlnametomib'
    rc = sysctlnametomib("vm.swap_info", mib, &length);
         ^
/home/am11/projects/dotnet/coreclr/src/pal/src/misc/sysinfo.cpp:390:18: error: use of undeclared identifier 'sysctl'
            rc = sysctl(mib, 3, &xsw, &length, NULL, 0);
                 ^
/home/am11/projects/dotnet/coreclr/src/pal/src/misc/sysinfo.cpp:599:30: error: use of undeclared identifier 'sysctlbyname'
        const bool success = sysctlbyname("hw.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
                             ^
/home/am11/projects/dotnet/coreclr/src/pal/src/misc/sysinfo.cpp:600:16: error: use of undeclared identifier 'sysctlbyname'
            || sysctlbyname("hw.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
               ^
/home/am11/projects/dotnet/coreclr/src/pal/src/misc/sysinfo.cpp:601:16: error: use of undeclared identifier 'sysctlbyname'
            || sysctlbyname("hw.l1dcachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0;
               ^
5 errors generated.
--- src/pal/src/CMakeFiles/coreclrpal.dir/misc/sysinfo.cpp.o ---
*** [src/pal/src/CMakeFiles/coreclrpal.dir/misc/sysinfo.cpp.o] Error code 1

make[2]: stopped in /usr/home/am11/projects/dotnet/coreclr/bin/obj/FreeBSD.x64.Release
1 error
```

cc @omajid, @wfurt: i was building master branches to run System.Diagnostics.Process tests in CoreFX and encountered this error. Otherwise build succeeds on FreeBSD 12.