### PR TITLE
Add assembly resolution attempt events

### DIFF
--- a/src/binder/clrprivbindercoreclr.cpp
+++ b/src/binder/clrprivbindercoreclr.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "common.h"
+#include "bindertracing.h"
 #include "assemblybinder.hpp"
 #include "clrprivbindercoreclr.h"
 
@@ -57,48 +58,58 @@ HRESULT CLRPrivBinderCoreCLR::BindAssemblyByName(IAssemblyName     *pIAssemblyNa
         ReleaseHolder<AssemblyName> pAssemblyName;
 
         SAFE_NEW(pAssemblyName, AssemblyName);
-        IF_FAIL_GO(pAssemblyName->Init(pIAssemblyName));
 
-        hr = BindAssemblyByNameWorker(pAssemblyName, &pCoreCLRFoundAssembly, false /* excludeAppPaths */);
-
-#if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
-        if ((hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)) ||
-            (hr == FUSION_E_APP_DOMAIN_LOCKED) || (hr == FUSION_E_REF_DEF_MISMATCH))
+        if (SUCCEEDED(pAssemblyName->Init(pIAssemblyName)))
         {
-            // If we are here, one of the following is possible:
-            //
-            // 1) The assembly has not been found in the current binder's application context (i.e. it has not already been loaded), OR
-            // 2) An assembly with the same simple name was already loaded in the context of the current binder but we ran into a Ref/Def
-            //    mismatch (either due to version difference or strong-name difference).
-            //
-            // Thus, if default binder has been overridden, then invoke it in an attempt to perform the binding for it make the call
-            // of what to do next. The host-overridden binder can either fail the bind or return reference to an existing assembly
-            // that has been loaded.
+            BinderTracing::ResolutionAttemptedOperation tracer{pAssemblyName};
 
-            // Attempt to resolve the assembly via managed TPA ALC instance if one exists
-            INT_PTR pManagedAssemblyLoadContext = GetManagedAssemblyLoadContext();
-            if (pManagedAssemblyLoadContext != NULL)
+            tracer.Trace(BinderTracing::ResolutionAttemptedOperation::Stage::FindInLoadContext);
+
+            hr = BindAssemblyByNameWorker(pAssemblyName, &pCoreCLRFoundAssembly, false /* excludeAppPaths */);
+#if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
+            if ((hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)) ||
+                (hr == FUSION_E_APP_DOMAIN_LOCKED) || (hr == FUSION_E_REF_DEF_MISMATCH))
             {
-                hr = AssemblyBinder::BindUsingHostAssemblyResolver(pManagedAssemblyLoadContext, pAssemblyName, pIAssemblyName,
-                                                                   NULL, &pCoreCLRFoundAssembly);
-                if (SUCCEEDED(hr))
+                // If we are here, one of the following is possible:
+                //
+                // 1) The assembly has not been found in the current binder's application context (i.e. it has not already been loaded), OR
+                // 2) An assembly with the same simple name was already loaded in the context of the current binder but we ran into a Ref/Def
+                //    mismatch (either due to version difference or strong-name difference).
+                //
+                // Thus, if default binder has been overridden, then invoke it in an attempt to perform the binding for it make the call
+                // of what to do next. The host-overridden binder can either fail the bind or return reference to an existing assembly
+                // that has been loaded.
+
+                // Attempt to resolve the assembly via managed TPA ALC instance if one exists
+                INT_PTR pManagedAssemblyLoadContext = GetManagedAssemblyLoadContext();
+                if (pManagedAssemblyLoadContext != NULL)
                 {
-                    // We maybe returned an assembly that was bound to a different AssemblyLoadContext instance.
-                    // In such a case, we will not overwrite the binding context (which would be wrong since it would not
-                    // be present in the cache of the current binding context).
-                    if (pCoreCLRFoundAssembly->GetBinder() == NULL)
+                    tracer.Trace(BinderTracing::ResolutionAttemptedOperation::Stage::ALCLoad,
+                                 pManagedAssemblyLoadContext);
+
+                    hr = AssemblyBinder::BindUsingHostAssemblyResolver(pManagedAssemblyLoadContext, pAssemblyName, pIAssemblyName,
+                                                                       NULL, &pCoreCLRFoundAssembly);
+                    if (SUCCEEDED(hr))
                     {
-                        pCoreCLRFoundAssembly->SetBinder(this);
+                        // We maybe returned an assembly that was bound to a different AssemblyLoadContext instance.
+                        // In such a case, we will not overwrite the binding context (which would be wrong since it would not
+                        // be present in the cache of the current binding context).
+                        if (pCoreCLRFoundAssembly->GetBinder() == NULL)
+                        {
+                            pCoreCLRFoundAssembly->SetBinder(this);
+                        }
                     }
                 }
             }
-        }
 #endif // !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
 
-        IF_FAIL_GO(hr);
+            tracer.SetResult(hr, pCoreCLRFoundAssembly);
 
-        *ppAssembly = pCoreCLRFoundAssembly.Extract();
-
+            if (SUCCEEDED(hr))
+            {
+                *ppAssembly = pCoreCLRFoundAssembly.Extract();
+            }
+        }
 Exit:;
     }
     EX_CATCH_HRESULT(hr);

--- a/src/binder/inc/bindertracing.h
+++ b/src/binder/inc/bindertracing.h
@@ -8,6 +8,7 @@
 #ifndef __BINDER_TRACING_H__
 #define __BINDER_TRACING_H__
 
+class Assembly;
 class AssemblySpec;
 class PEAssembly;
 
@@ -48,6 +49,61 @@ namespace BinderTracing
 
         ReleaseHolder<PEAssembly> m_resultAssembly;
         bool m_cached;
+    };
+
+
+    class ResolutionAttemptedOperation
+    {
+    private:
+        enum class Result : uint16_t
+        {
+            Attempt,
+            Success,
+            AssemblyNotFound,
+            MismatchedAssemblyName,
+            IncompatibleVersion,
+            Unknown,
+        };
+
+    public:
+        enum class Stage : uint16_t
+        {
+            NotYetStarted,
+            FindInLoadContext,
+            ALCLoad,
+            PlatformAssemblies,
+            DefaultALCFallback,
+            AppDomainAssemblyResolveEvent,
+        };
+
+        struct ResolutionAttempt
+        {
+            SString AssemblyName;
+            uint16_t Stage;
+            uint16_t Result;
+            SString ResultAssemblyName;
+            SString ResultAssemblyPath;
+            SString ErrorMessage;
+            SString AssemblyLoadContext;
+        };
+
+        ResolutionAttemptedOperation(BINDER_SPACE::AssemblyName *assemblyName);
+        ~ResolutionAttemptedOperation();
+
+        void SetResult(HRESULT hr, BINDER_SPACE::Assembly *assembly);
+
+        void Trace(Stage s, INT_PTR managedALC=0, AssemblySpec *assemblySpec=nullptr);
+
+    private:
+        BINDER_SPACE::AssemblyName *m_pAssemblyName;
+        Stage m_stage{Stage::NotYetStarted};
+
+        BINDER_SPACE::Assembly *m_pFoundAssembly{nullptr};
+        AssemblySpec *m_pAssemblySpec{nullptr};
+        INT_PTR m_pManagedALC{0};
+        Result m_result{Result::Attempt};
+
+        void TraceCurrentStage();
     };
 };
 

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -478,6 +478,20 @@
                       <map value="0x7" message="$(string.RuntimePublisher.GCHandleKind.AsyncPinnedMessage)"/>
                       <map value="0x8" message="$(string.RuntimePublisher.GCHandleKind.SizedRefMessage)"/>
                     </valueMap>
+                    <valueMap name="ResolutionAttemptedStageMap">
+                      <map value="0x0" message="$(string.RuntimePublisher.ResolutionAttempted.FindInLoadContext)"/>
+                      <map value="0x1" message="$(string.RuntimePublisher.ResolutionAttempted.AssemblyLoadContextLoad)"/>
+                      <map value="0x2" message="$(string.RuntimePublisher.ResolutionAttempted.PlatformAssemblies)"/>
+                      <map value="0x3" message="$(string.RuntimePublisher.ResolutionAttempted.DefaultAssemblyLoadContextFallback)"/>
+                      <map value="0x4" message="$(string.RuntimePublisher.ResolutionAttempted.AssemblyLoadContextResovingEvent)"/>
+                      <map value="0x5" message="$(string.RuntimePublisher.ResolutionAttempted.AppDomainAssemblyResolveEvent)"/>
+                    </valueMap>
+                    <valueMap name="ResolutionAttemptedResultMap">
+                      <map value="0x0" message="$(string.RuntimePublisher.ResolutionAttempted.Success)"/>
+                      <map value="0x1" message="$(string.RuntimePublisher.ResolutionAttempted.AssemblyNotFound)"/>
+                      <map value="0x2" message="$(string.RuntimePublisher.ResolutionAttempted.MismatchedAssemblyName)"/>
+                      <map value="0x3" message="$(string.RuntimePublisher.ResolutionAttempted.IncompatibleVersion)"/>
+                    </valueMap>
 
                     <!-- BitMaps -->
                     <bitMap name="ModuleRangeTypeMap">
@@ -1758,6 +1772,29 @@
                                 <RequestingAssemblyName> %4 </RequestingAssemblyName>
                                 <ComputedRequestedAssemblyPath> %5 </ComputedRequestedAssemblyPath>
                             </AssemblyLoadFromResolveHandlerInvoked>
+                        </UserData>
+                    </template>
+
+                    <template tid="ResolutionAttempted">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="AssemblyName" inType="win:UnicodeString" />
+                        <data name="Stage" map="ResolutionAttemptedStageMap" inType="win:UInt16" />
+                        <data name="AssemblyLoadContext" inType="win:UnicodeString" />
+                        <data name="Result" map="ResolutionAttemptedResultMap" inType="win:UInt16" />
+                        <data name="ResultAssemblyName" inType="win:UnicodeString" />
+                        <data name="ResultAssemblyPath" inType="win:UnicodeString" />
+                        <data name="ErrorMessage" inType="win:UnicodeString" />
+                        <UserData>
+                            <ResolutionAttempted xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <AssemblyName> %2 </AssemblyName>
+                                <Stage> %3 </Stage>
+                                <AssemblyLoadContext> %4 </AssemblyLoadContext>
+                                <Result> %5 </Result>
+                                <ResultAssemblyName> %6 </ResultAssemblyName>
+                                <ResultAssemblyPath> %7 </ResultAssemblyPath>
+                                <ErrorMessage> %8 </ErrorMessage>
+                            </ResolutionAttempted>
                         </UserData>
                     </template>
 
@@ -3572,6 +3609,11 @@
                            keywords ="AssemblyLoaderKeyword" opcode="AssemblyLoadFromResolveHandlerInvoked"
                            task="AssemblyLoader"
                            symbol="AssemblyLoadFromResolveHandlerInvoked" message="$(string.RuntimePublisher.AssemblyLoadFromResolveHandlerInvokedEventMessage)"/>
+
+                    <event value="296" version="0" level="win:Informational"  template="ResolutionAttempted"
+                           keywords ="AssemblyLoaderKeyword" opcode="win:Resolve"
+                           task="AssemblyLoader"
+                           symbol="ResolutionAttempted" message="$(string.RuntimePublisher.ResolutionAttempted)"/>
 
                 </events>
             </provider>
@@ -6773,6 +6815,7 @@
                 <string id="RuntimePublisher.AssemblyLoadContextResolvingHandlerInvokedEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nHandlerName=%3;%nAssemblyLoadContext=%4;%nResultAssemblyName=%5;%nResultAssemblyPath=%6" />
                 <string id="RuntimePublisher.AppDomainAssemblyResolveHandlerInvokedEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nHandlerName=%3;%nResultAssemblyName=%4;%nResultAssemblyPath=%5" />
                 <string id="RuntimePublisher.AssemblyLoadFromResolveHandlerInvokedEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nIsTrackedLoad=%3;%nRequestingAssemblyPath=%4;%nComputedRequestedAssemblyPath=%5" />
+                <string id="RuntimePublisher.ResolutionAttemptedEventMessage" value="ClrInstanceID=%1;%nAssemblyName=%2;%nStage=%3;%nAssemblyLoadContext=%4;%nResult=%5;%nResultAssemblyName=%6;%nResultAssemblyPath=%7;%nErrorMessage=%8" />
                 <string id="RuntimePublisher.StackEventMessage" value="ClrInstanceID=%1;%nReserved1=%2;%nReserved2=%3;%nFrameCount=%4;%nStack=%5" />
                 <string id="RuntimePublisher.AppDomainMemAllocatedEventMessage" value="AppDomainID=%1;%nAllocated=%2;%nClrInstanceID=%3" />
                 <string id="RuntimePublisher.AppDomainMemSurvivedEventMessage" value="AppDomainID=%1;%nSurvived=%2;%nProcessSurvived=%3;%nClrInstanceID=%4" />
@@ -6803,7 +6846,16 @@
                 <string id="RuntimePublisher.TieredCompilationResumeEventMessage" value="ClrInstanceID=%1;%nNewMethodCount=%2" />
                 <string id="RuntimePublisher.TieredCompilationBackgroundJitStartEventMessage" value="ClrInstanceID=%1;%nPendingMethodCount=%2" />
                 <string id="RuntimePublisher.TieredCompilationBackgroundJitStopEventMessage" value="ClrInstanceID=%1;%nPendingMethodCount=%2;%nJittedMethodCount=%3" />
-
+                <string id="RuntimePublisher.ResolutionAttempted.FindInLoadContext" value="NONE" />
+                <string id="RuntimePublisher.ResolutionAttempted.AssemblyLoadContextLoad" value="NONE" />
+                <string id="RuntimePublisher.ResolutionAttempted.PlatformAssemblies" value="NONE" />
+                <string id="RuntimePublisher.ResolutionAttempted.DefaultAssemblyLoadContextFallback" value="NONE" />
+                <string id="RuntimePublisher.ResolutionAttempted.AssemblyLoadContextResolvingEvent" value="NONE" />
+                <string id="RuntimePublisher.ResolutionAttempted.AppDomainAssemblyResolveEvent" value="NONE" />
+                <string id="RuntimePublisher.ResolutionAttempted.Success" value="NONE" />
+                <string id="RuntimePublisher.ResolutionAttempted.AssemblyNotFound" value="NONE" />
+                <string id="RuntimePublisher.ResolutionAttempted.MismatchedAssemblyName" value="NONE" />
+                <string id="RuntimePublisher.ResolutionAttempted.IncompatibleVersion" value="NONE" />
                 <string id="RundownPublisher.MethodDCStartEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6" />
                 <string id="RundownPublisher.MethodDCStart_V1EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nClrInstanceID=%7" />
                 <string id="RundownPublisher.MethodDCStart_V2EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nClrInstanceID=%7;%nReJITID=%8" />


### PR DESCRIPTION
These events are fired every time there's an attempt at resolving an
assembly before it is loaded.  Events are fired when trying to find the
assembly in the current load context, using a custom
AssemblyLoadContext, looking in the TPA, and so on.  Results are either
success, or a more descriptive value (e.g. assembly not found, or
incompatible version).