### PR TITLE
Port of dotnet/runtime#1059 to 3.1 branch

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -954,9 +954,10 @@ void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
     // reg3 = reg3 op reg2
     else
     {
-        inst_RV_RV(ins_Copy(targetType), targetReg, op1reg, targetType);
+        var_types op1Type = op1->TypeGet();
+        inst_RV_RV(ins_Copy(op1Type), targetReg, op1reg, op1Type);
         regSet.verifyRegUsed(targetReg);
-        gcInfo.gcMarkRegPtrVal(targetReg, targetType);
+        gcInfo.gcMarkRegPtrVal(targetReg, op1Type);
         dst = treeNode;
         src = op2;
     }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_27924/GitHub_27924.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_27924/GitHub_27924.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Runtime.CompilerServices;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+class Program
+{
+    static int returnVal = 100;
+    static byte[][] s = new byte[1000][];
+
+    static void Work()
+    {
+        for (uint i = 0; i < 1000000; i++)
+        {
+            var a = s[i++ % s.Length];
+
+            ref byte p = ref a[0];
+            ref byte q = ref a[1];
+
+            if (Unsafe.ByteOffset(ref p, ref q) != new IntPtr(1))
+            {
+                Console.WriteLine("ERROR: i = " + i);
+                returnVal = -1;
+            }
+            p = 1; q = 2;
+        }
+    }
+
+    static int Main(string[] args)
+    {
+        for(int i = 0; i < s.Length; i++) s[i] = new byte[2];
+
+        List<Task> tasks = new List<Task>();
+        for(int i = 0; i < 5; i++)
+        {
+            tasks.Add(Task.Run(Work));
+        }
+
+        Random r = new Random();
+        for (uint i = 0; i < 10000; i++)
+        {
+            s[r.Next(s.Length)] = new byte[3 + r.Next(100)];
+        }
+        Task t = Task.WhenAll(tasks);
+        t.Wait();
+        return returnVal;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_27924/GitHub_27924.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_27924/GitHub_27924.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_GcStress=0xc
+]]></CLRTestBatchPreCommands>
+  <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_GcStress=0xc
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>
+


### PR DESCRIPTION
This is the fix for #27924. This is a GC hole bug that was found externally, #27590.
The cause is that the JIT was using the target type of the subtract when it needed
to make a copy of the source, but it needs to use the source type.

## Customer Impact
Corruption of state that is non-deterministic and hard to track down.

## Regression?
Not a recent regression, but exposed by Unsafe.ByteOffset.

## Testing
The fix has been verified in the runtime repo.

## Risk
Low: The fix is straightfoward and only impacts 3 lines of code.

## Code Reviewer
@jaschook and @jkotas