### PR TITLE
Fix CancellationTokenRegistration.Unregister race condition

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/CancellationTokenSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/CancellationTokenSource.cs
@@ -524,6 +524,7 @@ namespace System.Threading
                 {
                     // Assign the next available unique ID.
                     id = partition.NextAvailableId++;
+                    Debug.Assert(id != 0, "IDs should never be the reserved value 0.");
 
                     // Get a node, from the free list if possible or else a new one.
                     node = partition.FreeNodeList;
@@ -942,8 +943,15 @@ namespace System.Threading
 
             internal bool Unregister(long id, CallbackNode node)
             {
-                Debug.Assert(id != 0, "Expected non-zero id");
                 Debug.Assert(node != null, "Expected non-null node");
+
+                if (id == 0)
+                {
+                    // In general, we won't get 0 passed in here.  However, race conditions between threads
+                    // Unregistering and also zero'ing out the CancellationTokenRegistration could cause 0
+                    // to be passed in here, in which case there's nothing to do. 0 is never a valid id.
+                    return false;
+                }
 
                 bool lockTaken = false;
                 Lock.Enter(ref lockTaken);


### PR DESCRIPTION
Port https://github.com/dotnet/runtime/pull/309 to release/3.1
Fixes https://github.com/dotnet/coreclr/issues/22946

## Description

If multiple threads race to Unregister and zero out a CancellationTokenRegistration field, we can end up null ref'ing due to a torn read/write on a struct resulting in passing around some inconsistent state.  This pattern is possible as part of clean up in Task.Delay(timeout, cancellationToken), with the null ref then happening on a thread pool thread that results in the app crashing.

## Customer Impact

Valid coding patterns, both in customer code and in our framework implementation, resulting in NullReferenceExceptions that may not be catchable.  Back in March a customer reported this, and just recently @rynowak hit up against it in ASP.NET.

## Regression?

Yes, from .NET Framework 4.8 and .NET Core 2.0.  This was introduced in https://github.com/dotnet/coreclr/pull/12819 in 2.1 as part of overhauling the CancellationToken implementation.

## Testing

Isolated a repro that quickly fails (within a second) prior to the fix and successfully runs for a long time after.

## Risk

Minimal.

cc: @tarekgh, @kouvel, @rynowak 

@danmosemsft 