### PR TITLE
[release/3.1] Support glibc deprecation of sys/sysctl.h 

### DIFF
--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -42,6 +42,10 @@
 #include <vm/vm_param.h>
 #endif // HAVE_XSWDEV
 
+#if HAVE_XSW_USAGE
+#include <sys/sysctl.h>
+#endif // HAVE_XSW_USAGE
+
 #ifdef __APPLE__
 #include <mach/vm_types.h>
 #include <mach/vm_param.h>
@@ -49,8 +53,12 @@
 #include <mach/mach_host.h>
 #endif // __APPLE__
 
-#if HAVE_SYSCTL
+#if HAVE_SYSCONF
+// <unistd.h> already included above
+#elif HAVE_SYSCTL
 #include <sys/sysctl.h>
+#else
+#error "Don't know how to get total physical memory on this platform"
 #endif
 
 #ifdef __linux__

--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -37,6 +37,10 @@ Revision History:
 #error Either sysctl or sysconf is required for GetSystemInfo.
 #endif
 
+#if HAVE_SYSCTLBYNAME
+#include <sys/sysctl.h>
+#endif
+
 #if HAVE_SYSINFO
 #include <sys/sysinfo.h>
 #endif

--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -28,9 +28,12 @@ Revision History:
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <sys/types.h>
-#if HAVE_SYSCTL
+
+#if HAVE_SYSCONF
+// <unistd.h> already included above
+#elif HAVE_SYSCTL
 #include <sys/sysctl.h>
-#elif !HAVE_SYSCONF
+#else
 #error Either sysctl or sysconf is required for GetSystemInfo.
 #endif
 


### PR DESCRIPTION
I can't build `release/3.1` out of the box on Fedora 31 with glibc 2.30. This fixes that.

This contains 3 changes:

- https://github.com/dotnet/coreclr/pull/27048
- https://github.com/dotnet/runtime/pull/31865
- And an analogue of the first PR to `gcenv.unix.cpp`