### PR TITLE
Pre-consolidation mop up fixes #3

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -277,7 +277,7 @@ if "%__SkipRestorePackages%" == "1" goto SkipRestoreProduct
 
 echo %__MsgPrefix%Restoring CoreCLR product from packages
 
-if not defined XunitTestBinBase set XunitTestBinBase=%__TestBinDir%
+if not defined XunitTestBinBase set XunitTestBinBase=%__TestBinDir%\
 set "CORE_ROOT=%XunitTestBinBase%\Tests\Core_Root"
 
 set __BuildLogRootName=Restore_Product

--- a/build-test.sh
+++ b/build-test.sh
@@ -522,7 +522,7 @@ build_native_projects()
             extraCmakeArguments="$extraCmakeArguments -DCLR_CMAKE_ENABLE_CODE_COVERAGE=1"
         fi
 
-        nextCommand="\"$scriptDir/gen-buildsys.sh\" \"$__TestDir\" \"$intermediatesForBuild\" $platformArch $__BuildType $generator $extraCmakeArguments $__cmakeargs"
+        nextCommand="CONFIG_DIR=\"$__RepoRootDir/eng/common/cross\" \"$scriptDir/gen-buildsys.sh\" \"$__TestDir\" \"$intermediatesForBuild\" $platformArch $__BuildType $generator $extraCmakeArguments $__cmakeargs"
         echo "Invoking $nextCommand"
         eval $nextCommand
 

--- a/build-test.sh
+++ b/build-test.sh
@@ -522,7 +522,7 @@ build_native_projects()
             extraCmakeArguments="$extraCmakeArguments -DCLR_CMAKE_ENABLE_CODE_COVERAGE=1"
         fi
 
-        nextCommand="CONFIG_DIR=\"$__RepoRootDir/eng/common/cross\" \"$scriptDir/gen-buildsys.sh\" \"$__TestDir\" \"$intermediatesForBuild\" $platformArch $__BuildType $generator $extraCmakeArguments $__cmakeargs"
+        nextCommand="\"$scriptDir/gen-buildsys.sh\" \"$__TestDir\" \"$intermediatesForBuild\" $platformArch $__BuildType $generator $extraCmakeArguments $__cmakeargs"
         echo "Invoking $nextCommand"
         eval $nextCommand
 

--- a/build.sh
+++ b/build.sh
@@ -231,7 +231,7 @@ build_native()
             extraCmakeArguments="$extraCmakeArguments -DCLR_CMAKE_ENABLE_CODE_COVERAGE=1"
         fi
 
-        nextCommand="CONFIG_DIR=\"$__RepoRootDir/eng/common/cross\" \"$scriptDir/gen-buildsys.sh\" \"$__ProjectRoot\" \"$intermediatesForBuild\" $platformArch $__BuildType $generator $scan_build $extraCmakeArguments $__cmakeargs"
+        nextCommand="\"$scriptDir/gen-buildsys.sh\" \"$__ProjectRoot\" \"$intermediatesForBuild\" $platformArch $__BuildType $generator $scan_build $extraCmakeArguments $__cmakeargs"
         echo "Invoking $nextCommand"
         eval $nextCommand
 

--- a/build.sh
+++ b/build.sh
@@ -193,7 +193,7 @@ build_native()
         __versionSourceFile="$intermediatesForBuild/version.c"
         if [ $__SkipGenerateVersion == 0 ]; then
             pwd
-            "$__RepoRootDir/eng/common/msbuild.sh" $__ArcadeScriptArgs $__ProjectRoot/eng/empty.csproj \
+            "$__RepoRootDir/eng/common/msbuild.sh" $__ArcadeScriptArgs $__RepoRootDir/eng/empty.csproj \
                                                    /p:NativeVersionFile=$__versionSourceFile \
                                                    /t:GenerateNativeVersionFile /restore \
                                                    $__CommonMSBuildArgs $__UnprocessedBuildArgs
@@ -231,7 +231,7 @@ build_native()
             extraCmakeArguments="$extraCmakeArguments -DCLR_CMAKE_ENABLE_CODE_COVERAGE=1"
         fi
 
-        nextCommand="\"$scriptDir/gen-buildsys.sh\" \"$__ProjectRoot\" \"$intermediatesForBuild\" $platformArch $__BuildType $generator $scan_build $extraCmakeArguments $__cmakeargs"
+        nextCommand="CONFIG_DIR=\"$__RepoRootDir/eng/common/cross\" \"$scriptDir/gen-buildsys.sh\" \"$__ProjectRoot\" \"$intermediatesForBuild\" $platformArch $__BuildType $generator $scan_build $extraCmakeArguments $__cmakeargs"
         echo "Invoking $nextCommand"
         eval $nextCommand
 

--- a/eng/helixcorefxtests.proj
+++ b/eng/helixcorefxtests.proj
@@ -85,6 +85,7 @@
       TODO: ProjectDir, RootBinDir, TestWorkingDir, and TargetsWindows are global properties set in dir.props, remove the property assignment here when we port to arcade.
      -->
     <ProjectDir Condition="'$(__ProjectDir)'==''">$(MSBuildThisFileDirectory)..\</ProjectDir>
+    <ProjectDir Condition="Exists('$(ProjectDir).dotnet-runtime-placeholder')">$(ProjectDir)\src\coreclr\</ProjectDir>
     <RootBinDir Condition="'$(__RootBinDir)'==''">$(ProjectDir)bin\</RootBinDir>
     <TestWorkingDir Condition="'$(__TestWorkingDir)'==''">$(RootBinDir)tests\$(__BuildOS).$(__BuildArch).$(__BuildType)\</TestWorkingDir>
     <TargetsWindows Condition="'$(__BuildOS)' == 'Windows_NT'">true</TargetsWindows>
@@ -149,7 +150,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_ProjectsToBuild Include="..\tests\testenvironment.proj">
+      <_ProjectsToBuild Include="$(ProjectDir)tests\testenvironment.proj">
         <Properties>Scenario=$(Scenario);TestEnvFileName=$(TestEnvFilePath);TargetsWindows=$(TargetsWindows)</Properties>
       </_ProjectsToBuild>
     </ItemGroup>

--- a/eng/pipelines/templates/build-test-job.yml
+++ b/eng/pipelines/templates/build-test-job.yml
@@ -67,7 +67,7 @@ jobs:
         displayName: Install native dependencies
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       # Necessary to install correct cmake version
-      - script: $(coreClrRepoRootDir)eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
+      - script: $(Build.SourcesDirectory)\eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
         displayName: Install native dependencies
 
 

--- a/eng/pipelines/templates/crossgen-comparison-job.yml
+++ b/eng/pipelines/templates/crossgen-comparison-job.yml
@@ -40,14 +40,14 @@ jobs:
       value: $(osGroup).$(hostArchType)_$(archType).$(buildConfigUpper)
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
       - name: binDirectory
-        value: $(Build.SourcesDirectory)/bin
+        value: $(coreClrRepoRoot)/bin
       - name: productDirectory
-        value: $(Build.SourcesDirectory)/bin/Product
+        value: $(binDirectory)/Product
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       - name: binDirectory
-        value: $(Build.SourcesDirectory)\bin
+        value: $(coreClrRepoRoot)\bin
       - name: productDirectory
-        value: $(Build.SourcesDirectory)\bin\Product
+        value: $(binDirectory\Product
 
     # Test job depends on the corresponding build job
     dependsOn: ${{ format('build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
@@ -83,12 +83,8 @@ jobs:
 
 
     # Populate Core_Root
-    - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build-test.sh $(buildConfig) $(archType) $(crossArg) generatelayoutonly
-        displayName: Populate Core_Root
-    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: build-test.cmd $(buildConfig) $(archType) generateLayoutOnly
-        displayName: Populate Core_Root
+    - script: $(coreClrRepoRootDir)build-test$(scriptExt) $(buildConfig) $(archType) $(crossArg) generatelayoutonly
+      displayName: Populate Core_Root
 
 
     # Create baseline output on the host (x64) machine
@@ -96,7 +92,7 @@ jobs:
       displayName: Create cross-platform crossgen baseline
       inputs:
         scriptSource: 'filePath'
-        scriptPath: $(Build.SourcesDirectory)/tests/scripts/crossgen_comparison.py
+        scriptPath: $(coreClrRepoRoot)/tests/scripts/crossgen_comparison.py
         ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
           arguments:
             crossgen_framework
@@ -126,7 +122,7 @@ jobs:
           Creator: $(Creator)
         WorkItemTimeout: 1:00 # 1 hour
         WorkItemDirectory: '$(binDirectory)'
-        CorrelationPayloadDirectory: '$(Build.SourcesDirectory)/tests/scripts'
+        CorrelationPayloadDirectory: '$(coreClrRepoRoot)/tests/scripts'
         ${{ if ne(parameters.osName, 'Windows_NT') }}:
           WorkItemCommand:
             chmod +x     $HELIX_WORKITEM_PAYLOAD/Product/$(targetFlavor)/crossgen;

--- a/eng/pipelines/templates/perf-job.yml
+++ b/eng/pipelines/templates/perf-job.yml
@@ -55,9 +55,9 @@ jobs:
 
     # Create Core_Root
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build-test.sh ${{ parameters.buildConfig }} ${{ parameters.archType }} generatelayoutonly
+      - script: $(coreClrRepoRootDir)build-test$(scriptExt) ${{ parameters.buildConfig }} ${{ parameters.archType }} generatelayoutonly
         displayName: Create Core_Root
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       # TODO: add generatelayoutonly to build-test.cmd.
-      - script: build-test.cmd ${{ parameters.buildConfig }} ${{ parameters.archType }} skipmanaged skipnative
+      - script: $(coreClrRepoRootDir)build-test$(scriptExt) ${{ parameters.buildConfig }} ${{ parameters.archType }} skipmanaged skipnative
         displayName: Create Core_Root

--- a/eng/pipelines/templates/run-test-job.yml
+++ b/eng/pipelines/templates/run-test-job.yml
@@ -257,7 +257,7 @@ jobs:
 
         # Choose which tests to send to Helix: CoreFX or CoreCLR.
         ${{ if eq(parameters.corefxTests, true) }}:
-          helixProjectArguments: '$(coreClrRepoRoot)/eng/helixcorefxtests.proj'
+          helixProjectArguments: '$(Build.SourcesDirectory)/eng/helixcorefxtests.proj'
         ${{ if ne(parameters.corefxTests, true) }}:
           helixProjectArguments: '$(coreClrRepoRoot)/tests/src/helixpublishwitharcade.proj'
 

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -117,7 +117,7 @@ set "__TestWorkingDir=%__RootBinDir%\tests\%__BuildOS%.%__BuildArch%.%__BuildTyp
 :: Default global test environment variables
 :: REVIEW: are these ever expected to be defined on entry to this script? Why? By whom?
 :: REVIEW: XunitTestReportDirBase is not used in this script. Who needs to have it set?
-if not defined XunitTestBinBase       set  XunitTestBinBase=%__TestWorkingDir%
+if not defined XunitTestBinBase       set  XunitTestBinBase=%__TestWorkingDir%\
 if not defined XunitTestReportDirBase set  XunitTestReportDirBase=%XunitTestBinBase%\Reports\
 
 REM We are not running in the official build scenario, call runtest.py

--- a/tests/src/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByOut/CMakeLists.txt
+++ b/tests/src/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByOut/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 2.6) 
-project (ReversePInvokePassingByOutNative) 
+project (RPIP_ByOutNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 include_directories("..") 
 set(SOURCES 
@@ -7,7 +7,8 @@ set(SOURCES
 ) 
 # Additional files to reference: 
 # add the executable 
-add_library (ReversePInvokePassingByOutNative SHARED ${SOURCES}) 
-target_link_libraries(ReversePInvokePassingByOutNative ${LINK_LIBRARIES_ADDITIONAL}) 
+add_library (RPIP_ByOutNative SHARED ${SOURCES}) 
+set_property (TARGET RPIP_ByOutNative PROPERTY OUTPUT_NAME ReversePInvokePassingByOutNative)
+target_link_libraries(RPIP_ByOutNative ${LINK_LIBRARIES_ADDITIONAL}) 
 # add the install targets 
-install (TARGETS ReversePInvokePassingByOutNative DESTINATION bin) 
+install (TARGETS RPIP_ByOutNative DESTINATION bin) 

--- a/tests/src/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/CMakeLists.txt
+++ b/tests/src/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 2.6) 
-project (ReversePInvokePassingByRefNative) 
+project (RPIP_ByRefNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 include_directories("..") 
 set(SOURCES 
@@ -7,7 +7,8 @@ set(SOURCES
 ) 
 # Additional files to reference: 
 # add the executable 
-add_library (ReversePInvokePassingByRefNative SHARED ${SOURCES}) 
-target_link_libraries(ReversePInvokePassingByRefNative ${LINK_LIBRARIES_ADDITIONAL}) 
+add_library (RPIP_ByRefNative SHARED ${SOURCES}) 
+set_property (TARGET RPIP_ByRefNative PROPERTY OUTPUT_NAME ReversePInvokePassingByRefNative)
+target_link_libraries(RPIP_ByRefNative ${LINK_LIBRARIES_ADDITIONAL}) 
 # add the install targets 
-install (TARGETS ReversePInvokePassingByRefNative DESTINATION bin) 
+install (TARGETS RPIP_ByRefNative DESTINATION bin) 


### PR DESCRIPTION
This change contains the remaining fixes I made while digging
through the PR run in the runtime repo:

1) Some more repo-relative vs. coreclr-relative repo adjustments
reflecting the migration process;

2) Make sure that XunitTestBinBase always ends with a directory
separator, otherwise my recent fix for Common folder exclusion
doesn't work;

3) Opportunistically shorten project names of two native interop
test components - as the project name is repeated about 3-4 times
in some intermediate paths, it quickly exceeds the standard
Windows path length limit. Please note there's no functional
change in the test.

Thanks

Tomas