### PR TITLE
[3.1 port] Fix EventSource to stop ignoring EventCommand.SendManifest

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -2820,14 +2820,12 @@ namespace System.Diagnostics.Tracing
                 }
                 else
                 {
-#if !FEATURE_PERFTRACING
                     if (commandArgs.Command == EventCommand.SendManifest)
                     {
                         // TODO: should we generate the manifest here if we hadn't already?
                         if (m_rawManifest != null)
                             SendManifest(m_rawManifest);
                     }
-#endif
 
                     // These are not used for non-update commands and thus should always be 'default' values
                     // Debug.Assert(enable == true);


### PR DESCRIPTION
This is a port of https://github.com/dotnet/runtime/pull/848 to 3.1 servicing. 

## Customer Impact

Sending ETW command to trigger manifest file to be generated does not work anymore. This blocks some customers who are relying on ETW commands to generate multiple ETL files per session, since the files they generate after the initial file don't have any test. 

## Regression?

Yes, from https://github.com/dotnet/coreclr/pull/11639/. This is some time around .NET Core 2.0 timeframe. 

## Testing

Added automated test as part of https://github.com/dotnet/runtime/pull/848. 
I also verified the fix with the repro sent by the customer who initially reported this (Azure Stack). 

## Risk

Low. The code path being changed affects only ETW, and is a relatively simple change. I've tested the scenario with all the ETW tests we have and verified that they pass. 