### PR TITLE
[release/3.1] Port fix for JIT silent bad code

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -10837,11 +10837,22 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     }
                     else if (lhs->OperIsBlk())
                     {
-                        // Check for ADDR(LCL_VAR), or ADD(ADDR(LCL_VAR),CNS_INT))
-                        // (the latter may appear explicitly in the IL).
-                        // Local field stores will cause the stack to be spilled when
-                        // they are encountered.
-                        lclVar = lhs->AsBlk()->Addr()->IsLocalAddrExpr();
+                        // Check if LHS address is within some struct local, to catch
+                        // cases where we're updating the struct by something other than a stfld
+                        GenTree* addr = lhs->AsBlk()->Addr();
+
+                        // Catches ADDR(LCL_VAR), or ADD(ADDR(LCL_VAR),CNS_INT))
+                        lclVar = addr->IsLocalAddrExpr();
+
+                        // Catches ADDR(FIELD(... ADDR(LCL_VAR)))
+                        if (lclVar == nullptr)
+                        {
+                            GenTree* lclTree = nullptr;
+                            if (impIsAddressInLocal(addr, &lclTree))
+                            {
+                                lclVar = lclTree->AsLclVarCommon();
+                            }
+                        }
                     }
                     if (lclVar != nullptr)
                     {

--- a/tests/src/JIT/Regression/JitBlue/Runtime_764/Runtime_764.cs
+++ b/tests/src/JIT/Regression/JitBlue/Runtime_764/Runtime_764.cs
@@ -21,6 +21,8 @@ public struct Ptr<T> where T: class
         _value = null;
         return tmp;
     }
+
+    T _value;
 }
 
 class Runtime_764

--- a/tests/src/JIT/Regression/JitBlue/Runtime_764/Runtime_764.cs
+++ b/tests/src/JIT/Regression/JitBlue/Runtime_764/Runtime_764.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Regression test case for importer bug.
+// If Release is inlined into Main, the importer may unsafely re-order trees.
+
+public struct Ptr<T> where T: class
+{
+    public Ptr(T value)
+    {
+        _value = value;
+    }
+
+    public T Release()
+    {
+        T tmp = _value;
+        _value = null;
+        return tmp;
+    }
+}
+
+class Runtime_764
+{
+    private static int Main(string[] args)
+    {
+        Ptr<string> ptr = new Ptr<string>("Hello, world");
+
+        bool res = false;
+        while (res)
+        {
+        }
+
+        string summary = ptr.Release();
+
+        if (summary == null)
+        {
+            Console.WriteLine("FAILED");
+            return -1;
+        }
+        else
+        {
+            Console.WriteLine("PASSED");
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/Runtime_764/Runtime_764.csproj
+++ b/tests/src/JIT/Regression/JitBlue/Runtime_764/Runtime_764.csproj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Release/3.1 port of dotnet/runtime#797.
Fixes dotnet/runtime#764

The jit might incorrectly order a read from a struct field with an operation
that modifies the field, so that the read returns the wrong value.

## Customer Impact
Silent bad code; program behaves incorrectly.

## Regression?
Yes, introduced during the development 3.0 cycle. 2.x behaves correctly.

## Testing
Verified the user's test case now passes; no diffs seen in any existing framework
or test code.

## Risk
**Low**: the jit is now spilling the eval stack entries to temps in cases where it
did not before; this should be conservatively safe.

cc @BruceForstall 

____

If we're appending an assignment whose LHS is is a location within a local
struct, we need to spill all references to that struct from the eval stack.

Update the existing logic for this to handle the case where the LHS is a field
of a local struct, and the field is updated by unusual means (here, `initobj`).

Fixes dotnet/runtime#764.