### PR TITLE
Release/3.1 port of dotnet/runtime#239

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -2699,7 +2699,7 @@ void Compiler::lvaSetClass(unsigned varNum, CORINFO_CLASS_HANDLE clsHnd, bool is
 // Notes:
 //    Preferentially uses the tree's type, when available. Since not all
 //    tree kinds can track ref types, the stack type is used as a
-//    fallback.
+//    fallback. If there is no stack type, then the class is set to object.
 
 void Compiler::lvaSetClass(unsigned varNum, GenTree* tree, CORINFO_CLASS_HANDLE stackHnd)
 {
@@ -2714,6 +2714,10 @@ void Compiler::lvaSetClass(unsigned varNum, GenTree* tree, CORINFO_CLASS_HANDLE 
     else if (stackHnd != nullptr)
     {
         lvaSetClass(varNum, stackHnd);
+    }
+    else
+    {
+        lvaSetClass(varNum, impGetObjectClass());
     }
 }
 

--- a/tests/src/JIT/Regression/JitBlue/GitHub_27923/GitHub_27923.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_27923/GitHub_27923.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class Writer
+{
+    public object Data { get; set; }
+    public int Position { get; set; }
+
+   [MethodImpl(MethodImplOptions.NoInlining)]
+   Writer()
+   {
+       Data = new int[] { 100, -1, -2, -3 };
+       Position = 4;
+   }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ArraySegment<byte> Test()
+    {
+        var writer = new Writer();
+        object temp = writer.Data;
+        byte[] data = Unsafe.As<object, byte[]>(ref temp);
+        return new ArraySegment<byte>(data, 0, writer.Position);
+    }
+    
+    public static int Main()
+    {
+        var x = Test();
+        return x[0];
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_27923/GitHub_27923.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_27923/GitHub_27923.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Fix for #27923

The jit might fail to locate a class handle for a ref class, leading to an
unexpected crash while jitting.

## Customer Impact
Unexpected and hard to diagnose crash/exception

## Regression?
Yes, introduced during the development 3.0 cycle. 2.x behaves correctly.

## Testing
Verified the user's test case now passes; no diffs seen in any existing
framework or test code.

## Risk
**Low**: the jit will now fall back to using the handle for System.Object if no
better option can be found.

cc @BruceForstall

____

In some cases we may end up in lvaSetClass without a valid ref class handle
from either the IR or the stack. Use the handle for object as a conservative
fallback.