### PR TITLE
Add tracing for handling of dependencies for assemblies loaded through Assembly.LoadFrom

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
@@ -258,7 +258,15 @@ namespace System.Reflection
             {
                 // If the requestor assembly was not loaded using LoadFrom, exit.
                 if (!s_loadFromAssemblyList.Contains(requestorPath))
+                {
+#if CORECLR
+                    if (AssemblyLoadContext.IsTracingEnabled())
+                    {
+                        AssemblyLoadContext.TraceAssemblyLoadFromResolveHandlerInvoked(args.Name, false, requestorPath, null);
+                    }
+#endif // CORECLR
                     return null;
+                }
             }
 
             // Requestor assembly was loaded using loadFrom, so look for its dependencies
@@ -266,7 +274,12 @@ namespace System.Reflection
             // Form the name of the assembly using the path of the assembly that requested its load.
             AssemblyName requestedAssemblyName = new AssemblyName(args.Name!);
             string requestedAssemblyPath = Path.Combine(Path.GetDirectoryName(requestorPath)!, requestedAssemblyName.Name + ".dll");
-
+#if CORECLR
+            if (AssemblyLoadContext.IsTracingEnabled())
+            {
+                AssemblyLoadContext.TraceAssemblyLoadFromResolveHandlerInvoked(args.Name, true, requestorPath, requestedAssemblyPath);
+            }
+#endif // CORECLR
             try
             {
                 // Load the dependency via LoadFrom so that it goes through the same path of being in the LoadFrom list.

--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -41,6 +41,9 @@ namespace System.Runtime.Loader
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
         internal static extern bool TraceAssemblyResolveHandlerInvoked(string assemblyName, string handlerName, string? resultAssemblyName, string? resultAssemblyPath);
 
+        [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
+        internal static extern bool TraceAssemblyLoadFromResolveHandlerInvoked(string assemblyName, bool isTrackedAssembly, string requestingAssemblyPath, string? requestedAssemblyPath);
+
         private Assembly InternalLoadFromPath(string? assemblyPath, string? nativeImagePath)
         {
             RuntimeAssembly? loadedAssembly = null;

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -396,6 +396,7 @@
                         <opcodes>
                             <opcode name="AssemblyLoadContextResolvingHandlerInvoked" message="$(string.RuntimePublisher.AssemblyLoadContextResolvingHandlerInvokedOpcodeMessage)" symbol="CLR_ALC_RESOLVING_HANDLER_INVOKED_OPCODE" value="12"/>
                             <opcode name="AppDomainAssemblyResolveHandlerInvoked" message="$(string.RuntimePublisher.AppDomainAssemblyResolveHandlerInvokedOpcodeMessage)" symbol="CLR_APPDOMAIN_ASSEMBLY_RESOLVE_HANDLER_INVOKED_OPCODE" value="13"/>
+                            <opcode name="AssemblyLoadFromResolveHandlerInvoked" message="$(string.RuntimePublisher.AssemblyLoadFromResolveHandlerInvokedOpcodeMessage)" symbol="CLR_ASSEMBLY_LOAD_FROM_RESOLVE_HANDLER_INVOKED_OPCODE" value="14"/>
                         </opcodes>
                     </task>
                 <!--Next available ID is 33-->
@@ -1740,6 +1741,23 @@
                                 <ResultAssemblyName> %4 </ResultAssemblyName>
                                 <ResultAssemblyPath> %5 </ResultAssemblyPath>
                             </AppDomainAssemblyResolveHandlerInvoked>
+                        </UserData>
+                    </template>
+
+                    <template tid="AssemblyLoadFromResolveHandlerInvoked">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="AssemblyName" inType="win:UnicodeString" />
+                        <data name="IsTrackedLoad" inType="win:Boolean" />
+                        <data name="RequestingAssemblyPath" inType="win:UnicodeString" />
+                        <data name="ComputedRequestedAssemblyPath" inType="win:UnicodeString" />
+                        <UserData>
+                            <AssemblyLoadFromResolveHandlerInvoked xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <AssemblyName> %2 </AssemblyName>
+                                <IsTrackedAssembly> %3 </IsTrackedAssembly>
+                                <RequestingAssemblyName> %4 </RequestingAssemblyName>
+                                <ComputedRequestedAssemblyPath> %5 </ComputedRequestedAssemblyPath>
+                            </AssemblyLoadFromResolveHandlerInvoked>
                         </UserData>
                     </template>
 
@@ -3549,6 +3567,11 @@
                            keywords ="AssemblyLoaderKeyword" opcode="AppDomainAssemblyResolveHandlerInvoked"
                            task="AssemblyLoader"
                            symbol="AppDomainAssemblyResolveHandlerInvoked" message="$(string.RuntimePublisher.AppDomainAssemblyResolveHandlerInvokedEventMessage)"/>
+
+                    <event value="295" version="0" level="win:Informational"  template="AssemblyLoadFromResolveHandlerInvoked"
+                           keywords ="AssemblyLoaderKeyword" opcode="AssemblyLoadFromResolveHandlerInvoked"
+                           task="AssemblyLoader"
+                           symbol="AssemblyLoadFromResolveHandlerInvoked" message="$(string.RuntimePublisher.AssemblyLoadFromResolveHandlerInvokedEventMessage)"/>
 
                 </events>
             </provider>
@@ -6749,6 +6772,7 @@
                 <string id="RuntimePublisher.AssemblyLoadStopEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nAssemblyPath=%3;%nRequestingAssembly=%4;%nAssemblyLoadContext=%5;%nRequestingAssemblyLoadContext=%6;%nSuccess=%7;%nResultAssemblyName=%8;%nResultAssemblyPath=%9;%nCached=%10" />
                 <string id="RuntimePublisher.AssemblyLoadContextResolvingHandlerInvokedEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nHandlerName=%3;%nAssemblyLoadContext=%4;%nResultAssemblyName=%5;%nResultAssemblyPath=%6" />
                 <string id="RuntimePublisher.AppDomainAssemblyResolveHandlerInvokedEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nHandlerName=%3;%nResultAssemblyName=%4;%nResultAssemblyPath=%5" />
+                <string id="RuntimePublisher.AssemblyLoadFromResolveHandlerInvokedEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nIsTrackedLoad=%3;%nRequestingAssemblyPath=%4;%nComputedRequestedAssemblyPath=%5" />
                 <string id="RuntimePublisher.StackEventMessage" value="ClrInstanceID=%1;%nReserved1=%2;%nReserved2=%3;%nFrameCount=%4;%nStack=%5" />
                 <string id="RuntimePublisher.AppDomainMemAllocatedEventMessage" value="AppDomainID=%1;%nAllocated=%2;%nClrInstanceID=%3" />
                 <string id="RuntimePublisher.AppDomainMemSurvivedEventMessage" value="AppDomainID=%1;%nSurvived=%2;%nProcessSurvived=%3;%nClrInstanceID=%4" />
@@ -7379,6 +7403,7 @@
 
                 <string id="RuntimePublisher.AssemblyLoadContextResolvingHandlerInvokedOpcodeMessage" value="AssemblyLoadContextResolvingHandlerInvoked" />
                 <string id="RuntimePublisher.AppDomainAssemblyResolveHandlerInvokedOpcodeMessage" value="AppDomainAssemblyResolveHandlerInvoked" />
+                <string id="RuntimePublisher.AssemblyLoadFromResolveHandlerInvokedOpcodeMessage" value="AssemblyLoadFromResolveHandlerInvoked" />
 
                 <string id="RundownPublisher.MethodDCStartOpcodeMessage" value="DCStart" />
                 <string id="RundownPublisher.MethodDCEndOpcodeMessage" value="DCStop" />

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -1452,3 +1452,15 @@ void QCALLTYPE AssemblyNative::TraceAssemblyResolveHandlerInvoked(LPCWSTR assemb
 
     END_QCALL;
 }
+
+// static
+void QCALLTYPE AssemblyNative::TraceAssemblyLoadFromResolveHandlerInvoked(LPCWSTR assemblyName, bool isTrackedAssembly, LPCWSTR requestingAssemblyPath, LPCWSTR requestedAssemblyPath)
+{
+    QCALL_CONTRACT;
+
+    BEGIN_QCALL;
+
+    FireEtwAssemblyLoadFromResolveHandlerInvoked(GetClrInstanceId(), assemblyName, isTrackedAssembly, requestingAssemblyPath, requestedAssemblyPath);
+
+    END_QCALL;
+}

--- a/src/vm/assemblynative.hpp
+++ b/src/vm/assemblynative.hpp
@@ -135,6 +135,7 @@ public:
     static BOOL QCALLTYPE InternalTryGetRawMetadata(QCall::AssemblyHandle assembly, UINT8 **blobRef, INT32 *lengthRef);
     static void QCALLTYPE TraceResolvingHandlerInvoked(LPCWSTR assemblyName, LPCWSTR handlerName, LPCWSTR alcName, LPCWSTR resultAssemblyName, LPCWSTR resultAssemblyPath);
     static void QCALLTYPE TraceAssemblyResolveHandlerInvoked(LPCWSTR assemblyName, LPCWSTR handlerName, LPCWSTR resultAssemblyName, LPCWSTR resultAssemblyPath);
+    static void QCALLTYPE TraceAssemblyLoadFromResolveHandlerInvoked(LPCWSTR assemblyName, bool isTrackedAssembly, LPCWSTR requestingAssemblyPath, LPCWSTR requestedAssemblyPath);
 };
 
 #endif

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -515,6 +515,7 @@ FCFuncStart(gAssemblyLoadContextFuncs)
     FCFuncElement("IsTracingEnabled", AssemblyNative::IsTracingEnabled)
     QCFuncElement("TraceResolvingHandlerInvoked", AssemblyNative::TraceResolvingHandlerInvoked)
     QCFuncElement("TraceAssemblyResolveHandlerInvoked", AssemblyNative::TraceAssemblyResolveHandlerInvoked)
+    QCFuncElement("TraceAssemblyLoadFromResolveHandlerInvoked", AssemblyNative::TraceAssemblyLoadFromResolveHandlerInvoked)
 FCFuncEnd()
 
 FCFuncStart(gAssemblyNameFuncs)

--- a/tests/src/Loader/binding/tracing/AssemblyToLoad.cs
+++ b/tests/src/Loader/binding/tracing/AssemblyToLoad.cs
@@ -5,5 +5,11 @@
 namespace AssemblyToLoad
 {
     public class Program
-    { }
+    {
+        public static System.Reflection.Assembly UseDependentAssembly()
+        {
+            var p = new AssemblyToLoadDependency.Program();
+            return System.Reflection.Assembly.GetAssembly(p.GetType());
+        }
+    }
 }

--- a/tests/src/Loader/binding/tracing/AssemblyToLoad.csproj
+++ b/tests/src/Loader/binding/tracing/AssemblyToLoad.csproj
@@ -8,4 +8,7 @@
   <ItemGroup>
     <Compile Include="AssemblyToLoad.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="AssemblyToLoadDependency.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/src/Loader/binding/tracing/AssemblyToLoadDependency.cs
+++ b/tests/src/Loader/binding/tracing/AssemblyToLoadDependency.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace AssemblyToLoadDependency
+{
+    public class Program
+    { }
+}

--- a/tests/src/Loader/binding/tracing/AssemblyToLoadDependency.csproj
+++ b/tests/src/Loader/binding/tracing/AssemblyToLoadDependency.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyToLoadDependency.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/src/Loader/binding/tracing/BinderTracingTest.csproj
+++ b/tests/src/Loader/binding/tracing/BinderTracingTest.csproj
@@ -31,6 +31,7 @@
   <Target Name="MoveDependentAssembliesToSubdirectory" AfterTargets="CopyFilesToOutputDirectory">
     <ItemGroup>
       <AssembliesToMove Include="$(OutDir)/AssemblyToLoad_*.*" />
+      <AssembliesToMove Include="$(OutDir)/AssemblyToLoadDependency.*" />
     </ItemGroup>
     <Move SourceFiles="@(AssembliesToMove)" DestinationFolder="$(OutDir)/DependentAssemblies" />
   </Target>


### PR DESCRIPTION
- Add `AssemblyLoadFromResolveHandlerInvoked` event for tracing of event handler for resolving dependencies for assemblies loaded through `Assembly.LoadFrom`
- Add tests to validate firing of new event