### PR TITLE
Make SuperILC execute .cmd/.sh only

### DIFF
--- a/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
@@ -59,13 +59,10 @@ namespace ReadyToRun.SuperIlc
 
             if (!options.NoExe)
             {
-                HashSet<string> scriptedExecutables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
                 foreach (string script in _executionScripts ?? Enumerable.Empty<string>())
                 {
                     ProcessInfo[] scriptExecutions = new ProcessInfo[(int)CompilerIndex.Count];
                     _executions.Add(scriptExecutions);
-                    scriptedExecutables.Add(Path.ChangeExtension(script, ".exe"));
 
                     foreach (CompilerRunner runner in compilerRunners)
                     {
@@ -79,35 +76,6 @@ namespace ReadyToRun.SuperIlc
                         folders.UnionWith(runner.ReferenceFolders);
 
                         scriptExecutions[(int)runner.Index] = new ProcessInfo(new ScriptExecutionProcessConstructor(runner, _outputFolder, script, modules, folders));
-                    }
-                }
-
-                if (options.CoreRootDirectory != null)
-                {
-                    foreach (string mainExe in _mainExecutables ?? Enumerable.Empty<string>())
-                    {
-                        if (scriptedExecutables.Contains(mainExe))
-                        {
-                            // Skip direct exe launch assuming it was run by the corresponding cmd script
-                            continue;
-                        }
-
-                        ProcessInfo[] appExecutions = new ProcessInfo[(int)CompilerIndex.Count];
-                        _executions.Add(appExecutions);
-                        foreach (CompilerRunner runner in compilerRunners)
-                        {
-                            HashSet<string> modules = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                            HashSet<string> folders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-                            modules.Add(mainExe);
-                            modules.Add(runner.GetOutputFileName(_outputFolder, mainExe));
-                            modules.UnionWith(_compilationInputFiles);
-                            modules.UnionWith(_compilationInputFiles.Select(file => runner.GetOutputFileName(_outputFolder, file)));
-                            folders.Add(Path.GetDirectoryName(mainExe));
-                            folders.UnionWith(runner.ReferenceFolders);
-
-                            appExecutions[(int)runner.Index] = new ProcessInfo(new AppExecutionProcessConstructor(runner, _outputFolder, mainExe, modules, folders));
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Until now, SuperILC was executing both .cmd/.sh files of tests and .exe
files it has found in the test folders that didn't match the .cmd/.sh
file names. This is different from how coreclr tests are run in regular
test runs. Only the .cmd/.sh files should be executed, the .exe files
with names not matching the .cmd/.sh files are always just helper
applications used by the tests and not the main test executables.
This change updates SuperILC to execute only the .cmd / .sh, thus
getting rid of about 5 failures from the coreclr pri 1 test runs.