### PR TITLE
Port to 3.1 - Fix DynamicMethodDesc::Destroy vs code heap enum. race

### DIFF
--- a/src/vm/dynamicmethod.cpp
+++ b/src/vm/dynamicmethod.cpp
@@ -851,19 +851,25 @@ void DynamicMethodDesc::Destroy()
     LoaderAllocator *pLoaderAllocator = GetLoaderAllocator();
 
     LOG((LF_BCL, LL_INFO1000, "Level3 - Destroying DynamicMethod {0x%p}\n", this));
-    if (!m_pSig.IsNull())
-    {
-        delete[] (BYTE*)m_pSig.GetValue();
-        m_pSig.SetValueMaybeNull(NULL);
-    }
-    m_cSig = 0;
-    if (!m_pszMethodName.IsNull())
-    {
-        delete[] m_pszMethodName.GetValue();
-        m_pszMethodName.SetValueMaybeNull(NULL);
-    }
+
+    // The m_pSig and m_pszMethodName need to be destroyed after the GetLCGMethodResolver()->Destroy() call
+    // otherwise the EEJitManager::CodeHeapIterator could return DynamicMethodDesc with these members NULLed, but
+    // the nibble map for the corresponding code memory indicating that this DynamicMethodDesc is still alive.
+    PCODE pSig = m_pSig.GetValue();
+    PTR_CUTF8 pszMethodName = m_pszMethodName.GetValue();
 
     GetLCGMethodResolver()->Destroy();
+    // The current DynamicMethodDesc storage is destroyed at this point
+
+    if (pszMethodName != NULL)
+    {
+        delete[] pszMethodName;
+    }
+
+    if (pSig != NULL)
+    {
+        delete[] (BYTE*)pSig;
+    }
 
     if (pLoaderAllocator->IsCollectible())
     {


### PR DESCRIPTION
Port of https://github.com/dotnet/runtime/pull/713
There is a race between DynamicMethodDesc::Destroy called from
the finalizer thread and the MethodDescs enumeration called from
ETW::MethodLog::SendEventsForJitMethods at process exit.
DynamicMethodDesc::Destroy cleans up its members m_pSig and
m_pszMethodName and then it calls GetLCGMethodResolver()->Destroy();
That calls EEJitManager::FreeCodeMemory, which tries to take the
m_CodeHeapCritSec lock. But this lock is already held by
the ETW::MethodLog::SendEventsForJitMethods.
So the iterator can see half-destroyed DynamicMethodDesc and
a crash happens when trying to get the dynamic method name
from the m_pszMethodName for the ETW event purposes.

The fix is to call the GetLCGMethodResolver()->Destroy() before
destroying the m_pSig and m_pszMethodName.

# Customer impact
The bug is causing random crashes, one of our teams had to turn off AppInsights temporarily as a workaround.

# Regression?
No

# Testing
Local testing and all libraries and coreclr tests in the runtime repo - this change has been in the runtime master since December.

# Risk
Low, the change just prolongs lifetime of two DynamicMethodDesc members beyond the point when other code can access them.
