### PR TITLE
[3.1] Fail FuncEval if slot backpatching lock is held by any thread

### DIFF
--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -15313,6 +15313,15 @@ HRESULT Debugger::FuncEvalSetup(DebuggerIPCE_FuncEvalInfo *pEvalInfo,
         return CORDBG_E_FUNC_EVAL_BAD_START_POINT;
     }
 
+    if (MethodDescBackpatchInfoTracker::IsLockedByAnyThread())
+    {
+        // A thread may have suspended for the debugger while holding the slot backpatching lock while trying to enter
+        // cooperative GC mode. If the FuncEval calls a method that is eligible for slot backpatching (virtual or interface
+        // methods that are eligible for tiering), the FuncEval may deadlock on trying to acquire the same lock. Fail the
+        // FuncEval to avoid the issue.
+        return CORDBG_E_FUNC_EVAL_BAD_START_POINT;
+    }
+
     // Create a DebuggerEval to hold info about this eval while its in progress. Constructor copies the thread's
     // CONTEXT.
     DebuggerEval *pDE = new (interopsafe, nothrow) DebuggerEval(filterContext, pEvalInfo, fInException);

--- a/src/vm/tieredcompilation.cpp
+++ b/src/vm/tieredcompilation.cpp
@@ -522,7 +522,13 @@ void TieredCompilationManager::ResumeCountingCalls(MethodDesc* pMethodDesc)
 {
     WRAPPER_NO_CONTRACT;
     _ASSERTE(pMethodDesc != nullptr);
-    MethodDescBackpatchInfoTracker::ConditionalLockHolder lockHolder(pMethodDesc->MayHaveEntryPointSlotsToBackpatch());
+
+    bool mayHaveEntryPointSlotsToBackpatch = pMethodDesc->MayHaveEntryPointSlotsToBackpatch();
+    if (mayHaveEntryPointSlotsToBackpatch)
+    {
+        MethodDescBackpatchInfoTracker::PollForDebuggerSuspension();
+    }
+    MethodDescBackpatchInfoTracker::ConditionalLockHolder lockHolder(mayHaveEntryPointSlotsToBackpatch);
 
     EX_TRY
     {
@@ -746,6 +752,10 @@ void TieredCompilationManager::ActivateCodeVersion(NativeCodeVersion nativeCodeV
     ILCodeVersion ilParent;
     HRESULT hr = S_OK;
     bool mayHaveEntryPointSlotsToBackpatch = pMethod->MayHaveEntryPointSlotsToBackpatch();
+    if (mayHaveEntryPointSlotsToBackpatch)
+    {
+        MethodDescBackpatchInfoTracker::PollForDebuggerSuspension();
+    }
     MethodDescBackpatchInfoTracker::ConditionalLockHolder lockHolder(mayHaveEntryPointSlotsToBackpatch);
 
     {


### PR DESCRIPTION
- In many cases cooperative GC mode is entered after acquiring the slot backpatching lock and the thread may block for debugger suspension while holding the lock. A FuncEval may time out on entering the lock if for example it calls a virtual or interface method for the first time. Failing the FuncEval when the lock is held enables the debugger to fall back to other options for expression evaluation.
- Also added polls for debugger suspension before acquiring the slot backpatching lock on background threads that often operate in preemptive GC mode. A common case in master is when the debugger breaks while the tiering delay timer is active, the timer ticks shortly afterwards (after debugger suspension completes) and if a thread pool thread is already available, the background thread would block while holding the lock. This is less common in 3.1 because the callback pulses the GC mode at the beginning, but still may occur occasionally. The poll checks for debugger suspension and pulses the GC mode to block before acquiring the lock.

### Customer impact

- This is a top feedback item for VS on 3.x: [feedback ticket](https://developercommunity.visualstudio.com/content/problem/855101/to-prevent-an-unsafe-abort-popup-appears-often-in.html)

### Regression?

Yes, regression from 2.x, starting in 3.0

### Testing

- It's a timing issue and was reproduced by inducing specific timings in various phases of tiering
- Verified that the timeout does not occur after the fix in the vast majority of cases. Instead, the FuncEval is failed when the lock is held and VS falls back to alternate means for evaluating the expression. See more in risks below.
- Checked debugger-broken stacks at various phases of tiering to verify that the poll for debugger suspension is working as expected
- Standard tests

### Risks

- The fix is only a heuristic and lessens the problem when it is detected that the lock is held by some thread. Since the lock is acquired in preemptive GC mode, it is still possible that after the check at the start of a FuncEval, another thread acquires the lock and the FuncEval may time out. The polling makes it less likely for the lock to be taken by background tiering work, for example if a FuncEval starts while rejitting a method.
- The expression evaluation experience may be worse when it is detected that the lock is held, and may still happen from unfortunate timing
- Low risk for the change itself

Port of https://github.com/dotnet/runtime/pull/2380
Fix for https://github.com/dotnet/runtime/issues/1537