### PR TITLE
Port to 3.1 - Fix getting affinity set on MUSL on Jetson TX2

### DIFF
--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -326,7 +326,7 @@ bool GCToOSInterface::Initialize()
 
     if (st == 0)
     {
-        for (size_t i = 0; i < g_totalCpuCount; i++)
+        for (size_t i = 0; i < CPU_SETSIZE; i++)
         {
             if (CPU_ISSET(i, &cpuSet))
             {
@@ -1152,7 +1152,7 @@ bool GCToOSInterface::GetProcessorForHeap(uint16_t heap_number, uint16_t* proc_n
     bool success = false;
 
     uint16_t availableProcNumber = 0;
-    for (size_t procNumber = 0; procNumber < g_totalCpuCount; procNumber++)
+    for (size_t procNumber = 0; procNumber < MAX_SUPPORTED_CPUS; procNumber++)
     {
         if (g_processAffinitySet.Contains(procNumber))
         {

--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -3079,10 +3079,9 @@ PAL_GetCurrentThreadAffinitySet(SIZE_T size, UINT_PTR* data)
     if (st == 0)
     {
         const SIZE_T BitsPerBitsetEntry = 8 * sizeof(UINT_PTR);
-        int nrcpus = PAL_GetTotalCpuCount();
 
         // Get info for as much processors as it is possible to fit into the resulting set
-        SIZE_T remainingCount = std::min(size * BitsPerBitsetEntry, (SIZE_T)nrcpus);
+        SIZE_T remainingCount = std::min(size * BitsPerBitsetEntry, (SIZE_T)CPU_SETSIZE);
         SIZE_T i = 0;
         while (remainingCount != 0)
         {

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -1013,7 +1013,7 @@ bool GCToOSInterface::GetProcessorForHeap(uint16_t heap_number, uint16_t* proc_n
     // Locate heap_number-th available processor
     uint16_t procIndex;
     size_t cnt = heap_number;
-    for (uint16_t i = 0; i < GCToOSInterface::GetTotalProcessorCount(); i++)
+    for (uint16_t i = 0; i < MAX_SUPPORTED_CPUS; i++)
     {
         if (g_processAffinitySet.Contains(i))
         {


### PR DESCRIPTION
Customer impact
---

Prevents running Linux Alpine tests on checked runtime on Jetson TX2 ARM boards used by our lab. This bug causes the checked runtime to assert and crash during startup on this board.

Customers may see degraded GC performance on Jetson TX2 and similar devices.

Regression?
---

Regression from 2.1, introduced by the docker/cgroup changes.

Risk
---
Low

----
Ports https://github.com/dotnet/runtime/pull/206 to release/3.1.

The code in PAL_GetCurrentThreadAffinitySet relied on the fact that the
number of processors reported as configured in the system is always
larger than the maximum CPU index. However, it turns out that it is not
true on some devices / distros. The Jetson TX2 reports CPUs 0, 3, 4 and
5 in the affinity mask and the 1 and 2 are never reported. GLIBC reports
6 as the number of configured CPUs, however MUSL reports just 4. The
PAL_GetCurrentThreadAffinitySet was using the number of CPUs reported as
configured as the upper bound for scanning affinity set, so on Jetson
TX2, the affinity mask returned had just two bits set while there were
4 CPUs. That triggered an assert in the GCToOSInterface::Initialize.

This change fixes that by reading the maximum CPU index from the
/proc/cpuinfo. It falls back to using the number of processors
configured when the /proc/cpuinfo is not available (on macOS, FreeBSD, ...)

Fixes https://github.com/dotnet/runtime/issues/170