### PR TITLE
Port fix for dotnet/runtime#32059 to release/3.1 (JIT: make sure to set compLongUsed during struct promotion)

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -2183,6 +2183,13 @@ void Compiler::StructPromotionHelper::PromoteStructVar(unsigned lclNum)
         fieldVarDsc->lvFldOrdinal    = pFieldInfo->fldOrdinal;
         fieldVarDsc->lvParentLcl     = lclNum;
         fieldVarDsc->lvIsParam       = varDsc->lvIsParam;
+
+        // This new local may be the first time we've seen a long typed local.
+        if (fieldVarDsc->lvType == TYP_LONG)
+        {
+            compiler->compLongUsed = true;
+        }
+
 #if defined(_TARGET_AMD64_) || defined(_TARGET_ARM64_)
 
         // Reset the implicitByRef flag.

--- a/tests/src/JIT/Regression/JitBlue/Runtime_32059/Runtime_32059.il
+++ b/tests/src/JIT/Regression/JitBlue/Runtime_32059/Runtime_32059.il
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+.assembly extern System.Runtime {}
+.assembly Runtime_32059 {}
+
+.class private auto ansi beforefieldinit Runtime_32059 extends [System.Runtime]System.Object
+{
+
+.method public hidebysig static int32 Main(string[] args) cil managed
+{
+  .entrypoint
+  .locals init (valuetype [System.Runtime]System.DateTime V_0)
+  .maxstack 12
+  ldarg.0
+  ldnull
+  ldnull
+  ldnull
+  ldnull
+  ldnull
+  ldnull
+  ldnull
+  ldloc.0
+  ldc.i4.0
+  ldnull
+  newobj     instance void Runtime_32059::.ctor(string[],
+                                           string,
+                                           string,
+                                           string,
+                                           string,
+                                           string,
+                                           string,
+                                           string,
+                                           valuetype [System.Runtime]System.DateTime,
+                                           int32,
+                                           string)
+  tail.
+  call       instance int32 Runtime_32059::F()
+  ret
+}
+
+.method public specialname rtspecialname instance void .ctor(string[] o,
+                             string h,
+                             string g,
+                             string f,
+                             string e,
+                             string d,
+                             string c,
+                             string b,
+                             valuetype [System.Runtime]System.DateTime a,
+                             int32 pc,
+                             string current) cil managed  noinlining
+{
+  ldarg.0
+  call instance void [System.Runtime]System.Object::.ctor()
+  ret
+} 
+
+.method public hidebysig instance int32 F() cil managed noinlining
+{
+  ldc.i4 100
+  ret
+}
+}
+
+
+
+
+

--- a/tests/src/JIT/Regression/JitBlue/Runtime_32059/Runtime_32059.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/Runtime_32059/Runtime_32059.ilproj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Runtime_32059.il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
If we're promoting a long field, make sure `compLongUsed` gets set.
Otherwise we may fail to properly decompose a long later on, leading
to access violations in the jit.

See dotnet/runtime#32059 for the original bug report, and
dotnet/runtime#32702 for the fix in 5.0.

## Customer Impact
Unexpected and hard to diagnose crash in the jit. No easy workaround.

## Regression?
Yes, introduced during the development 3.0 cycle. 2.x behaves correctly.

## Testing
Verified the user's test case now passes; no diffs seen in any existing
framework or test code.

## Risk
**Low**: fix is surgical and enables existing long operand handling in
the jit in one case that can be overlooked. Only impacts x86 and arm
codegen. Problematic IL patterns may not be reachable from C#.