### PR TITLE
[release/3.1] Fix build on systems with glibc >= 2.30

### DIFF
--- a/configurecompiler.cmake
+++ b/configurecompiler.cmake
@@ -503,11 +503,15 @@ if (CLR_CMAKE_PLATFORM_UNIX)
     # to a struct or a class that has virtual members or a base class. In that case, clang
     # may not generate the same object layout as MSVC.
     add_compile_options(-Wno-incompatible-ms-struct)
+    # Do not convert a #warning into an #error
+    add_compile_options("-Wno-error=#warnings")
   else()
     add_compile_options(-Wno-unused-variable)
     add_compile_options(-Wno-unused-but-set-variable)
     add_compile_options(-fms-extensions)
     add_compile_options(-Wno-unknown-pragmas)
+    # Do not convert a #warning into an #error
+    add_compile_options(-Wno-error=cpp)
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
       add_compile_options(-Wno-nonnull-compare)
     endif()


### PR DESCRIPTION
## Issue

release/3.1 does not build on newer Linux distros, due to glibc deprecation warnings being treated as errors. The fix for release/3.1 is to disable this warning. (We have proper fix for .NET 5.)

## Customer Impact

Customers building .NET Runtime from sources have to apply private patches to keep the build working.

## Regression?

Regression from older Linux distros.

---

On newer systems with glibc 2.30, the compiler emits a warning:

    In file included from coreclr/src/pal/src/misc/sysinfo.cpp:32:
    /usr/include/sys/sysctl.h:21:2: error: "The <sys/sysctl.h> header is deprecated and will be removed." [-Werror,-W#warnings]
    #warning "The <sys/sysctl.h> header is deprecated and will be removed."
     ^

The glibc 2.30 release notes cover this at
https://sourceware.org/ml/libc-alpha/2019-08/msg00029.html:

* The Linux-specific <sys/sysctl.h> header and the sysctl function have been
  deprecated and will be removed from a future version of glibc.
  Application should directly access /proc instead.  For obtaining random
  bits, the getentropy function can be used.

To keep coreclr release/3.1 building, disable treating the #warning as an
error. Clang and GCC have separate flags to turn this error off.