### PR TITLE
Fix memory leaked caused by Marshal.GetFunctionPointerForDelegate

### DIFF
--- a/src/vm/dllimportcallback.cpp
+++ b/src/vm/dllimportcallback.cpp
@@ -961,10 +961,17 @@ void UMEntryThunk::Terminate()
     CONTRACTL
     {
         NOTHROW;
+        MODE_ANY;
     }
     CONTRACTL_END;
 
     m_code.Poison();
+
+    if (GetObjectHandle())
+    {
+        DestroyLongWeakHandle(GetObjectHandle());
+        m_pObjectHandle = 0;
+    }
 
     s_thunkFreeList.AddToList(this);
 }

--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -310,22 +310,6 @@ public:
 #endif
     }
 
-    ~UMEntryThunk()
-    {
-        CONTRACTL
-        {
-            NOTHROW;
-            GC_NOTRIGGER;
-            MODE_ANY;
-        }
-        CONTRACTL_END;
-
-        if (GetObjectHandle())
-        {
-            DestroyLongWeakHandle(GetObjectHandle());
-        }
-    }
-
     void Terminate();
 
     VOID RunTimeInit()


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/353

Customer impact
---

Memory leak when using Marshal.GetFunctionPointerForDelegate

Regression?
---

Not a regression -- introduced in Windows Phone CoreCLR port.

Risk
---

Low

----

cc @jeffschwMSFT @jkotas 