### PR TITLE
Port the 5.0 fix for issue #1104

### DIFF
--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -362,7 +362,7 @@ bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeCon
     JITDUMP("[RangeCheck::IsMonotonicallyIncreasing] [%06d]\n", Compiler::dspTreeID(expr));
 
     // Add hashtable entry for expr.
-    bool alreadyPresent = !m_pSearchPath->Set(expr, nullptr, SearchPath::Overwrite);
+    bool alreadyPresent = m_pSearchPath->Set(expr, nullptr, SearchPath::Overwrite);
     if (alreadyPresent)
     {
         return true;

--- a/tests/src/JIT/Regression/JitBlue/Runtime_1104/Runtime_1104.cs
+++ b/tests/src/JIT/Regression/JitBlue/Runtime_1104/Runtime_1104.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+class Runtime_1104
+{
+    static int TestOutOfBoundProxy(Func<int> actualTest)
+    {
+        try
+        {
+            actualTest();
+        }
+        catch (IndexOutOfRangeException)
+        {
+            Console.WriteLine("caught IndexOutOfRangeException");
+            return 100;
+        }
+        Debug.Fail("unreached");
+        return 101;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int TestOutOfBoundLowerDecreasing()
+    {
+        int[] arr = new int[10];
+        int i = 9;
+        int j = 15;
+        int sum = 0;
+
+        // our range check optimizer is very naive, so if you don't have
+        // i < 10, then it thinks `i` can overflow and doesn't bother 
+        // calling `Widen` at all.
+        //
+        while (j >= 0 && i < 10)
+        {
+            --j;
+            --i;
+            sum += arr[i];  // range check will use 9 as lower bound.
+
+            Console.WriteLine("i = " + i + ", j = " + j);
+        }
+        return sum;
+    }
+
+    public static int Main()
+    {
+        try
+        {
+            TestOutOfBoundProxy(TestOutOfBoundLowerDecreasing);
+        }
+        catch (Exception)
+        {
+            return 101;
+        }
+
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/Runtime_1104/Runtime_1104.csproj
+++ b/tests/src/JIT/Regression/JitBlue/Runtime_1104/Runtime_1104.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/Runtime_1104/Runtime_1104.csproj
+++ b/tests/src/JIT/Regression/JitBlue/Runtime_1104/Runtime_1104.csproj
@@ -1,10 +1,33 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
 </Project>


### PR DESCRIPTION
This is the fix for the 3.1 branch for the runtime issue #1104 
This a a bug which Sergey Andreenko @sandreenko found where the JIT can
optimize away a range check, allowing an out of bounds read or write.
The original cause was from PR #23109, where a cut-and-paste typo inverted the 
initialization code for `bool alreadyPresent` in `RangeCheck::IsMonotonicallyIncreasing`

**Customer Impact**
Invalid code gen that allows an out of bounds read or write.

**Regression?**
A regression introduced during 3.0 development.

**Testing**
The fix has been verified in the runtime repo.

**Risk**
Low: The fix is straightforward and only impacts 1 line of code.

**Code Reviewer**
@sandreenko and @BruceForstall 