### PR TITLE
Fix RHEL6 build

### DIFF
--- a/functions.cmake
+++ b/functions.cmake
@@ -289,7 +289,7 @@ function(strip_symbols targetName outputFilename skipStrip)
   endif(CLR_CMAKE_PLATFORM_UNIX)
 endfunction()
 
-# install_clr(TARGETS TARGETS targetName [targetName2 ...] [DESTINATION destination])
+# install_clr(TARGETS TARGETS targetName [targetName2 ...] [DESTINATION destination] [SKIP_STRIP])
 function(install_clr)
   set(options SKIP_STRIP)
   set(oneValueArgs DESTINATION)

--- a/functions.cmake
+++ b/functions.cmake
@@ -250,7 +250,7 @@ function(target_precompile_header)
   endif(MSVC)
 endfunction()
 
-function(strip_symbols targetName outputFilename)
+function(strip_symbols targetName outputFilename skipStrip)
   if (CLR_CMAKE_PLATFORM_UNIX)
     if (STRIP_SYMBOLS)
       set(strip_source_file $<TARGET_FILE:${targetName}>)
@@ -258,26 +258,30 @@ function(strip_symbols targetName outputFilename)
       if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
         set(strip_destination_file ${strip_source_file}.dwarf)
 
-        add_custom_command(
-          TARGET ${targetName}
-          POST_BUILD
-          VERBATIM
-          COMMAND ${DSYMUTIL} --flat --minimize ${strip_source_file}
-          COMMAND ${STRIP} -S ${strip_source_file}
-          COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
-        )
+        if(NOT ${skipStrip})
+            add_custom_command(
+            TARGET ${targetName}
+            POST_BUILD
+            VERBATIM
+            COMMAND ${DSYMUTIL} --flat --minimize ${strip_source_file}
+            COMMAND ${STRIP} -S ${strip_source_file}
+            COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
+            )
+        endif()
       else (CMAKE_SYSTEM_NAME STREQUAL Darwin)
         set(strip_destination_file ${strip_source_file}.dbg)
 
-        add_custom_command(
-          TARGET ${targetName}
-          POST_BUILD
-          VERBATIM
-          COMMAND ${OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
-          COMMAND ${OBJCOPY} --strip-debug ${strip_source_file}
-          COMMAND ${OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
-          COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
-        )
+        if(NOT ${skipStrip})
+            add_custom_command(
+            TARGET ${targetName}
+            POST_BUILD
+            VERBATIM
+            COMMAND ${OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
+            COMMAND ${OBJCOPY} --strip-debug ${strip_source_file}
+            COMMAND ${OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
+            COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
+            )
+        endif()
       endif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
       set(${outputFilename} ${strip_destination_file} PARENT_SCOPE)
@@ -287,7 +291,7 @@ endfunction()
 
 # install_clr(TARGETS TARGETS targetName [targetName2 ...] [DESTINATION destination])
 function(install_clr)
-  set(options "")
+  set(options SKIP_STRIP)
   set(oneValueArgs DESTINATION)
   set(multiValueArgs TARGETS)
   cmake_parse_arguments(PARSE_ARGV 0 INSTALL_CLR "${options}" "${oneValueArgs}" "${multiValueArgs}")
@@ -303,7 +307,10 @@ function(install_clr)
   foreach(targetName ${INSTALL_CLR_TARGETS})
     list(FIND CLR_CROSS_COMPONENTS_LIST ${targetName} INDEX)
     if (NOT DEFINED CLR_CROSS_COMPONENTS_LIST OR NOT ${INDEX} EQUAL -1)
-        strip_symbols(${targetName} strip_destination_file)
+        if("${INSTALL_CLR_SKIP_STRIP}" STREQUAL "")
+            set(INSTALL_CLR_SKIP_STRIP FALSE)
+        endif()
+        strip_symbols(${targetName} strip_destination_file ${INSTALL_CLR_SKIP_STRIP})
 
         # We don't need to install the export libraries for our DLLs
         # since they won't be directly linked against.

--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -93,5 +93,5 @@ verify_dependencies(
 
 # add the install targets
 install_clr(TARGETS System.Globalization.Native)
-install_clr(TARGETS System.Globalization.Native DESTINATION sharedFramework)
+install_clr(TARGETS System.Globalization.Native DESTINATION sharedFramework SKIP_STRIP)
 install(TARGETS System.Globalization.Native_Static DESTINATION .)

--- a/src/dlls/clretwrc/CMakeLists.txt
+++ b/src/dlls/clretwrc/CMakeLists.txt
@@ -21,6 +21,6 @@ add_library_clr(clretwrc SHARED
 
 # add the install targets
 install_clr(TARGETS clretwrc)
-install_clr(TARGETS clretwrc DESTINATION sharedFramework)
+install_clr(TARGETS clretwrc DESTINATION sharedFramework SKIP_STRIP)
 
 add_dependencies(clretwrc eventing_headers)

--- a/src/dlls/dbgshim/CMakeLists.txt
+++ b/src/dlls/dbgshim/CMakeLists.txt
@@ -82,4 +82,4 @@ target_link_libraries(dbgshim ${DBGSHIM_LIBRARIES})
 
 # add the install targets
 install_clr(TARGETS dbgshim)
-install_clr(TARGETS dbgshim DESTINATION sharedFramework)
+install_clr(TARGETS dbgshim DESTINATION sharedFramework SKIP_STRIP)

--- a/src/dlls/mscordac/CMakeLists.txt
+++ b/src/dlls/mscordac/CMakeLists.txt
@@ -185,7 +185,7 @@ target_link_libraries(mscordaccore PRIVATE ${COREDAC_LIBRARIES})
 
 # add the install targets
 install_clr(TARGETS mscordaccore)
-install_clr(TARGETS mscordaccore DESTINATION sharedFramework)
+install_clr(TARGETS mscordaccore DESTINATION sharedFramework SKIP_STRIP)
 if(WIN32)
     set(LONG_NAME_HOST_ARCH ${CLR_CMAKE_HOST_ARCH})
     set(LONG_NAME_TARGET_ARCH ${CLR_CMAKE_TARGET_ARCH})

--- a/src/dlls/mscordbi/CMakeLists.txt
+++ b/src/dlls/mscordbi/CMakeLists.txt
@@ -119,4 +119,4 @@ endif(WIN32)
 
 # add the install targets
 install_clr(TARGETS mscordbi)
-install_clr(TARGETS mscordbi DESTINATION sharedFramework)
+install_clr(TARGETS mscordbi DESTINATION sharedFramework SKIP_STRIP)

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -203,7 +203,7 @@ endif(WIN32)
 
 # add the install targets
 install_clr(TARGETS coreclr)
-install_clr(TARGETS coreclr DESTINATION sharedFramework)
+install_clr(TARGETS coreclr DESTINATION sharedFramework SKIP_STRIP)
 
 # Enable profile guided optimization
 add_pgo(coreclr)

--- a/src/dlls/mscorrc/full/CMakeLists.txt
+++ b/src/dlls/mscorrc/full/CMakeLists.txt
@@ -7,7 +7,7 @@ if(WIN32)
   )
 
   install_clr(TARGETS mscorrc.debug)
-  install_clr(TARGETS mscorrc.debug DESTINATION sharedFramework)
+  install_clr(TARGETS mscorrc.debug DESTINATION sharedFramework SKIP_STRIP)
 
 else()
   build_resources(${CMAKE_CURRENT_SOURCE_DIR}/../include.rc mscorrc_debug TARGET_CPP_FILE)

--- a/src/dlls/mscorrc/small/CMakeLists.txt
+++ b/src/dlls/mscorrc/small/CMakeLists.txt
@@ -5,4 +5,4 @@ add_library_clr(mscorrc SHARED
 )
 
 install_clr(TARGETS mscorrc)
-install_clr(TARGETS mscorrc DESTINATION sharedFramework)
+install_clr(TARGETS mscorrc DESTINATION sharedFramework SKIP_STRIP)

--- a/src/jit/standalone/CMakeLists.txt
+++ b/src/jit/standalone/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(clrjit
 
 # add the install targets
 install_clr(TARGETS clrjit)
-install_clr(TARGETS clrjit DESTINATION sharedFramework)
+install_clr(TARGETS clrjit DESTINATION sharedFramework SKIP_STRIP)
 
 # Enable profile guided optimization
 add_pgo(clrjit)

--- a/src/tools/crossgen/CMakeLists.txt
+++ b/src/tools/crossgen/CMakeLists.txt
@@ -71,4 +71,4 @@ add_subdirectory(../../vm/crossgen ../../vm/crossgen)
 
 # add the install targets
 install_clr(TARGETS crossgen)
-install_clr(TARGETS crossgen DESTINATION sharedFramework)
+install_clr(TARGETS crossgen DESTINATION sharedFramework SKIP_STRIP)


### PR DESCRIPTION
Make stripping symbols overridable at `install_clr` invocation to avoid double-stripping symbols.

I've validated that the build passes locally with this change.