### PR TITLE
Port to 3.1 - Fix a native memory leak in EventPipe

### DIFF
--- a/src/vm/eventpipebuffer.cpp
+++ b/src/vm/eventpipebuffer.cpp
@@ -23,7 +23,9 @@ EventPipeBuffer::EventPipeBuffer(unsigned int bufferSize, EventPipeThread* pWrit
     m_state = EventPipeBufferState::WRITABLE;
     m_pWriterThread = pWriterThread;
     m_eventSequenceNumber = eventSequenceNumber;
-    m_pBuffer = new BYTE[bufferSize];
+    // Use ClrVirtualAlloc instead of malloc to allocate buffer to avoid potential internal fragmentation in the native CRT heap.
+    // (See https://github.com/dotnet/runtime/pull/35924 and https://github.com/microsoft/ApplicationInsights-dotnet/issues/1678 for more details)
+    m_pBuffer = (BYTE*)ClrVirtualAlloc(NULL, bufferSize, MEM_COMMIT, PAGE_READWRITE);
     memset(m_pBuffer, 0, bufferSize);
     m_pLimit = m_pBuffer + bufferSize;
     m_pCurrent = GetNextAlignedAddress(m_pBuffer);
@@ -47,7 +49,7 @@ EventPipeBuffer::~EventPipeBuffer()
     }
     CONTRACTL_END;
 
-    delete[] m_pBuffer;
+    ClrVirtualFree(m_pBuffer, 0, MEM_RELEASE);
 }
 
 bool EventPipeBuffer::WriteEvent(Thread *pThread, EventPipeSession &session, EventPipeEvent &event, EventPipeEventPayload &payload, LPCGUID pActivityId, LPCGUID pRelatedActivityId, StackContents *pStack)

--- a/src/vm/eventpipebuffermanager.cpp
+++ b/src/vm/eventpipebuffermanager.cpp
@@ -168,6 +168,12 @@ EventPipeBuffer* EventPipeBufferManager::AllocateBufferForThread(EventPipeThread
         const unsigned int maxBufferSize = 1024 * 1024;
         bufferSize = Min(bufferSize, maxBufferSize);
 
+        // Make the buffer size fit into with pagesize-aligned block, 
+        // since ClrVirtualAlloc expects page-aligned sizes to be passed 
+        // as arguments (see ctor of EventPipeBuffer)
+        bufferSize = (bufferSize + g_SystemInfo.dwAllocationGranularity - 1) & ~static_cast<unsigned int>(g_SystemInfo.dwAllocationGranularity - 1);
+
+
         // EX_TRY is used here as opposed to new (nothrow) because
         // the constructor also allocates a private buffer, which
         // could throw, and cannot be easily checked


### PR DESCRIPTION
Port of https://github.com/dotnet/runtime/pull/35924.

A customer reported a seemingly unbounded memory usage growth over time when using AppInsights: https://github.com/microsoft/ApplicationInsights-dotnet/issues/1678.

EventPipeBuffers were being allocated using `malloc`, and over time this may cause an internal fragmentation within glibc's internal data structure, resulting in a memory leak over time. A usage pattern that worsens this leak is to start tracing, fill up all the buffers, then stop tracing, and repeat that many times. This fix mitigates the issue by making EventPipeBuffer to use ClrVirtualAlloc instead of malloc.

## Customer Impact
On Linux platforms (specifically ones that use glibc), customers may see an unexpected growth in the native heap size over a long period of time if using EventPipe for a long time (ex. using Application Insights Service Profiler), making our first-party and third-party tracing solutions potentially problematic in production scenarios when used for elongated periods of time.

## Regression?
No, EventPipe buffers were always allocated using malloc.

## Testing
The fix was tested against the scenario the customer provided and . Additional performance tests that use EventPipe showed minimal performance regression (<4 % in the worst case). 

## Risk
I believe the risk is low - the fix is localized to only 3-lines change and the behavior is well-understood. I have tested the fix locally for the past three weeks for various performance measurements and the fix passed all the runtime tracing tests that I ran locally and all the tests in the CI when I merged https://github.com/dotnet/runtime/pull/35924.

