### PR TITLE
Port to 3.1 - Fix out of range access in GetRecycleMemoryInfo

### DIFF
--- a/src/vm/win32threadpool.h
+++ b/src/vm/win32threadpool.h
@@ -749,7 +749,9 @@ public:
 #else // !FEATURE_PAL
             if (PAL_HasGetCurrentProcessorNumber())
             {
-                processorNumber = GetCurrentProcessorNumber();
+                // On linux, GetCurrentProcessorNumber which uses sched_getcpu() can return a value greater than the number
+                // of processors reported by sysconf(_SC_NPROCESSORS_ONLN) when using OpenVZ kernel.
+                processorNumber = GetCurrentProcessorNumber()%NumberOfProcessors;
             }
 #endif // !FEATURE_PAL
             return pRecycledListPerProcessor[processorNumber][memType];


### PR DESCRIPTION
Customer impact
---

Runtime crash or hang within a few seconds in certain types of Linux virtualized environments (e.g. OpenVZ)

Regression?
---
Regression from 2.1, introduced by https://github.com/dotnet/coreclr/pull/23824

Risk
---
Low

---

Ports change #26873 to release 3.1 branch.

On OpenVZ virtualized linux, GetCurrentProcessorNumber which uses sched_getcpu()
can return a value greater than the number of processors reported by
sched_getaffinity with CPU_COUNT or sysconf(_SC_NPROCESSORS_ONLN).
For example, taskset -c 2,3 ./MyApp will make CPU_COUNT be 2 but
sched_getcpu() can return 2 or 3, and OpenVZ kernel can make
sysconf(_SC_NPROCESSORS_ONLN) return a limited cpu count but
sched_getcpu() still report the real processor number.

Example of affinity vs current CPU id on OpenVZ:
nproc: 8
nprocOnline: 1
affinity: 1, 0, 0, 0, 0, 0, 0, 0, cpuid: 2
affinity: 1, 0, 0, 0, 0, 0, 0, 0, cpuid: 2
affinity: 1, 0, 0, 0, 0, 0, 0, 0, cpuid: 2
affinity: 1, 0, 0, 0, 0, 0, 0, 0, cpuid: 2
affinity: 1, 0, 0, 0, 0, 0, 0, 0, cpuid: 2
affinity: 1, 0, 0, 0, 0, 0, 0, 0, cpuid: 5
affinity: 1, 0, 0, 0, 0, 0, 0, 0, cpuid: 5