### PR TITLE
Revert CPU clipping in the presence of CPU quota to 3.0, 2.x behavior.

### DIFF
--- a/src/classlibnative/bcltype/system.cpp
+++ b/src/classlibnative/bcltype/system.cpp
@@ -352,6 +352,13 @@ INT32 QCALLTYPE SystemNative::GetProcessorCount()
         processorCount = systemInfo.dwNumberOfProcessors;
     }
 
+#ifdef FEATURE_PAL	
+    uint32_t cpuLimit;	
+
+    if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < (uint32_t)processorCount)	
+        processorCount = cpuLimit;	
+#endif
+
     END_QCALL;
 
     return processorCount;

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -2558,6 +2558,12 @@ PAL_GetCPUBusyTime(
         {
             return 0;
         }
+
+        UINT cpuLimit;	
+        if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < dwNumberOfProcessors)	
+        {	
+            dwNumberOfProcessors = cpuLimit;	
+        }
     }
 
     if (getrusage(RUSAGE_SELF, &resUsage) == -1)

--- a/src/utilcode/util.cpp
+++ b/src/utilcode/util.cpp
@@ -1289,6 +1289,10 @@ int GetCurrentProcessCpuCount()
 
 #else // !FEATURE_PAL
     count = PAL_GetLogicalCpuCountFromOS();
+
+    uint32_t cpuLimit;	
+    if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < count)	
+        count = cpuLimit;	
 #endif // !FEATURE_PAL
 
     cCPUs = count;


### PR DESCRIPTION
This is a fix for an issue tracked by https://github.com/dotnet/runtime/issues/622. 
It is a reversal of a change made in 3.1 vs. 3.0 and 2.X 
(Basically reverting https://github.com/dotnet/coreclr/pull/26806)
The change was an improvement in some cases, but was causing considerable performance regressions in constrained container scenarios.

## Customer Impact
Customers report performance regressions in constrained container scenarios when CPU quotas are applied.

## Regression?
Yes. From 3.0 and 2.x

## Testing
Regular PR tests. 
Verified that the most affected aspnet benchmarks are back to 3.0 performance levels.

## Risk
Low: This is reverting to behavior that we had for a few releases.