### PR TITLE
Use git bundles

### DIFF
--- a/eng/pipelines/templates/checkout-job.yml
+++ b/eng/pipelines/templates/checkout-job.yml
@@ -5,13 +5,13 @@
 ### and OSX build clients don't have 7-zip installed) and simplify other details such
 ### as line endings.
 jobs:
-- job: 'checkout_windows'
-  displayName: 'Checkout (Windows)'
+- job: checkout
+  displayName: Checkout
 
   pool:
     # Public Windows Build Pool
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      vmImage: 'windows-latest'
+      vmImage: windows-latest
 
     # Private Windows Build Pool
     ${{ if ne(variables['System.TeamProject'], 'public') }}:
@@ -23,42 +23,9 @@ jobs:
     clean: true
     fetchDepth: 5
 
-  ### Zip up downloaded repo and publish to Helix
-  - template: upload-artifact-step.yml
-    parameters:
-      displayName: 'GIT repository (Windows)'
-      rootFolder: $(Build.SourcesDirectory)
-      includeRootFolder: false
-      archiveType: 'zip'
-      tarCompression: ''
-      archiveExtension: '.zip'
-      artifactName: repo_windows
+  - script: git bundle create $(Build.StagingDirectory)/Checkout.bundle HEAD
+    displayName: Create Checkout.bundle
 
-- job: 'checkout_unix'
-  displayName: 'Checkout (Unix)'
-
-  pool:
-    # Public Linux Build Pool
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      vmImage: 'ubuntu-latest'
-
-    # Private Linux Build Pool
-    ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      name: NetCoreInternal-Pool
-      queue: BuildPool.Ubuntu.1604.Amd64
-
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
-
-  ### Zip up downloaded repo and publish to Helix
-  - template: upload-artifact-step.yml
-    parameters:
-      displayName: 'GIT repository (Unix)'
-      rootFolder: $(Build.SourcesDirectory)
-      includeRootFolder: false
-      archiveType: 'tar'
-      tarCompression: 'gz'
-      archiveExtension: '.tar.gz'
-      artifactName: repo_unix
+  - publish: $(Build.StagingDirectory)/Checkout.bundle
+    artifact: Checkout_bundle
+    displayName: Upload Checkout.bundle

--- a/eng/pipelines/templates/checkout-job.yml
+++ b/eng/pipelines/templates/checkout-job.yml
@@ -9,14 +9,11 @@ jobs:
   displayName: Checkout
 
   pool:
-    # Public Windows Build Pool
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      vmImage: windows-latest
+      name: Hosted MacOS
 
-    # Private Windows Build Pool
     ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      name: NetCoreInternal-Pool
-      queue: BuildPool.Windows.10.Amd64.VS2017
+      name: Hosted Mac Internal
   
   steps:
   - checkout: self

--- a/eng/pipelines/templates/xplat-job.yml
+++ b/eng/pipelines/templates/xplat-job.yml
@@ -31,10 +31,7 @@ jobs:
     condition: ${{ parameters.condition }}
     dependsOn:
       - ${{ if ne(parameters.stagedBuild, true) }}:
-        - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-          - 'checkout_windows'
-        - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-          - 'checkout_unix'
+        - checkout
       - ${{ if ne(parameters.dependsOn, '') }}:
         - ${{ parameters.dependsOn }}
 
@@ -167,17 +164,13 @@ jobs:
     - checkout: none
       clean: true
 
-    # Download the GIT repository
-    - template: download-artifact-step.yml
-      parameters:
-        displayName: 'GIT repository'
-        cleanUnpackFolder: false
-        unpackFolder: $(Build.SourcesDirectory)
-        ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-          artifactFileName: repo_windows.zip
-          artifactName: repo_windows
-        ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-          artifactFileName: repo_unix.tar.gz
-          artifactName: repo_unix
+    - download: current
+      artifact: Checkout_bundle
+      displayName: Download Checkout.bundle
+
+    - script: |
+        git clone $(Pipeline.Workspace)/Checkout_bundle/Checkout.bundle .
+        git remote set-url origin $(Build.Repository.Uri)
+      displayName: Clone the repository from Checkout.bundle
 
     - ${{ parameters.steps }}


### PR DESCRIPTION
The goal here is to get rid of two separate Windows and non-Windows checkout jobs (and have one instead) and use the git bundle to move the repo clone between CI jobs. 