### PR TITLE
Move helixpublishwitharcade.proj one directory higher

### DIFF
--- a/eng/pipelines/templates/run-test-job.yml
+++ b/eng/pipelines/templates/run-test-job.yml
@@ -259,7 +259,7 @@ jobs:
         ${{ if eq(parameters.corefxTests, true) }}:
           helixProjectArguments: '$(Build.SourcesDirectory)/eng/helixcorefxtests.proj'
         ${{ if ne(parameters.corefxTests, true) }}:
-          helixProjectArguments: '$(coreClrRepoRoot)/tests/src/helixpublishwitharcade.proj'
+          helixProjectArguments: '$(coreClrRepoRoot)/tests/helixpublishwitharcade.proj'
 
         ${{ if in(parameters.testGroup, 'innerloop', 'outerloop') }}:
           scenarios:

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -26,6 +26,7 @@
     <BinDir>$(__BinDir)\</BinDir>
     <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)Product\$(BuildOS).$(BuildArch).$(BuildType)\</BinDir>
 
+    <TestWorkingDir>$(__TestWorkingDir)\</TestWorkingDir>
     <TestWorkingDir Condition="'$(__TestWorkingDir)'==''">$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\</TestWorkingDir>
 
     <AltJitArch>$(__AltJitArch)</AltJitArch>

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -58,14 +58,14 @@
   </Target>
 
   <PropertyGroup>
-    <BinDir>$([MSBuild]::NormalizeDirectory($(BinDir)))</BinDir>
+    <BinDir>$([MSBuild]::NormalizeDirectory($(TestWorkingDir)))</BinDir>
     <CoreRootDirectory>$(BinDir)Tests\Core_Root\</CoreRootDirectory>
     <PayloadsRootDirectory>$(BinDir)Payloads\</PayloadsRootDirectory>
     <TestEnvFileName Condition=" '$(TargetsWindows)' == 'true' ">SetStressModes_$(Scenario).cmd</TestEnvFileName>
     <TestEnvFileName Condition=" '$(TargetsWindows)' != 'true' ">SetStressModes_$(Scenario).sh</TestEnvFileName>
   </PropertyGroup>
 
-  <Import Project="../testgrouping.proj" />
+  <Import Project="testgrouping.proj" />
 
   <Target Name="DiscoverAllXUnitWrappers">
     <ItemGroup>
@@ -122,7 +122,7 @@
   </Target>
 
   <Target Name="PrepareCorrelationPayloadDirectory">
-    <MSBuild Projects="xunitconsolerunner.depproj" Targets="Restore" />
+    <MSBuild Projects="src\xunitconsolerunner.depproj" Targets="Restore" />
 
     <ItemGroup>
       <_XUnitConsoleRunnerFiles Include="$(NuGetPackageRoot)$(MicrosoftDotNetXUnitConsoleRunnerPackage)\$(MicrosoftDotNetXUnitConsoleRunnerVersion)\**\xunit.console.*" />
@@ -138,7 +138,7 @@
 
     <ItemGroup>
       <_PayloadGroups Include="$(PayloadGroups)" />
-      <_ProjectsToBuild Include="../testenvironment.proj">
+      <_ProjectsToBuild Include="testenvironment.proj">
         <Properties>Scenario=$(Scenario);TestEnvFileName=$(PayloadsRootDirectory)%(_PayloadGroups.Identity)\$(TestEnvFileName);TargetsWindows=$(TargetsWindows)</Properties>
       </_ProjectsToBuild>
     </ItemGroup>

--- a/tests/src/Directory.Build.props
+++ b/tests/src/Directory.Build.props
@@ -35,8 +35,6 @@
     <BuildProjectRelativeDir Condition="'$(MSBuildProjectDirectory.Contains($(SourceDir)))'">$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace($(SourceDir),''))\$(MSBuildProjectName)</BuildProjectRelativeDir>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(BuildProjectRelativeDir)\</IntermediateOutputPath>
     <OutputPath>$(BaseOutputPathWithConfig)$(BuildProjectRelativeDir)\</OutputPath>
-    <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(BaseOutputPath)\testStagingDir\</TestWorkingDir>
-    <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)\$(MSBuildProjectName)/</TestPath>
     <SkipXunitDependencyCopying>true</SkipXunitDependencyCopying>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #27508. After moving 'helixpublishwitharcade.proj' from 'tests' to 'tests\src' directory we inadvertently started generating the unused 'helixpublishwitharcade.cmd' file as the result of importing 'tests\src\Directory.Build.props'. Nothing in 'tests\src\Directory.Build.props' file is actually needed for 'helixpublishwitharcade.proj' besides setting the `BinDir` property.  This change moves 'helixpublishwitharcade.proj' back to the 'tests' directory and does a minor properties cleanup.