### PR TITLE
Fix issues in release 3.0

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingVersion)" />
+    <PackageDownload Include="Microsoft.DotNet.Helix.Sdk" Version="[$(MicrosoftDotNetHelixSdkVersion)]" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsVersion)" />
   </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,6 +17,7 @@
     <!-- arcade -->
     <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19461.7</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>1.0.0-beta.19461.7</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetHelixSdkVersion>2.0.0-beta.19461.7</MicrosoftDotNetHelixSdkVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.19278.1</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <!-- roslyn -->
     <MicrosoftNetCompilersToolsetVersion>3.3.0-beta2-19367-02</MicrosoftNetCompilersToolsetVersion>

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -73,7 +73,7 @@ jobs:
     - OSX_x64
     - Windows_NT_x64
     - Windows_NT_x86
-    - Windows_NT_arm
+    # - Windows_NT_arm return this when https://github.com/dotnet/runtime/issues/1097 is fixed.
     - Windows_NT_arm64
     helixQueueGroup: ci
     jobParameters:

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -52,7 +52,18 @@ jobs:
   parameters:
     jobTemplate: test-job.yml
     buildConfig: checked
-    platformGroup: all
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_musl_x64
+    - Linux_musl_arm64
+    - Linux_rhel6_x64
+    - Linux_x64
+    - OSX_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    # - Windows_NT_arm return this when https://github.com/dotnet/runtime/issues/1097 is fixed.
+    - Windows_NT_arm64
     helixQueueGroup: ci
     jobParameters:
       testGroup: outerloop

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -84,9 +84,9 @@ jobs:
 #
 # Formatting
 #
-- template: /eng/platform-matrix.yml
-  parameters:
-    jobTemplate: format-job.yml
-    platforms:
-    - Linux_x64
-    - Windows_NT_x64
+# - template: /eng/platform-matrix.yml
+#   parameters:
+#     jobTemplate: format-job.yml
+#     platforms:
+#     - Linux_x64
+#     - Windows_NT_x64

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -64,7 +64,7 @@ jobs:
     - Linux_musl_x64
     - Linux_x64
     - OSX_x64
-    - Windows_NT_arm
+    # - Windows_NT_arm return this when https://github.com/dotnet/runtime/issues/1097 is fixed.
     - Windows_NT_arm64
     - Windows_NT_x64
     - Windows_NT_x86

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -122,8 +122,8 @@ jobs:
 #
 # Formatting
 #
-- template: /eng/platform-matrix.yml
-  parameters:
-    jobTemplate: format-job.yml
-    platforms:
-    - Linux_x64
+# - template: /eng/platform-matrix.yml
+#   parameters:
+#     jobTemplate: format-job.yml
+#     platforms:
+#     - Linux_x64

--- a/src/pal/src/exception/remote-unwind.cpp
+++ b/src/pal/src/exception/remote-unwind.cpp
@@ -68,13 +68,19 @@ SET_DEFAULT_DEBUG_CHANNEL(EXCEPT);
 #include <elf.h>
 #include <link.h>
 
-#if defined(_X86_) || defined(_ARM_) 
+#if defined(_X86_) || defined(_ARM_)
+#if !defined(PRIx32)
+#define PRIx32 "lx"
+#endif
 #define PRIx PRIx32
 #define PRIu PRIu32
 #define PRId PRId32
 #define PRIA "08"
 #define PRIxA PRIA PRIx
 #elif defined(_AMD64_) || defined(_ARM64_)
+#if !defined(PRIx64)
+#define PRIx64 "llx"
+#endif
 #define PRIx PRIx64
 #define PRIu PRIu64
 #define PRId PRId64


### PR DESCRIPTION
Changes discussed to obtain green CI and fix RHEL6 outerloop builds:

- Restore the Helix SDK using Tools.props to work around msbuild issues
- Disable formatting jobs
- Disable windows ARM jobs until dotnet/runtime#1097 is solved
- Fix TRACE statement for RHEL6 in debug/checked pal out-of-proc unwind.

cc @jeffschwMSFT @mmitche @jashook @trylek 