### PR TITLE
Port PR #258 to 3.1

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -15741,16 +15741,21 @@ unsigned GenTree::IsLclVarUpdateTree(GenTree** pOtherTree, genTreeOps* pOper)
     if (OperIs(GT_ASG))
     {
         GenTree* lhs = gtOp.gtOp1;
-        if (lhs->OperGet() == GT_LCL_VAR)
+        GenTree* rhs = AsOp()->gtOp2;
+        if ((lhs->OperGet() == GT_LCL_VAR) && rhs->OperIsBinary())
         {
             unsigned lhsLclNum = lhs->AsLclVarCommon()->gtLclNum;
-            GenTree* rhs       = gtOp.gtOp2;
-            if (rhs->OperIsBinary() && (rhs->gtOp.gtOp1->gtOper == GT_LCL_VAR) &&
-                (rhs->gtOp.gtOp1->AsLclVarCommon()->gtLclNum == lhsLclNum))
+            GenTree* rhsOp1    = rhs->AsOp()->gtOp1;
+            GenTree* rhsOp2    = rhs->AsOp()->gtOp2;
+
+            // Some operators, such as HWINTRINSIC, are currently declared as binary but
+            // may not have two operands. We must check that both operands actually exist.
+            if ((rhsOp1 != nullptr) && (rhsOp2 != nullptr) && (rhsOp1->OperGet() == GT_LCL_VAR) &&
+                (rhsOp1->AsLclVarCommon()->GetLclNum() == lhsLclNum))
             {
                 lclNum      = lhsLclNum;
-                *pOtherTree = rhs->gtOp.gtOp2;
-                *pOper      = rhs->gtOper;
+                *pOtherTree = rhsOp2;
+                *pOper      = rhs->OperGet();
             }
         }
     }

--- a/tests/src/Regressions/coreclr/GitHub_27937/Test27937.csproj
+++ b/tests/src/Regressions/coreclr/GitHub_27937/Test27937.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test27937.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/src/Regressions/coreclr/GitHub_27937/Test27937.csproj
+++ b/tests/src/Regressions/coreclr/GitHub_27937/Test27937.csproj
@@ -1,14 +1,31 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{CBD0D777-3583-49CC-8538-DD84447F6522}</ProjectGuid>
     <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
   <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
     <Compile Include="test27937.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/tests/src/Regressions/coreclr/GitHub_27937/test27937.cs
+++ b/tests/src/Regressions/coreclr/GitHub_27937/test27937.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Runtime.Intrinsics;
+
+class Test27937
+{
+    static unsafe void calc(float* fa, float* fb)
+    {
+        float* pb = fb;
+        float* eb = pb + 16;
+
+        do
+        {
+            float* pa = fa;
+            float* ea = pa + 16;
+            var va = Vector128<float>.Zero;
+
+            do
+            {
+                *pa = va.ToScalar();
+
+                pa += Vector128<float>.Count;
+                pb += Vector128<float>.Count;
+            } while (pa < ea);
+
+        } while (pb < eb);
+    }
+
+    static unsafe int Main()
+    {
+        float* a = stackalloc float[16];
+        float* b = stackalloc float[16];
+
+        calc(a, b);
+
+        return 100;
+    }
+}


### PR DESCRIPTION
Port of dotnet/runtime#258 to 3.1 branch.
This is the fix for #27937. The manifestation is an AV in the JIT. Although it isn't SBCG, it is difficult for the developer to track down that this is a JIT bug, rather than caused by something in their code.

## Customer Impact
Unexpected and hard to diagnose crashes.

## Regression?
No.

## Testing
The fix has been verified in the runtime repo.

## Risk
Low: The fix is straightforward and only prevents the AV case.

## Code Reviewers
Authored by @saucecontrol, reviewed by @CarolEidt and @swaroop-sridhar 