### PR TITLE
Backport Cross DAC runtime layout changes

### DIFF
--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -2459,4 +2459,16 @@ typedef DPTR(PTR_PCODE) PTR_PTR_PCODE;
 // @dbgtodo : Separating asserts and target consistency checks is tracked by DevDiv Bugs 31674
 #define TARGET_CONSISTENCY_CHECK(expr,msg) _ASSERTE_MSG(expr,msg)
 
+// For cross compilation, controlling type layout is important
+// We add a simple macro here which defines DAC_ALIGNAS to the C++11 alignas operator
+// This helps force the alignment of the next member
+// For most cross compilation cases the layout of types simply works
+// There are a few cases (where this macro is helpful) which are not consistent accross platforms:
+// - Base class whose size is padded to its align size.  On Linux the gcc/clang
+//   layouts will reuse this padding in the derived class for the first member
+// - Class with an vtable pointer and an alignment greater than the pointer size.
+//   The Windows compilers will align the first member to the alignment size of the
+//   class.  Linux will align the first member to its natural alignment
+#define DAC_ALIGNAS(a) alignas(a)
+
 #endif // #ifndef __daccess_h__

--- a/src/inc/sstring.h
+++ b/src/inc/sstring.h
@@ -808,6 +808,7 @@ template <COUNT_T MEMSIZE>
 class InlineSString : public SString
 {
 private:
+    DAC_ALIGNAS(SString)
     BYTE m_inline[SBUFFER_PADDED_SIZE(MEMSIZE)];
 
 public:
@@ -990,6 +991,7 @@ template <COUNT_T MEMSIZE>
 class ScratchBuffer : public SString::AbstractScratchBuffer
 {
   private:
+    DAC_ALIGNAS(::SString::AbstractScratchBuffer)
     BYTE m_inline[MEMSIZE];
 
   public:

--- a/src/inc/stgpool.h
+++ b/src/inc/stgpool.h
@@ -1105,6 +1105,7 @@ private:
 
 
 private:
+    DAC_ALIGNAS(StgPool) // Align first member to alignment of base class
     CGuidPoolHash m_Hash;                    // Hash table for lookups.
     int            m_bHash;                    // true to keep hash table.
 };  // class StgGuidPool
@@ -1257,6 +1258,7 @@ private:
     __checkReturn 
     HRESULT RehashBlobs();
 
+    DAC_ALIGNAS(StgPool)                     // Align first member to alignment of base class
     CBlobPoolHash m_Hash;                    // Hash table for lookups.
 };  // class StgBlobPool
 

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -2648,6 +2648,7 @@ template <class MemMgr>
 class CHashTableAndData : public CHashTable
 {
 public:
+    DAC_ALIGNAS(CHashTable)
     ULONG      m_iFree;                // Index into m_pcEntries[] of next available slot
     ULONG      m_iEntries;             // size of m_pcEntries[]
 

--- a/src/md/compiler/regmeta.h
+++ b/src/md/compiler/regmeta.h
@@ -1987,8 +1987,7 @@ protected:
 #endif //FEATURE_METADATA_INTERNAL_APIS
 
     UTSemReadWrite      *m_pSemReadWrite;
-    bool                m_fOwnSem;
-
+    unsigned    m_fOwnSem : 1;
     unsigned    m_bRemap : 1;               // If true, there is a token mapper.
     unsigned    m_bSaveOptimized : 1;       // If true, save optimization has been done.
     unsigned    m_hasOptimizedRefToDef : 1; // true if we have performed ref to def optimization

--- a/src/md/inc/liteweightstgdb.h
+++ b/src/md/inc/liteweightstgdb.h
@@ -190,6 +190,7 @@ public:
         const void **ppv,                   // [OUT] put pointer to MD stream here.
         ULONG   *pcb);                      // [OUT] put size of the stream here.
 
+    DAC_ALIGNAS(CLiteWeightStgdb<CMiniMdRW>) // Align the first member to the alignment of the base class
     UINT32      m_cbSaveSize;               // Size of the saved streams.
     int         m_bSaveCompressed;          // If true, save as compressed stream (#-, not #~)
     VOID*       m_pImage;                   // Set in OpenForRead, NULL for anything but PE files

--- a/src/md/inc/metamodel.h
+++ b/src/md/inc/metamodel.h
@@ -2120,6 +2120,7 @@ public:
 
     FORCEINLINE void MarkUnsafeToDelete() { m_isSafeToDelete = false; }
 
+    DAC_ALIGNAS(CMiniMdBase)
     bool m_isSafeToDelete; // This starts out true, but gets set to FALSE if we detect
                            // a MiniMd API call that might have given out an internal pointer.
 #endif

--- a/src/md/inc/metamodelro.h
+++ b/src/md/inc/metamodelro.h
@@ -77,6 +77,7 @@ public:
 #endif //FEATURE_PREJIT
 
 protected:
+    DAC_ALIGNAS(CMiniMdTemplate<CMiniMd>) // Align the first member to the alignment of the base class
     // Table info.
     MetaData::TableRO m_Tables[TBL_COUNT];
 #ifdef FEATURE_PREJIT

--- a/src/md/inc/metamodelrw.h
+++ b/src/md/inc/metamodelrw.h
@@ -672,6 +672,7 @@ public:
         return HashToken(tkObject);
     }
 
+    DAC_ALIGNAS(CMiniMdTemplate<CMiniMdRW>) // Align the first member to the alignment of the base class
     CMemberRefHash *m_pMemberRefHash;
 
     // Hash table for Methods and Fields

--- a/src/md/inc/recordpool.h
+++ b/src/md/inc/recordpool.h
@@ -154,6 +154,7 @@ public:
         void        **pContext);            // Stored context here.
     
 private:
+    DAC_ALIGNAS(StgPool) // Align first member to alignment of base class
     UINT32 m_cbRec;                // How large is each record?
     
 };  // class RecordPool

--- a/src/vm/class.h
+++ b/src/vm/class.h
@@ -2171,6 +2171,7 @@ struct ComPlusCallInfo;
 class DelegateEEClass : public EEClass
 {
 public:
+    DAC_ALIGNAS(EEClass) // Align the first member to the alignment of the base class
     PTR_Stub                         m_pStaticCallStub;
     PTR_Stub                         m_pInstRetBuffCallStub;
     RelativePointer<PTR_MethodDesc>  m_pInvokeMethod;
@@ -2241,6 +2242,7 @@ class ArrayClass : public EEClass
 
 private:
 
+    DAC_ALIGNAS(EEClass) // Align the first member to the alignment of the base class
     unsigned char   m_rank;
     CorElementType  m_ElementType;// Cache of element type in m_ElementTypeHnd
 

--- a/src/vm/loaderallocator.hpp
+++ b/src/vm/loaderallocator.hpp
@@ -151,6 +151,8 @@ protected:
     // Heaps for allocating data that persists for the life of the AppDomain
     // Objects that are allocated frequently should be allocated into the HighFreq heap for
     // better page management
+
+    DAC_ALIGNAS(UINT64) // Align the first member to alignof(m_nLoaderAllocator). Windows does this by default, force Linux to match.
     BYTE *              m_InitialReservedMemForLoaderHeaps;
     BYTE                m_LowFreqHeapInstance[sizeof(LoaderHeap)];
     BYTE                m_HighFreqHeapInstance[sizeof(LoaderHeap)];
@@ -623,6 +625,7 @@ class GlobalLoaderAllocator : public LoaderAllocator
     VPTR_VTABLE_CLASS(GlobalLoaderAllocator, LoaderAllocator)
     VPTR_UNIQUE(VPTRU_LoaderAllocator+1)
 
+    DAC_ALIGNAS(LoaderAllocator) // Align the first member to the alignment of the base class
     BYTE                m_ExecutableHeapInstance[sizeof(LoaderHeap)];
 
 protected:
@@ -645,6 +648,7 @@ class AssemblyLoaderAllocator : public LoaderAllocator
     VPTR_UNIQUE(VPTRU_LoaderAllocator+3)
 
 protected:
+    DAC_ALIGNAS(LoaderAllocator) // Align the first member to the alignment of the base class
     LoaderAllocatorID  m_Id;
     ShuffleThunkCache* m_pShuffleThunkCache;
 public:    


### PR DESCRIPTION
This represents the minimum set of changes required to
be able to build the Cross DAC out of band.

This fixes the layout difference between the Windows
compiler and the clang Linux compiler.

The code adds `alignas` directives to allow cross OS compilation type layouts to match.
Also moves a bool into a bitfield. 

# Customer impact

This allows us to develop and test a new 3.1 feature (#28027) allowing triage of Linux dumps on Windows.

 # Regression?

No, this is in support of a new 3.1 feature.

 # Testing

This has been tested by using a PDB to Dwarf comparison tool to check type layouts.

This is based on a PR which has been in the 5.0 branch for a ~6 weeks.

 # Risk

Low
