### PR TITLE
[3.1 port] Fix GC heap corruption on ARM

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -14980,7 +14980,7 @@ allocate_in_free:
 #else // FEATURE_STRUCTALIGN
         if (!((old_loc == 0) || same_large_alignment_p (old_loc, result+pad)))
         {
-            pad += switch_alignment_size (is_plug_padded (old_loc));
+            pad += switch_alignment_size (pad != 0);
             set_node_realigned (old_loc);
             dprintf (3, ("Allocation realignment old_loc: %Ix, new_loc:%Ix",
                          (size_t)old_loc, (size_t)(result+pad)));


### PR DESCRIPTION
Port of dotnet/runtime#1389 to 3.1 branch.  Applications may crash in GC code due to GC heap corruption caused by incorrect padding size calculation on ARM.

## Customer Impact
Unexpected and hard to diagnose crashes.

## Regression?
No.

## Testing
The fix has been verified in the runtime repo.

## Risk
Low: one-line fix of the incorrect calculation.