### PR TITLE
[release/uwp6.2] Port dotnet/runtime#31946 fix for string.Replace infinite loop

### DIFF
--- a/src/mscorlib/shared/System/String.Manipulation.cs
+++ b/src/mscorlib/shared/System/String.Manipulation.cs
@@ -967,7 +967,11 @@ namespace System
             do
             {
                 index = ci.IndexOf(this, oldValue, startIndex, this.Length - startIndex, options, &matchLength);
-                if (index >= 0)
+
+                // There's the possibility that 'oldValue' has zero collation weight (empty string equivalent).
+                // If this is the case, we behave as if there are no more substitutions to be made.
+
+                if (index >= 0 && matchLength > 0)
                 {
                     // append the unmodified portion of string
                     result.Append(this, startIndex, index - startIndex);


### PR DESCRIPTION
Issue https://github.com/dotnet/runtime/issues/1060 reports that in a linguistic (non-ordinal) call to `string.Replace`, if the target string contains code points with zero collation weight, the `string.Replace` logic can enter an infinite loop.

This has already been fixed in .NET 5 (see https://github.com/dotnet/runtime/pull/31946). This PR ports that fix down to _release/3.1_.

## Customer Impact
Infinite loop if calling `string.Replace("<something-with-zero-collation-weight>", "...", StringComparison.<any-non-ordinal-comparison>)`. __This has already impacted at least one first-party application__, and they are requesting a backported fix for UWP.

## Regression?
Not a regression. This overload of `string.Replace` is the only one affected, and it wasn't introduced until .NET Core 2.0. It appears to have [very little usage](https://apisof.net/catalog/System.String.Replace(String,String,StringComparison)) outside of domain-specific scenarios, like text editors.

## Testing
The .NET 5 fix at https://github.com/dotnet/runtime/pull/31946 includes tests for the fix.

## Risk
Low. A code path which previously went into an infinite loop now terminates successfully.

## Code Reviewer
@tarekgh