### PR TITLE
This is a point fix for not allowing fast tail calls on windows arm64 for vararg methods

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7055,7 +7055,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
 #if (defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM_)) || (defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM64_))
     if (info.compIsVarArgs || callee->IsVarargs())
     {
-        reportFastTailCallDecision("Fast tail calls with varargs not supported on Windows ARM/ARM64");
+        reportFastTailCallDecision("Fast tail calls with varargs not supported on Windows ARM/ARM64", 0, 0);
         return false;
     }
 #endif // (defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM_)) || defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM64_))

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7047,6 +7047,19 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     // out-going area required for callee is bounded by caller's fixed argument space.
     //
     // Note that callee being a vararg method is not a problem since we can account the params being passed.
+    //
+    // We will currently decide to not fast tail call on Windows armarch if the caller or callee is a vararg
+    // method. This is due to the ABI differences for native vararg methods for these platforms. There is
+    // work required to shuffle arguments to the correct locations.
+
+#if (defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM_)) || (defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM64_))
+    if (info.compIsVarArgs || callee->IsVarargs())
+    {
+        reportFastTailCallDecision("Fast tail calls with varargs not supported on Windows ARM/ARM64");
+        return false;
+    }
+#endif // (defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM_)) || defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM64_))
+
     unsigned nCallerArgs = info.compArgsCount;
 
     size_t callerArgRegCount      = codeGen->intRegState.rsCalleeRegArgCount;


### PR DESCRIPTION
This only affects windows arm and arm64.

/cc @dotnet/jit-contrib 