### PR TITLE
[release/3.1] Fix build with clang 10

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -612,7 +612,7 @@ esac
 
 __BuildType=Debug
 __CodeCoverage=
-__IgnoreWarnings=0
+__IgnoreWarnings=1
 
 # Set the various build properties here so that CMake and MSBuild can pick them up
 __ProjectDir="$__ProjectRoot"
@@ -648,7 +648,7 @@ __GccMajorVersion=0
 __GccMinorVersion=0
 __NuGetPath="$__PackagesDir/NuGet.exe"
 __DistroRid=""
-__cmakeargs=""
+__cmakeargs="-DCLR_CMAKE_WARNINGS_ARE_ERRORS=OFF"
 __SkipGenerateVersion=0
 __PortableBuild=1
 __msbuildonunsupportedplatform=0

--- a/src/inc/slist.h
+++ b/src/inc/slist.h
@@ -160,13 +160,13 @@ public:
     void Init()
     {
         LIMITED_METHOD_CONTRACT;
-        m_pHead = &m_link;
+        m_pHead = PTR_SLink(&m_link);
         // NOTE :: fHead variable is template argument 
         // the following code is a compiled in, only if the fHead flag
         // is set to false,
         if (!fHead)
         {
-            m_pTail = &m_link;
+            m_pTail = PTR_SLink(&m_link);
         }
     }
 
@@ -274,7 +274,7 @@ public:
         SLink   *ret = SLink::FindAndRemove(m_pHead, GetLink(pObj), &prior);
         
         if (ret == m_pTail)
-            m_pTail = prior;
+            m_pTail = PTR_SLink(prior);
         
         return GetObject(ret);
     }

--- a/src/pal/inc/mbusafecrt.h
+++ b/src/pal/inc/mbusafecrt.h
@@ -32,7 +32,7 @@ typedef int errno_t;
 #define SAFECRT_SUCCESS 0
 
 #ifndef THROW_DECL
-#if defined(_MSC_VER) || defined(__llvm__) || !defined(__cplusplus)
+#if defined(_MSC_VER) || !defined(__cplusplus)
 #define THROW_DECL
 #else
 #define THROW_DECL throw()

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -145,7 +145,7 @@ typedef PVOID NATIVE_LIBRARY_HANDLE;
 
 /******************* Compiler-specific glue *******************************/
 #ifndef THROW_DECL
-#if defined(_MSC_VER) || defined(__llvm__) || !defined(__cplusplus)
+#if defined(_MSC_VER) || !defined(__cplusplus)
 #define THROW_DECL
 #else
 #define THROW_DECL throw()


### PR DESCRIPTION
This fixes 3 different sets of build issues that are seen when compiling with clang 10.

- Clang 10 fails to compile slist.h because the code contained is   actually invalid. The assignment operator being used doesn't exist.

  This is a backport of https://github.com/dotnet/runtime/pull/33096

- Clang 10 has moved exception-handling mismatches in function declarations under the -fms-compatibility flag (instead of the -fms-extensions flag). Our declarations of atoll and other similar functions are missing the exception declaration `throw()`. This mismatch in exception declarations makes clang 10 unable to build this code. Fix it by defining THROW_DECL as `throw()` which is supported at least as far back as clang 3.3.

  This is a backport of https://github.com/dotnet/runtime/pull/32837

- Clang 10 has enabled additional warnings. Lets turn of -Werror globally in this release branch by making the `-ignorewarnings` switch  to `./build.sh` be the default.