### PR TITLE
[release/3.1] Use 3.1.100 SDK in 3.1 build

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.101"
+    "dotnet": "3.1.100"
   },
   "native-tools": {
     "cmake": "3.11.1",


### PR DESCRIPTION
To ensure that the 3.1 stack uses a consistent SDK.  The upper portions of the stack require the 3.1 SDK because for TFM purposes.