### PR TITLE
Emit an Event for Every Tiered Compilation Call Counter Operation

### DIFF
--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -1201,7 +1201,7 @@ namespace ETW
                 static void SendResume(UINT32 newMethodCount);
                 static void SendBackgroundJitStart(UINT32 pendingMethodCount);
                 static void SendBackgroundJitStop(UINT32 pendingMethodCount, UINT32 jittedMethodCount);
-                static void SendIncrementMethodCallCounter(MethodDesc *pMethod, INT32 callCount);
+                static void SendIncrementMethodCallCounter(MethodDesc *pMethodDesc, INT32 callCount);
 #else
                 static bool IsEnabled() { return false; }
                 static void SendSettings() {}

--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -1201,6 +1201,7 @@ namespace ETW
                 static void SendResume(UINT32 newMethodCount);
                 static void SendBackgroundJitStart(UINT32 pendingMethodCount);
                 static void SendBackgroundJitStop(UINT32 pendingMethodCount, UINT32 jittedMethodCount);
+                static void SendIncrementMethodCallCounter(MethodDesc *pMethod, INT32 callCount);
 #else
                 static bool IsEnabled() { return false; }
                 static void SendSettings() {}

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -387,6 +387,7 @@
                             <opcode name="Settings" message="$(string.RuntimePublisher.TieredCompilationSettingsOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_SETTINGS_OPCODE" value="11"/>
                             <opcode name="Pause" message="$(string.RuntimePublisher.TieredCompilationPauseOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_PAUSE_OPCODE" value="12"/>
                             <opcode name="Resume" message="$(string.RuntimePublisher.TieredCompilationResumeOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_RESUME_OPCODE" value="13"/>
+                            <opcode name="Increment" message="$(string.RuntimePublisher.TieredCompilationIncrementOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_INCREMENT_OPCODE" value="14"/>
                         </opcodes>
                     </task>
 
@@ -2613,6 +2614,25 @@
                         </Settings>
                       </UserData>
                     </template>
+
+                    <template tid="TieredCompilationIncrementMethodCallCounter">
+                        <data name="MethodID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="MethodNamespace" inType="win:UnicodeString" />
+                        <data name="MethodName" inType="win:UnicodeString" />
+                        <data name="MethodSignature" inType="win:UnicodeString" />
+                        <data name="CounterValue" inType="win:Int32" />
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <UserData>
+                            <TieredCompilationIncrementMethodCallCounter xmlns="myNs">
+                                <MethodID> %1 </MethodID>
+                                <MethodNamespace> %2 </MethodNamespace>
+                                <MethodName> %3 </MethodName>
+                                <MethodSignature> %4 </MethodSignature>
+                                <CounterValue> %5 </CounterValue>
+                                <ClrInstanceID> %6 </ClrInstanceID>
+                            </TieredCompilationIncrementMethodCallCounter>
+                        </UserData>
+                    </template>
                 </templates>
 
                 <events>
@@ -3546,6 +3566,9 @@
                     <event value="284" version="0" level="win:Informational" template="TieredCompilationBackgroundJitStop"
                            keywords="CompilationKeyword" task="TieredCompilation" opcode="win:Stop"
                            symbol="TieredCompilationBackgroundJitStop" message="$(string.RuntimePublisher.TieredCompilationBackgroundJitStopEventMessage)"/>
+                    <event value="285" version="0" level="win:Verbose" template="TieredCompilationIncrementMethodCallCounter"
+                           keywords ="CompilationDiagnosticKeyword" task="TieredCompilation" opcode="Increment"
+                           symbol="TieredCompilationIncrementMethodCallCounter" message="$(string.RuntimePublisher.TieredCompilationIncrementMethodCallCounterEventMessage)"/>
 
                     <!-- Assembly loader events 290-299 -->
                     <event value="290" version="0" level="win:Informational"  template="AssemblyLoadStart"
@@ -6803,6 +6826,7 @@
                 <string id="RuntimePublisher.TieredCompilationResumeEventMessage" value="ClrInstanceID=%1;%nNewMethodCount=%2" />
                 <string id="RuntimePublisher.TieredCompilationBackgroundJitStartEventMessage" value="ClrInstanceID=%1;%nPendingMethodCount=%2" />
                 <string id="RuntimePublisher.TieredCompilationBackgroundJitStopEventMessage" value="ClrInstanceID=%1;%nPendingMethodCount=%2;%nJittedMethodCount=%3" />
+                <string id="RuntimePublisher.TieredCompilationIncrementMethodCallCounterEventMessage" value="MethodID=%1;%nMethodNamespace=%2;%nMethodName=%3;%nMethodSignature=%4;%nCounterValue=%5;%nClrInstanceID=%6" />
 
                 <string id="RundownPublisher.MethodDCStartEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6" />
                 <string id="RundownPublisher.MethodDCStart_V1EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nClrInstanceID=%7" />
@@ -7400,6 +7424,7 @@
                 <string id="RuntimePublisher.TieredCompilationSettingsOpcodeMessage" value="Settings" />
                 <string id="RuntimePublisher.TieredCompilationPauseOpcodeMessage" value="Pause" />
                 <string id="RuntimePublisher.TieredCompilationResumeOpcodeMessage" value="Resume" />
+                <string id="RuntimePublisher.TieredCompilationIncrementOpcodeMessage" value="Increment" />
 
                 <string id="RuntimePublisher.AssemblyLoadContextResolvingHandlerInvokedOpcodeMessage" value="AssemblyLoadContextResolvingHandlerInvoked" />
                 <string id="RuntimePublisher.AppDomainAssemblyResolveHandlerInvokedOpcodeMessage" value="AppDomainAssemblyResolveHandlerInvoked" />

--- a/src/vm/callcounter.cpp
+++ b/src/vm/callcounter.cpp
@@ -163,6 +163,9 @@ bool CallCounter::IncrementCount(MethodDesc* pMethodDesc)
         }
     }
 
+    // Insert the call counting event here.
+    ETW::CompilationLog::TieredCompilation::Runtime::IncrementMethodCallCounter(pMethodDesc, callCountLimit);
+
     if (callCountLimit > 0)
     {
         return true; // continue counting calls

--- a/src/vm/callcounter.cpp
+++ b/src/vm/callcounter.cpp
@@ -164,7 +164,7 @@ bool CallCounter::IncrementCount(MethodDesc* pMethodDesc)
     }
 
     // Insert the call counting event here.
-    ETW::CompilationLog::TieredCompilation::Runtime::IncrementMethodCallCounter(pMethodDesc, callCountLimit);
+    ETW::CompilationLog::TieredCompilation::Runtime::SendIncrementMethodCallCounter(pMethodDesc, callCountLimit);
 
     if (callCountLimit > 0)
     {

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -7622,6 +7622,33 @@ void ETW::CompilationLog::TieredCompilation::Runtime::SendBackgroundJitStop(UINT
     FireEtwTieredCompilationBackgroundJitStop(GetClrInstanceId(), pendingMethodCount, jittedMethodCount);
 }
 
+void ETW::CompilationLog::TieredCompilation::Runtime::IncrementMethodCallCounter(MethodDesc *pMethod, INT32 callCount)
+{
+    CONTRACTL {
+        NOTHROW;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+    _ASSERTE(pMethod != NULL);
+    _ASSERTE(g_pConfig->TieredCompilation());
+
+    if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, TieredCompilationIncrementMethodCallCounter))
+    {
+        EX_TRY
+        {
+                SString tNamespace, tMethodName, tMethodSignature;
+                pMethodDesc->GetMethodInfo(tNamespace, tMethodName, tMethodSignature);
+
+                FireEtwTieredCompilationIncrementMethodCallCounter(
+                    (UINT64)pMethodDesc,
+                    (PCWSTR)tNamespace.GetUnicode(),
+                    (PCWSTR)tMethodName.GetUnicode(),
+                    (PCWSTR)tMethodSignature.GetUnicode(),
+                    callCount,
+                    GetClrInstanceId());
+
+        } EX_CATCH{ } EX_END_CATCH(SwallowAllExceptions);
+}
+
 #endif // !FEATURE_REDHAWK
 
 #ifdef FEATURE_PERFTRACING

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -7622,13 +7622,13 @@ void ETW::CompilationLog::TieredCompilation::Runtime::SendBackgroundJitStop(UINT
     FireEtwTieredCompilationBackgroundJitStop(GetClrInstanceId(), pendingMethodCount, jittedMethodCount);
 }
 
-void ETW::CompilationLog::TieredCompilation::Runtime::IncrementMethodCallCounter(MethodDesc *pMethod, INT32 callCount)
+void ETW::CompilationLog::TieredCompilation::Runtime::SendIncrementMethodCallCounter(MethodDesc *pMethodDesc, INT32 callCount)
 {
     CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
     } CONTRACTL_END;
-    _ASSERTE(pMethod != NULL);
+    _ASSERTE(pMethodDesc != NULL);
     _ASSERTE(g_pConfig->TieredCompilation());
 
     if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, TieredCompilationIncrementMethodCallCounter))
@@ -7647,6 +7647,7 @@ void ETW::CompilationLog::TieredCompilation::Runtime::IncrementMethodCallCounter
                     GetClrInstanceId());
 
         } EX_CATCH{ } EX_END_CATCH(SwallowAllExceptions);
+    }
 }
 
 #endif // !FEATURE_REDHAWK


### PR DESCRIPTION
Adds a new verbose event that when enabled via the CompilationDiagnostic keyword will emit an event each time a tiered compilation method call counter increment operation occurs.

This is expected to be very verbose, but can help with understanding call counter behavior and verifying tiered compilation behavior in real workloads.