### PR TITLE
Fix SIMD intrinsics handling in crossgen2

### DIFF
--- a/src/tools/crossgen2/Common/Compiler/VectorFieldLayoutAlgorithm.cs
+++ b/src/tools/crossgen2/Common/Compiler/VectorFieldLayoutAlgorithm.cs
@@ -106,5 +106,10 @@ namespace ILCompiler
                 type.Name == "Vector128`1" ||
                 type.Name == "Vector256`1");
         }
+
+        public static bool IsVectorOfTType(DefType type)
+        {
+            return type.IsIntrinsic && type.Namespace == "System.Numerics" && type.Name == "Vector`1";
+        }
     }
 }

--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -697,6 +697,13 @@ namespace Internal.JitInterface
                 result |= CorInfoFlag.CORINFO_FLG_FINAL;
             }
 
+            // Check for SIMD intrinsics
+            if (method.OwningType.IsIntrinsic && method.OwningType is MetadataType mdType && 
+                (mdType.Name == "Vector`1") && (mdType.Namespace == "System.Numerics"))
+            {
+                throw new RequiresRuntimeJitException("This function is using SIMD intrinsics, their size is machine specific");
+            }
+
             // Check for hardware intrinsics
             if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(method))
             {

--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -697,12 +697,14 @@ namespace Internal.JitInterface
                 result |= CorInfoFlag.CORINFO_FLG_FINAL;
             }
 
+#if READYTORUN
             // Check for SIMD intrinsics
-            if (method.OwningType.IsIntrinsic && method.OwningType is MetadataType mdType && 
-                (mdType.Name == "Vector`1") && (mdType.Namespace == "System.Numerics"))
+            DefType owningDefType = method.OwningType as DefType;
+            if (owningDefType != null && VectorFieldLayoutAlgorithm.IsVectorOfTType(owningDefType))
             {
                 throw new RequiresRuntimeJitException("This function is using SIMD intrinsics, their size is machine specific");
             }
+#endif
 
             // Check for hardware intrinsics
             if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(method))

--- a/src/tools/crossgen2/Common/JitInterface/SystemVStructClassificator.cs
+++ b/src/tools/crossgen2/Common/JitInterface/SystemVStructClassificator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using ILCompiler;
 using Internal.TypeSystem;
 
 namespace Internal.JitInterface
@@ -261,16 +262,8 @@ namespace Internal.JitInterface
                 InstantiatedType instantiatedType = typeDesc as InstantiatedType;
                 if (instantiatedType != null)
                 {
-                    string typeName = instantiatedType.Name;
-                    string namespaceName = instantiatedType.Namespace;
-
-                    if (typeName == "Vector256`1" || typeName == "Vector128`1" || typeName == "Vector64`1")
-                    {
-                        Debug.Assert(namespaceName == "System.Runtime.Intrinsics");
-                        return false;
-                    }
-
-                    if ((typeName ==  "Vector`1") && (namespaceName == "System.Numerics"))
+                    if (VectorFieldLayoutAlgorithm.IsVectorType(instantiatedType) ||
+                        VectorFieldLayoutAlgorithm.IsVectorOfTType(instantiatedType))
                     {
                         return false;
                     }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -45,7 +45,7 @@ namespace ILCompiler
                 throw new NotImplementedException();
             else if (type.IsRuntimeDeterminedType)
                 throw new NotImplementedException();
-            else if (type.IsIntrinsic && (type.Name == "Vector`1") && (type.Namespace == "System.Numerics"))
+            else if (VectorIntrinsicFieldLayoutAlgorithm.IsVectorOfTType(type))
             {
                 return _vectorFieldLayoutAlgorithm;
             }


### PR DESCRIPTION
Crossgen2 was compiling methods that call SIMD intrinsics
(System.Numerics.Vector<T>). This is not correct, as the size of the
vector is a runtime specific detail - e.g. when running on devices
without SSE2 support, the size is 4 and when running on devices with
SSE2 support, the size is 8.
So methods that call SIMD intrinsics should not be crossgened.
This fixes runtime errors in 6 coreclr pri 0 tests.