### PR TITLE
[release/3.1] Port fix to revert EncoderNLS and DecoderNLS Convert changes

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/DecoderNLS.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/DecoderNLS.cs
@@ -207,12 +207,10 @@ namespace System.Text
             charsUsed = _encoding.GetChars(bytes, byteCount, chars, charCount, this);
             bytesUsed = _bytesUsed;
 
-            // Per MSDN, "The completed output parameter indicates whether all the data in the input
-            // buffer was converted and stored in the output buffer." That means we've successfully
-            // consumed all the input _and_ there's no pending state or fallback data remaining to be output.
+            // See comment in EncoderNLS.Convert for the details of the logic below.
 
             completed = (bytesUsed == byteCount)
-                && !this.HasState
+                && (!flush || !this.HasState)
                 && (_fallbackBuffer is null || _fallbackBuffer.Remaining == 0);
 
             // Our data thingy are now full, we can return

--- a/src/System.Private.CoreLib/shared/System/Text/EncoderNLS.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/EncoderNLS.cs
@@ -194,12 +194,39 @@ namespace System.Text
             bytesUsed = _encoding.GetBytes(chars, charCount, bytes, byteCount, this);
             charsUsed = _charsUsed;
 
-            // Per MSDN, "The completed output parameter indicates whether all the data in the input
-            // buffer was converted and stored in the output buffer." That means we've successfully
-            // consumed all the input _and_ there's no pending state or fallback data remaining to be output.
+            // If the 'completed' out parameter is set to false, it means one of two things:
+            // a) this call to Convert did not consume the entire source buffer; or
+            // b) this call to Convert did consume the entire source buffer, but there's
+            //    still pending data that needs to be written to the destination buffer.
+            //
+            // In either case, the caller should slice the input buffer, provide a fresh
+            // destination buffer, and call Convert again in a loop until 'completed' is true.
+            //
+            // The caller *must* specify flush = true on the final iteration(s) of the loop
+            // and iterate until 'completed' is set to true. Otherwise data loss may occur.
+            //
+            // Technically, the expected logic is detailed below.
+            //
+            // If 'flush' = false, the 'completed' parameter MUST be set to false if not all
+            // elements of the source buffer have been consumed. The 'completed' parameter MUST
+            // be set to true once the entire source buffer has been consumed and there is no
+            // pending data for the destination buffer. (In other words, the 'completed' parameter
+            // MUST be set to true if passing a zero-length source buffer and an infinite-length
+            // destination buffer will make no forward progress.) The 'completed' parameter value
+            // is undefined for the case where all source data has been consumed but there remains
+            // pending data for the destination buffer.
+            //
+            // If 'flush' = true, the 'completed' parameter is set to true IF AND ONLY IF:
+            // a) all elements of the source buffer have been transcoded into the destination buffer; AND
+            // b) there remains no internal partial read state within this instance; AND
+            // c) there remains no pending data for the destination buffer.
+            //
+            // In other words, if 'flush' = true, then when 'completed' is set to true it should mean
+            // that all data has been converted and that this instance is indistinguishable from a
+            // freshly-reset instance.
 
             completed = (charsUsed == charCount)
-                && !this.HasState
+                && (!flush || !this.HasState)
                 && (_fallbackBuffer is null || _fallbackBuffer.Remaining == 0);
 
             // Our data thingys are now full, we can return

--- a/tests/CoreFX/CoreFX.issues.rsp
+++ b/tests/CoreFX/CoreFX.issues.rsp
@@ -70,9 +70,12 @@
 # https://github.com/dotnet/coreclr/issues/22414
 -nomethod System.Numerics.Tests.ToStringTest.RunRegionSpecificStandardFormatToStringTests
 
-# Failure in System.Text.Encoding.Tests due to bug fix in DecoderNLS.Convert
-# https://github.com/dotnet/coreclr/issues/27191
+# Failure in System.Text.Encoding.Tests due to bug fix in EncoderNLS.Convert and DecoderNLS.Convert
+# https://github.com/dotnet/coreclr/pull/27996
 -nomethod System.Text.Tests.DecoderConvert2.PosTest6
+-nomethod System.Text.Tests.DecoderConvert2.PosTest11
+-nomethod System.Text.Tests.EncoderConvert2.EncoderUTF8ConvertMixedASCIIUnicodeCharArrayPartial
+-nomethod System.Text.Tests.EncoderConvert2.EncoderUTF8ConvertUnicodeCharArrayPartial
 
 # Timeout in System.Text.RegularExpressions.Tests.RegexMatchTests.Match_ExcessPrefix
 # https://github.com/dotnet/coreclr/issues/18912


### PR DESCRIPTION
Port https://github.com/dotnet/runtime/pull/752 to release/3.1
Fixes https://github.com/dotnet/runtime/issues/594

## Description

In .NET Core 3.0 / 3.1 we changed how the _completed_ out parameter is set on the `EncoderNLS.Convert` and `DecoderNLS.Convert` routines. We had changed the logic to match precisely what MSDN's documentation stated and to fix a possible data corruption bug; however, this broke a number of customers' applications by sending them into infinite loops.

This PR reverts that change.

## Customer Impact

If customers were relying on the previous behavior of the _completed_ out parameter, their applications could end up in an infinite loop. What makes matters worse is that the sample code on the MSDN page for `Encoder.Convert` and `Decoder.Convert` is also susceptible to this pattern, so we suspect a large number of customers may have based their own application code on the sample.

## Regression?

Yes, from .NET Framework 4.x and .NET Core 2.x. One half of this change was introduced in .NET Core 3.0 (see https://github.com/dotnet/coreclr/commit/43a5159d39bd52195c5095da4006183f791c696b); the other half was introduced in .NET Core 3.1 (see https://github.com/dotnet/coreclr/commit/c07ec4cd2f88c23edc87500893576d83c20f2e6d).

## Testing

The reversion is already committed in the 5.0 branches (see https://github.com/dotnet/runtime/commit/d49b541ab156d992aeb4bbe410f7a816bb0ac039), so we have been getting test coverage on those nightlies. No notable regressions have been reported.

## Risk

Somewhere between minimal and moderate. It's possible that some applications may have taken a dependency on the new behavior. See for instance https://github.com/dotnet/aspnetcore/pull/17747, where ASP.NET appears to have unintentionally taken a dependency on the new behavior and had to proactively make a change so that they behave correctly both before and after this PR goes through.

/cc @tarekgh @anurse @danmosemsft 