### PR TITLE
Do not fast tail call with callee stack space.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7325,9 +7325,13 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
         return false;
     }
 
-    if (calleeStackSize > callerStackSize)
+    // The callee has stack arguments. This may cause us to shuffle arguments in lowerFastTailCall.
+    // Do not fastTailCall.
+    //
+    // We never can safely shuffle arguments in LowerFastTailCall. See https://github.com/dotnet/coreclr/issues/12468.
+    if (calleeStackSize > 0)
     {
-        reportFastTailCallDecision("Will not fastTailCall calleeStackSize > callerStackSize", callerStackSize,
+        reportFastTailCallDecision("Will not fastTailCall calleeStackSize > 0", callerStackSize,
                                    calleeStackSize);
         return false;
     }


### PR DESCRIPTION
This change is pessimistic, but it will guarentee correctness.
We specifically know that LowerFastTailCall fundamentally is broken.
This has been fixed in https://github.com/dotnet/coreclr/pull/26255.
This change exists only to make sure that we do not have SBC in older releases.

Note that this changes behavoir, there are valid fast tail calls which could have avoided StackOverFlow exceptions.

These tail calls must have not had overlapping slot locations, for a flawed definition of slot location. Which simply means they got lucky when generating code.