### PR TITLE
Return compGetTieringName printing.

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -6139,7 +6139,7 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE            classPtr,
 #ifdef DEBUG
     if (JitConfig.DumpJittedMethods() == 1 && !compIsForInlining())
     {
-        printf("Compiling %4d %s::%s, IL size = %u, hash=%08x\n", Compiler::jitTotalMethodCompiled, info.compClassName,
+        printf("Compiling %4d %s::%s, IL size = %u, hash=%08x %s\n", Compiler::jitTotalMethodCompiled, info.compClassName,
                info.compMethodName, info.compILCodeSize, info.compMethodHash(), compGetTieringName());
     }
     if (compIsForInlining())


### PR DESCRIPTION
I believe that was deleted by mistake in https://github.com/dotnet/coreclr/pull/27147.
Return it back.

