### PR TITLE
Remove SOS_README.md from every app's OutDir

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.FreeBSD.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.FreeBSD.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -7,9 +7,6 @@
     <NativeBinary Include="$(BinDir)libmscordaccore.so" />
     <NativeBinary Include="$(BinDir)libmscordbi.so" />
     <NativeBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <File Include="$(BinDir)SOS_README.md">
-      <TargetPath>runtimes\$(PackageTargetRuntime)\native</TargetPath>
-    </File>
     <CrossGenBinary Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
     <CrossArchitectureSpecificToolFile Condition="'$(HasCrossTargetComponents)' == 'true'" Include="$(BinDir)$(CrossTargetComponentFolder)\crossgen" />

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -13,9 +13,6 @@
     <NativeBinary Include="$(BinDir)libmscordaccore.so" />
     <NativeBinary Include="$(BinDir)libmscordbi.so" />
     <NativeBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <File Include="$(BinDir)SOS_README.md">
-      <TargetPath>runtimes\$(PackageTargetRuntime)\native</TargetPath>
-    </File>
     <NativeBinary Condition="'$(_PlatformDoesNotSupportCreatedump)' != 'true'" Include="$(BinDir)createdump" />
     <CrossGenBinary Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.OSX.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.OSX.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -5,9 +5,6 @@
     <NativeBinary Include="$(BinDir)libdbgshim.dylib" />
     <NativeBinary Include="$(BinDir)libmscordaccore.dylib" />
     <NativeBinary Include="$(BinDir)libmscordbi.dylib" />
-    <File Include="$(BinDir)SOS_README.md">
-      <TargetPath>runtimes\$(PackageTargetRuntime)\native</TargetPath>
-    </File>
     <NativeBinary Include="$(BinDir)System.Globalization.Native.dylib" />
     <CrossGenBinary Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -18,9 +18,6 @@
     <NativeBinary Include="$(BinDir)mscordbi.dll" />
     <NativeBinary Include="$(BinDir)mscorrc.debug.dll" />
     <NativeBinary Include="$(BinDir)mscorrc.dll" />
-    <File Include="$(BinDir)SOS_README.md">
-      <TargetPath>runtimes\$(PackageTargetRuntime)\native</TargetPath>
-    </File>
     <NativeBinary Include="$(BinDir)Redist\ucrt\DLLs\$(BuildArch)\*.dll" Condition="'$(BuildType)'=='Release' AND '$(BuildArch)' != 'arm64'" />
     <CrossGenBinary Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen.exe" />

--- a/src/ToolBox/SOS/CMakeLists.txt
+++ b/src/ToolBox/SOS/CMakeLists.txt
@@ -3,5 +3,3 @@ if(WIN32)
     add_subdirectory(DacTableGen)
   endif()    
 endif(WIN32)
-
-_install(FILES SOS_README.md DESTINATION .)


### PR DESCRIPTION
Issue https://github.com/dotnet/runtime/issues/35888

Runtime master repo PR: https://github.com/dotnet/runtime/pull/33878

# Customer impact
The is causing customers' apps to fail with SOS_README.md not found. 

# Regression?
No

# Testing
Change in runtime master already.

# Risk
Low. Don't ship SOS_README.md anymore and it doesn't get put in the deps files.