### PR TITLE
[3.1 port] Fix debugger crash during unload of assemblies in ALC

### DIFF
--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -5392,6 +5392,7 @@ DebuggerModule* Debugger::LookupOrCreateModule(Module* pModule, AppDomain *pAppD
     // If it doesn't exist, create it.
     if (dmod == NULL)
     {
+        LOG((LF_CORDB, LL_INFO1000, "D::LOCM dmod for m=0x%x ad=0x%x not found, creating.\n", pModule, pAppDomain));
         HRESULT hr = S_OK;
         EX_TRY
         {
@@ -5406,7 +5407,8 @@ DebuggerModule* Debugger::LookupOrCreateModule(Module* pModule, AppDomain *pAppD
     // The module must be in the AppDomain that was requested
     _ASSERTE( (dmod == NULL) || (dmod->GetAppDomain() == pAppDomain) );
 
-    LOG((LF_CORDB, LL_INFO1000, "D::LOCM m=0x%x ad=0x%x -> dm=0x%x\n", pModule, pAppDomain, dmod));
+    LOG((LF_CORDB, LL_INFO1000, "D::LOCM m=0x%x ad=0x%x -> dm=0x%x(Mod=0x%x, DomFile=0x%x, AD=0x%x)\n",
+        pModule, pAppDomain, dmod, dmod->GetRuntimeModule(), dmod->GetDomainFile(), dmod->GetAppDomain()));
     return dmod;
 }
 
@@ -10014,8 +10016,10 @@ void Debugger::UnloadModule(Module* pRuntimeModule,
         }
         _ASSERTE(module != NULL);
 
-        STRESS_LOG3(LF_CORDB, LL_INFO10000, "D::UM: Unloading Mod:%#08x, %#08x, %#08x\n",
-            pRuntimeModule, pAppDomain, pRuntimeModule->IsIStream());
+        STRESS_LOG6(LF_CORDB, LL_INFO10000,
+            "D::UM: Unloading RTMod:%#08x (DomFile: %#08x, IsISStream:%#08x); DMod:%#08x(RTMod:%#08x DomFile: %#08x)\n",
+            pRuntimeModule, pRuntimeModule->GetDomainFile(), pRuntimeModule->IsIStream(),
+            module, module->GetRuntimeModule(), module->GetDomainFile());
 
         // Note: the appdomain the module was loaded in must match the appdomain we're unloading it from. If it doesn't,
         // then we've either found the wrong DebuggerModule in LookupModule or we were passed bad data.

--- a/src/debug/ee/debuggermodule.cpp
+++ b/src/debug/ee/debuggermodule.cpp
@@ -226,11 +226,10 @@ void DebuggerModuleTable::AddModule(DebuggerModule *pModule)
 }
 
 //-----------------------------------------------------------------------------
-// Remove a DebuggerModule  from the module table.
-// This occurs in response to AppDomain unload.
-// Note that this doesn't necessarily mean the EE Module is being unloaded (it may be shared)
+// Remove a DebuggerModule from the module table when it gets notified.
+// This occurs in response to the finalization of an unloaded AssemblyLoadContext.
 //-----------------------------------------------------------------------------
-void DebuggerModuleTable::RemoveModule(Module* module, AppDomain *pAppDomain)
+void DebuggerModuleTable::RemoveModule(Module* pModule, AppDomain *pAppDomain)
 {
     CONTRACTL
     {
@@ -239,12 +238,33 @@ void DebuggerModuleTable::RemoveModule(Module* module, AppDomain *pAppDomain)
     }
     CONTRACTL_END;
 
-    // If this is a domain neutral module, then scan the complete list of DebuggerModules looking
-    // for the one with a matching appdomain id.
-    // Note: we have to make sure to lookup the module with the app domain parameter if the module lives in a shared
-    // assembly or the system assembly. <BUGNUM>Bugs 65943 & 81728.</BUGNUM>
-    _ASSERTE( FALSE );
-        
+    LOG((LF_CORDB, LL_INFO1000, "DMT::RM Attempting to remove Module:0x%x AD:0x%x\n", pModule, pAppDomain));
+
+    _ASSERTE(ThreadHoldsLock());
+    _ASSERTE(pModule != NULL);
+
+    HASHFIND hf;
+
+    for (DebuggerModuleEntry *pDME = (DebuggerModuleEntry *) FindFirstEntry(&hf);
+         pDME != NULL;
+         pDME = (DebuggerModuleEntry*) FindNextEntry(&hf))
+    {
+        DebuggerModule *pDM = pDME->module;
+        Module* pRuntimeModule = pDM->GetRuntimeModule();
+
+        if ((pRuntimeModule == pModule) && (pDM->GetAppDomain() == pAppDomain))
+        {
+            LOG((LF_CORDB, LL_INFO1000, "DMT::RM Removing DebuggerMod:0x%x - Module:0x%x DF:0x%x AD:0x%x\n",
+                pDM, pModule, pDM->GetDomainFile(), pAppDomain));
+            TRACE_FREE(pDM);
+            DeleteInteropSafe(pDM);
+            Delete(HASH(pRuntimeModule), (HASHENTRY *) pDME);
+            _ASSERTE(GetModule(pModule, pAppDomain) == NULL);
+            return;
+        }
+    }
+
+    LOG((LF_CORDB, LL_INFO1000, "DMT::RM  No debugger module found for Module:0x%x AD:0x%x\n", pModule, pAppDomain));
 }
 
 
@@ -337,5 +357,3 @@ DebuggerModule *DebuggerModuleTable::GetNextModule(HASHFIND *info)
     else
         return entry->module;
 }
-
-


### PR DESCRIPTION
Issue dotnet/runtime#2317 reports that trying to use unloadable ALCs under the debugger often ends up in a crash. There was a missing implementation when removing values from the module cache which in turn triggered a sporadic bad error in the DAC

This has already been fixed in .NET 5 (see dotnet/runtime#32311). This PR ports that fix down to _release/3.1_.

Fixes dotnet/runtime#2317

## Customer Impact
Inner loop get's heavily impacted for plugin scenarios. From dotnet/runtime#2317 
> Developing/using the use cases that where described in the .net core announcement under [Assembly Unloadability](https://devblogs.microsoft.com/dotnet/announcing-net-core-3-0) is slowed down as it is not possible to debug any scenario that requires assembly unloading. Without this fix the application must be restarted or tested without a debugger attached. This makes plugin development very annoying and less attractive.

Also see https://developercommunity.visualstudio.com/content/problem/698374/vs2019-and-fatal-error-has-occurred-and-debugging.html

## Regression?
Not a regression. Unloadable ALC's were introduced in the 3.0/3.1 time-frame as a new feature. However, adoption is cumbersome on inner loop due to this. 

## Testing
There's currently work in flight to add ALCs and unloadability verification for debugger scenarios. 

## Risk
Low. The only code path that reaches this is exactly the one that's getting fixed and that still has somewhat low adoption. 

## Code Reviewer
@sdmaclea 