### PR TITLE
Remove exclusion of two runtime assemblies from build in SuperILC

### DIFF
--- a/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -44,10 +44,6 @@ namespace ReadyToRun.SuperIlc
 
             // TODO (TRylek): problem related to devirtualization of method without IL - System.Enum.Equals(object)
             new FrameworkExclusion("System.ComponentModel.TypeConverter", "TODO trylek - devirtualization of method without IL", crossgen2Only: true),
-
-            // TODO: additional framework build failures
-            new FrameworkExclusion("Microsoft.Diagnostics.Tracing.TraceEvent", "Assert failure in JIT", crossgen2Only: true),
-            new FrameworkExclusion("System.Private.CoreLib", "Assert failure in JIT", crossgen2Only: true),
         };
 
         private readonly IEnumerable<BuildFolder> _buildFolders;


### PR DESCRIPTION
The System.Private.CoreLib builds fine using crossgen2 now (I've been
building it locally for a couple of weeks already).
I've also tried to remove exclusion of the
Microsoft.Diagnostics.Tracing.TraceEvent and it is passing now as well.