### PR TITLE
Port fix for #1241 to 3.1

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -10186,6 +10186,7 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
         GenTreeLclVarCommon* lclVarTree        = nullptr;
         GenTreeLclVarCommon* srcLclVarTree     = nullptr;
         unsigned             destLclNum        = BAD_VAR_NUM;
+        unsigned             modifiedLclNum    = BAD_VAR_NUM;
         LclVarDsc*           destLclVar        = nullptr;
         FieldSeqNode*        destFldSeq        = nullptr;
         bool                 destDoFldAsg      = false;
@@ -10201,10 +10202,11 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
         {
             blockWidthIsConst = true;
             destOnStack       = true;
+            modifiedLclNum    = dest->AsLclVarCommon()->GetLclNum();
             if (dest->gtOper == GT_LCL_VAR)
             {
                 lclVarTree = dest->AsLclVarCommon();
-                destLclNum = lclVarTree->gtLclNum;
+                destLclNum = modifiedLclNum;
                 destLclVar = &lvaTable[destLclNum];
                 if (destLclVar->lvType == TYP_STRUCT)
                 {
@@ -10259,26 +10261,27 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
                 noway_assert(destAddr->TypeGet() == TYP_BYREF || destAddr->TypeGet() == TYP_I_IMPL);
                 if (destAddr->IsLocalAddrExpr(this, &lclVarTree, &destFldSeq))
                 {
-                    destOnStack = true;
-                    destLclNum  = lclVarTree->gtLclNum;
-                    destLclVar  = &lvaTable[destLclNum];
+                    destOnStack    = true;
+                    destLclNum     = lclVarTree->GetLclNum();
+                    modifiedLclNum = destLclNum;
+                    destLclVar     = &lvaTable[destLclNum];
                 }
             }
         }
 
-        if (destLclVar != nullptr)
-        {
 #if LOCAL_ASSERTION_PROP
-            // Kill everything about destLclNum (and its field locals)
-            if (optLocalAssertionProp)
+        // Kill everything about modifiedLclNum (and its field locals)
+        if ((modifiedLclNum != BAD_VAR_NUM) && optLocalAssertionProp)
+        {
+            if (optAssertionCount > 0)
             {
-                if (optAssertionCount > 0)
-                {
-                    fgKillDependentAssertions(destLclNum DEBUGARG(tree));
-                }
+                fgKillDependentAssertions(modifiedLclNum DEBUGARG(tree));
             }
+        }
 #endif // LOCAL_ASSERTION_PROP
 
+        if (destLclVar != nullptr)
+        {
             if (destLclVar->lvPromoted && blockWidthIsConst)
             {
                 noway_assert(varTypeIsStruct(destLclVar));

--- a/tests/src/JIT/Regression/JitBlue/Runtime_1241/Runtime_1241.cs
+++ b/tests/src/JIT/Regression/JitBlue/Runtime_1241/Runtime_1241.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace Runtime_1241
+{
+
+    public struct Vertex
+    {
+        public Vector3 Position;
+        public Vector2 TexCoords;
+
+        public Vertex(Vector3 pos, Vector2 tex)
+        {
+            Position = pos;
+            TexCoords = tex;
+        }
+    }
+
+    class Program
+    {
+        static int Main()
+        {
+            int returnVal = 100;
+
+            // This prints all zeros in the failure case.
+            Console.WriteLine("Replacing array element with new struct directly");
+            {
+                var bug = Bug.Create();
+                bug.MutateBroken();
+
+                Console.WriteLine(bug.Vertices[0].Position);
+                if ((bug.Vertices[0].Position.X != 1) || (bug.Vertices[0].Position.Y != 1) || (bug.Vertices[0].Position.Z != 1))
+                {
+                    returnVal = -1;
+                }
+            }
+
+            // Works
+            Console.WriteLine("Replacing array element with new struct, stored in a local variable first");
+            {
+                var bug = Bug.Create();
+                bug.MutateWorks();
+
+                Console.WriteLine(bug.Vertices[0].Position);
+                if ((bug.Vertices[0].Position.X != 1) || (bug.Vertices[0].Position.Y != 1) || (bug.Vertices[0].Position.Z != 1))
+                {
+                    returnVal = -1;
+                }
+            }
+
+            return returnVal;
+        }
+    }
+
+    public class Bug
+    {
+        public static Bug Create()
+        {
+            return new Bug
+            {
+                Vertices = Enumerable.Range(1, 100).Select(i => new Vertex(new Vector3(i), Vector2.One)).ToArray()
+            };
+        }
+
+        public Vertex[] Vertices { get; set; }
+
+        public void MutateBroken()
+        {
+            for (var i = 0; i < Vertices.Length; i++)
+            {
+                var vert = Vertices[i];
+
+                Vertices[i] = new Vertex(vert.Position, vert.TexCoords);
+            }
+        }
+
+        public void MutateWorks()
+        {
+            for (var i = 0; i < Vertices.Length; i++)
+            {
+                var vert = Vertices[i];
+
+                var newVert = new Vertex(vert.Position, vert.TexCoords);
+
+                Vertices[i] = newVert;
+            }
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/Runtime_1241/Runtime_1241.csproj
+++ b/tests/src/JIT/Regression/JitBlue/Runtime_1241/Runtime_1241.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType />
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Port of dotnet/runtime#1279 to 3.1 branch.
This is the fix for dotnet/runtime#1241. This is a SBCG bug reported externally. When a struct is partially written, the JIT fails to invalidate assertions (in this case that the entire struct had been zero'd). This results in incorrect optimization. The fix is to invalidate the assertions in the partial write case.

## Customer Impact
SBCG resulting in incorrect behavior.

## Regression?
Not a recent regression, but exposed by doing more optimizations on structs.

## Testing
The fix has been verified in the runtime repo.

## Risk
Low: The fix is straightforward and kills assertions which only disables optimizations.

## Code Reviewer
@briansull and @BruceForstall 