### PR TITLE
[armel/Linux] Fix armel build

### DIFF
--- a/src/pal/tools/gen-buildsys.sh
+++ b/src/pal/tools/gen-buildsys.sh
@@ -79,6 +79,10 @@ if [ "$CROSSCOMPILE" == "1" ]; then
     cmake_extra_defines="$cmake_extra_defines -DCMAKE_TOOLCHAIN_FILE=${__RepoRootDir}/eng/common/cross/toolchain.cmake"
 fi
 
+if [ "$build_arch" == "armel" ]; then
+  cmake_extra_defines="$cmake_extra_defines -DARM_SOFTFP=1"
+fi
+
 cmake_command=$(command -v cmake)
 
 if [[ "$scan_build" == "ON" && "$SCAN_BUILD_COMMAND" != "" ]]; then


### PR DESCRIPTION
Option '-DARM_SOFTFP' not passed after #27077 which required for armel build.
This commit fix it.

Haven't checked dotnet/runtime, but think it should be ported.
cc @jkotas @y-yamshchikov @o-piskunov