### PR TITLE
[interpreter] Fix error: use of undeclared identifier 'g_pExecuteBackoutCodeHelperMethod'

### DIFF
--- a/src/vm/interpreter.cpp
+++ b/src/vm/interpreter.cpp
@@ -10210,7 +10210,7 @@ void Interpreter::CallI()
             }
             else
             {
-                pMD = g_pExecuteBackoutCodeHelperMethod;  // A random static method.
+                pMD = MscorlibBinder::GetMethod(METHOD__INTERLOCKED__COMPARE_EXCHANGE_OBJECT);  // A random static method.
             }
             MethodDescCallSite mdcs(pMD, &mSig, ftnPtr);
 #if 0


### PR DESCRIPTION
Hi,

Just change `g_pExecuteBackoutCodeHelperMethod` to `MscorlibBinder::GetMethod(METHOD__INTERLOCKED__COMPARE_EXCHANGE_OBJECT)` as @jkotas suggested.

https://github.com/dotnet/coreclr/issues/27848

Thanks,
Leslie Zhai