### PR TITLE
[3.1] Fix Unix named mutex crash during some race conditions

### DIFF
--- a/src/pal/src/include/pal/mutex.hpp
+++ b/src/pal/src/include/pal/mutex.hpp
@@ -148,7 +148,6 @@ private:
 
 private:
     SharedMemoryProcessDataHeader *m_processDataHeader;
-    NamedMutexSharedData *m_sharedData;
     SIZE_T m_lockCount;
 #if !NAMED_MUTEX_USE_PTHREAD_MUTEX
     HANDLE m_processLockHandle;
@@ -156,6 +155,7 @@ private:
 #endif // !NAMED_MUTEX_USE_PTHREAD_MUTEX
     CorUnix::CPalThread *m_lockOwnerThread;
     NamedMutexProcessData *m_nextInThreadOwnedNamedMutexList;
+    bool m_hasRefFromLockOwnerThread;
 
 public:
     static SharedMemoryProcessDataHeader *CreateOrOpen(LPCSTR name, bool acquireLockIfCreated, bool *createdRef);
@@ -171,7 +171,18 @@ public:
         int sharedLockFileDescriptor
     #endif // !NAMED_MUTEX_USE_PTHREAD_MUTEX
     );
+
+public:
+    virtual bool CanClose() const override;
+    virtual bool HasImplicitRef() const override;
+    virtual void SetHasImplicitRef(bool value) override;
     virtual void Close(bool isAbruptShutdown, bool releaseSharedData) override;
+
+public:
+    bool IsLockOwnedByCurrentThread() const
+    {
+        return GetSharedData()->IsLockOwnedByCurrentThread();
+    }
 
 private:
     NamedMutexSharedData *GetSharedData() const;

--- a/src/pal/src/include/pal/sharedmemory.h
+++ b/src/pal/src/include/pal/sharedmemory.h
@@ -188,9 +188,10 @@ public:
 class SharedMemoryProcessDataBase
 {
 public:
-    virtual void Close(bool isAbruptShutdown, bool releaseSharedData)
-    {
-    }
+    virtual bool CanClose() const = 0;
+    virtual bool HasImplicitRef() const = 0;
+    virtual void SetHasImplicitRef(bool value) = 0;
+    virtual void Close(bool isAbruptShutdown, bool releaseSharedData) = 0;
 
     virtual ~SharedMemoryProcessDataBase()
     {

--- a/src/pal/src/include/pal/synchobjects.hpp
+++ b/src/pal/src/include/pal/synchobjects.hpp
@@ -118,7 +118,6 @@ namespace CorUnix
         Volatile<LONG>         m_lSharedSynchLockCount;
         LIST_ENTRY             m_leOwnedObjsList;
 
-        CRITICAL_SECTION       m_ownedNamedMutexListLock;
         NamedMutexProcessData *m_ownedNamedMutexListHead;
 
         ThreadNativeWaitData   m_tnwdNativeData;
@@ -178,6 +177,7 @@ namespace CorUnix
         void RemoveOwnedNamedMutex(NamedMutexProcessData *processData);
         NamedMutexProcessData *RemoveFirstOwnedNamedMutex();
         bool OwnsNamedMutex(NamedMutexProcessData *processData);
+        bool OwnsAnyNamedMutex() const;
 
         // The following methods provide access to the native wait lock for 
         // those implementations that need a lock to protect the support for 

--- a/src/pal/src/sharedmemory/sharedmemory.cpp
+++ b/src/pal/src/sharedmemory/sharedmemory.cpp
@@ -878,6 +878,7 @@ void SharedMemoryProcessDataHeader::Close()
     // nonzero, don't clean up any object or global process-local state.
     if (m_refCount == 0)
     {
+        _ASSERTE(m_data == nullptr || m_data->CanClose());
         SharedMemoryManager::RemoveProcessDataHeader(this);
     }
 
@@ -1015,7 +1016,12 @@ void SharedMemoryProcessDataHeader::IncRefCount()
     _ASSERTE(SharedMemoryManager::IsCreationDeletionProcessLockAcquired());
     _ASSERTE(m_refCount != 0);
 
-    ++m_refCount;
+    if (++m_refCount == 2 && m_data != nullptr && m_data->HasImplicitRef())
+    {
+        // The synchronization object got an explicit ref that will govern its lifetime, remove the implicit ref
+        --m_refCount;
+        m_data->SetHasImplicitRef(false);
+    }
 }
 
 void SharedMemoryProcessDataHeader::DecRefCount()
@@ -1023,10 +1029,21 @@ void SharedMemoryProcessDataHeader::DecRefCount()
     _ASSERTE(SharedMemoryManager::IsCreationDeletionProcessLockAcquired());
     _ASSERTE(m_refCount != 0);
 
-    if (--m_refCount == 0)
+    if (--m_refCount != 0)
     {
-        InternalDelete(this);
+        return;
     }
+
+    if (m_data != nullptr && !m_data->CanClose())
+    {
+        // Extend the lifetime of the synchronization object. The process data object is responsible for removing this extra ref
+        // when the synchronization object transitions into a state where it can be closed.
+        ++m_refCount;
+        m_data->SetHasImplicitRef(true);
+        return;
+    }
+
+    InternalDelete(this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/pal/src/synchmgr/synchmanager.cpp
+++ b/src/pal/src/synchmgr/synchmanager.cpp
@@ -568,6 +568,17 @@ namespace CorUnix
         CThreadSynchronizationInfo * pSynchInfo = &pthrTarget->synchronizationInfo;
         CPalSynchronizationManager * pSynchManager = GetInstance();
 
+        // The shared memory manager's process lock is acquired before calling into some PAL synchronization primitives that may
+        // take the PAL synchronization manager's synch lock (acquired below). For example, when using a file lock
+        // implementation for a named mutex (see NamedMutexProcessData::NamedMutexProcessData()), under the shared memory
+        // manager's process lock, CreateMutex is called, which acquires the PAL synchronization manager's synch lock. The same
+        // lock order needs to be maintained here to avoid a deadlock.
+        bool abandonNamedMutexes = pSynchInfo->OwnsAnyNamedMutex();
+        if (abandonNamedMutexes)
+        {
+            SharedMemoryManager::AcquireCreationDeletionProcessLock();
+        }
+
         // Local lock
         AcquireLocalSynchLock(pthrCurrent);
 
@@ -610,15 +621,18 @@ namespace CorUnix
             pSynchManager->m_cacheOwnedObjectsListNodes.Add(pthrCurrent, poolnItem);
         }
 
-        // Abandon owned named mutexes
-        while (true)
+        if (abandonNamedMutexes)
         {
-            NamedMutexProcessData *processData = pSynchInfo->RemoveFirstOwnedNamedMutex();
-            if (processData == nullptr)
+            // Abandon owned named mutexes
+            while (true)
             {
-                break;
+                NamedMutexProcessData *processData = pSynchInfo->RemoveFirstOwnedNamedMutex();
+                if (processData == nullptr)
+                {
+                    break;
+                }
+                processData->Abandon();
             }
-            processData->Abandon();
         }
 
         if (pthrTarget != pthrCurrent)
@@ -660,6 +674,12 @@ namespace CorUnix
         }
 
         ReleaseLocalSynchLock(pthrCurrent);
+
+        if (abandonNamedMutexes)
+        {
+            SharedMemoryManager::ReleaseCreationDeletionProcessLock();
+        }
+
         DiscardAllPendingAPCs(pthrCurrent, pthrTarget);
 
         return palErr;
@@ -4036,7 +4056,6 @@ namespace CorUnix
             m_ownedNamedMutexListHead(nullptr)
     {
         InitializeListHead(&m_leOwnedObjsList);
-        InitializeCriticalSection(&m_ownedNamedMutexListLock);
 
 #ifdef SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING
         m_lPendingSignalingCount = 0;
@@ -4046,7 +4065,6 @@ namespace CorUnix
 
     CThreadSynchronizationInfo::~CThreadSynchronizationInfo()
     {
-        DeleteCriticalSection(&m_ownedNamedMutexListLock);
         if (NULL != m_shridWaitAwakened)
         {
             free(m_shridWaitAwakened);
@@ -4283,20 +4301,21 @@ namespace CorUnix
 
     void CThreadSynchronizationInfo::AddOwnedNamedMutex(NamedMutexProcessData *processData)
     {
+        _ASSERTE(this == &GetCurrentPalThread()->synchronizationInfo);
         _ASSERTE(processData != nullptr);
+        _ASSERTE(processData->IsLockOwnedByCurrentThread());
         _ASSERTE(processData->GetNextInThreadOwnedNamedMutexList() == nullptr);
 
-        EnterCriticalSection(&m_ownedNamedMutexListLock);
         processData->SetNextInThreadOwnedNamedMutexList(m_ownedNamedMutexListHead);
         m_ownedNamedMutexListHead = processData;
-        LeaveCriticalSection(&m_ownedNamedMutexListLock);
     }
 
     void CThreadSynchronizationInfo::RemoveOwnedNamedMutex(NamedMutexProcessData *processData)
     {
+        _ASSERTE(this == &GetCurrentPalThread()->synchronizationInfo);
         _ASSERTE(processData != nullptr);
+        _ASSERTE(processData->IsLockOwnedByCurrentThread());
 
-        EnterCriticalSection(&m_ownedNamedMutexListLock);
         if (m_ownedNamedMutexListHead == processData)
         {
             m_ownedNamedMutexListHead = processData->GetNextInThreadOwnedNamedMutexList();
@@ -4321,38 +4340,44 @@ namespace CorUnix
             }
             _ASSERTE(found);
         }
-        LeaveCriticalSection(&m_ownedNamedMutexListLock);
     }
 
     NamedMutexProcessData *CThreadSynchronizationInfo::RemoveFirstOwnedNamedMutex()
     {
-        EnterCriticalSection(&m_ownedNamedMutexListLock);
+        _ASSERTE(this == &GetCurrentPalThread()->synchronizationInfo);
+
         NamedMutexProcessData *processData = m_ownedNamedMutexListHead;
         if (processData != nullptr)
         {
+            _ASSERTE(processData->IsLockOwnedByCurrentThread());
             m_ownedNamedMutexListHead = processData->GetNextInThreadOwnedNamedMutexList();
             processData->SetNextInThreadOwnedNamedMutexList(nullptr);
         }
-        LeaveCriticalSection(&m_ownedNamedMutexListLock);
         return processData;
     }
 
     bool CThreadSynchronizationInfo::OwnsNamedMutex(NamedMutexProcessData *processData)
     {
-        EnterCriticalSection(&m_ownedNamedMutexListLock);
-        bool found = false;
+        _ASSERTE(this == &GetCurrentPalThread()->synchronizationInfo);
+
         for (NamedMutexProcessData *current = m_ownedNamedMutexListHead;
             current != nullptr;
             current = current->GetNextInThreadOwnedNamedMutexList())
         {
+            _ASSERTE(current->IsLockOwnedByCurrentThread());
             if (current == processData)
             {
-                found = true;
-                break;
+                return true;
             }
         }
-        LeaveCriticalSection(&m_ownedNamedMutexListLock);
-        return found;
+
+        return false;
+    }
+
+    bool CThreadSynchronizationInfo::OwnsAnyNamedMutex() const
+    {
+        _ASSERTE(this == &GetCurrentPalThread()->synchronizationInfo);
+        return m_ownedNamedMutexListHead != nullptr;
     }
 
 #if SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING

--- a/src/pal/src/synchobj/mutex.cpp
+++ b/src/pal/src/synchobj/mutex.cpp
@@ -1258,7 +1258,8 @@ NamedMutexProcessData::NamedMutexProcessData(
     m_sharedLockFileDescriptor(sharedLockFileDescriptor),
 #endif // !NAMED_MUTEX_USE_PTHREAD_MUTEX
     m_lockOwnerThread(nullptr),
-    m_nextInThreadOwnedNamedMutexList(nullptr)
+    m_nextInThreadOwnedNamedMutexList(nullptr),
+    m_hasRefFromLockOwnerThread(false)
 {
     _ASSERTE(SharedMemoryManager::IsCreationDeletionProcessLockAcquired());
     _ASSERTE(processDataHeader != nullptr);
@@ -1274,6 +1275,39 @@ NamedMutexProcessData::NamedMutexProcessData(
 #endif // !NAMED_MUTEX_USE_PTHREAD_MUTEX
 }
 
+bool NamedMutexProcessData::CanClose() const
+{
+    _ASSERTE(SharedMemoryManager::IsCreationDeletionProcessLockAcquired());
+
+    // When using a pthread robust mutex, the mutex may only be unlocked and destroyed by the thread that owns the lock. When
+    // using file locks, even though any thread could release that lock, the behavior is kept consistent to the more
+    // conservative case. If the last handle to the mutex is closed when a different thread owns the lock, the mutex cannot be
+    // closed. Due to these limitations, the behavior in this corner case is necessarily different from Windows. The caller will
+    // extend the lifetime of the mutex and will call OnLifetimeExtendedDueToCannotClose() shortly.
+    return m_lockOwnerThread == nullptr || m_lockOwnerThread == GetCurrentPalThread();
+}
+
+bool NamedMutexProcessData::HasImplicitRef() const
+{
+    _ASSERTE(SharedMemoryManager::IsCreationDeletionProcessLockAcquired());
+    return m_hasRefFromLockOwnerThread;
+}
+
+void NamedMutexProcessData::SetHasImplicitRef(bool value)
+{
+    _ASSERTE(SharedMemoryManager::IsCreationDeletionProcessLockAcquired());
+    _ASSERTE(m_hasRefFromLockOwnerThread != value);
+    _ASSERTE(!value || !CanClose());
+
+    // If value == true:
+    //   The mutex could not be closed and the caller extended the lifetime of the mutex. Record that the lock owner thread
+    //   should release the ref when the lock is released on that thread.
+    // Else:
+    //   The mutex has an implicit ref and got the first explicit reference from this process. Remove the implicit ref from the
+    //   lock owner thread.
+    m_hasRefFromLockOwnerThread = value;
+}
+
 void NamedMutexProcessData::Close(bool isAbruptShutdown, bool releaseSharedData)
 {
     _ASSERTE(SharedMemoryManager::IsCreationDeletionProcessLockAcquired());
@@ -1283,20 +1317,23 @@ void NamedMutexProcessData::Close(bool isAbruptShutdown, bool releaseSharedData)
     // active references to the mutex. So when shutting down abruptly, don't clean up any object or global process-local state.
     if (!isAbruptShutdown)
     {
+        _ASSERTE(CanClose());
+        _ASSERTE(!m_hasRefFromLockOwnerThread);
+
         CPalThread *lockOwnerThread = m_lockOwnerThread;
-        if (lockOwnerThread != nullptr)
+        if (lockOwnerThread == GetCurrentPalThread())
         {
-            // The mutex was not released before it was closed. If the lock is owned by the current thread, abandon the mutex.
-            // In both cases, clean up the owner thread's list of owned mutexes.
+            // The mutex was not released before the last handle to it from this process was closed on the lock-owning thread.
+            // Another process may still have a handle to the mutex, but since it appears as though this process would not be
+            // releasing the mutex, abandon the mutex. The only way for this process to otherwise release the mutex is to open
+            // another handle to it and release the lock on the same thread, which would be incorrect-looking code. The behavior
+            // in this corner case is different from Windows.
             lockOwnerThread->synchronizationInfo.RemoveOwnedNamedMutex(this);
-            if (lockOwnerThread == GetCurrentPalThread())
-            {
-                Abandon();
-            }
-            else
-            {
-                m_lockOwnerThread = nullptr;
-            }
+            Abandon();
+        }
+        else
+        {
+            _ASSERTE(lockOwnerThread == nullptr);
         }
 
         if (releaseSharedData)
@@ -1347,18 +1384,20 @@ NamedMutexSharedData *NamedMutexProcessData::GetSharedData() const
 void NamedMutexProcessData::SetLockOwnerThread(CorUnix::CPalThread *lockOwnerThread)
 {
     _ASSERTE(lockOwnerThread == nullptr || lockOwnerThread == GetCurrentPalThread());
-    _ASSERTE(GetSharedData()->IsLockOwnedByCurrentThread());
+    _ASSERTE(IsLockOwnedByCurrentThread());
 
     m_lockOwnerThread = lockOwnerThread;
 }
 
 NamedMutexProcessData *NamedMutexProcessData::GetNextInThreadOwnedNamedMutexList() const
 {
+    _ASSERTE(IsLockOwnedByCurrentThread());
     return m_nextInThreadOwnedNamedMutexList;
 }
 
 void NamedMutexProcessData::SetNextInThreadOwnedNamedMutexList(NamedMutexProcessData *next)
 {
+    _ASSERTE(IsLockOwnedByCurrentThread());
     m_nextInThreadOwnedNamedMutexList = next;
 }
 
@@ -1377,7 +1416,7 @@ MutexTryAcquireLockResult NamedMutexProcessData::TryAcquireLock(DWORD timeoutMil
     // at the appropriate time, see ReleaseLock().
     if (m_lockCount != 0)
     {
-        _ASSERTE(sharedData->IsLockOwnedByCurrentThread()); // otherwise, this thread would not have acquired the lock
+        _ASSERTE(IsLockOwnedByCurrentThread()); // otherwise, this thread would not have acquired the lock
         _ASSERTE(GetCurrentPalThread()->synchronizationInfo.OwnsNamedMutex(this));
 
         if (m_lockCount + 1 < m_lockCount)
@@ -1452,7 +1491,7 @@ MutexTryAcquireLockResult NamedMutexProcessData::TryAcquireLock(DWORD timeoutMil
     // Check if it's a recursive lock attempt
     if (m_lockCount != 0)
     {
-        _ASSERTE(sharedData->IsLockOwnedByCurrentThread()); // otherwise, this thread would not have acquired the process lock
+        _ASSERTE(IsLockOwnedByCurrentThread()); // otherwise, this thread would not have acquired the process lock
         _ASSERTE(GetCurrentPalThread()->synchronizationInfo.OwnsNamedMutex(this));
 
         if (m_lockCount + 1 < m_lockCount)
@@ -1575,12 +1614,13 @@ MutexTryAcquireLockResult NamedMutexProcessData::TryAcquireLock(DWORD timeoutMil
 
 void NamedMutexProcessData::ReleaseLock()
 {
-    if (!GetSharedData()->IsLockOwnedByCurrentThread())
+    if (!IsLockOwnedByCurrentThread())
     {
         throw SharedMemoryException(static_cast<DWORD>(NamedMutexError::ThreadHasNotAcquiredMutex));
     }
 
     _ASSERTE(GetCurrentPalThread()->synchronizationInfo.OwnsNamedMutex(this));
+    _ASSERTE(!m_hasRefFromLockOwnerThread);
 
     _ASSERTE(m_lockCount != 0);
     --m_lockCount;
@@ -1596,23 +1636,36 @@ void NamedMutexProcessData::ReleaseLock()
 
 void NamedMutexProcessData::Abandon()
 {
+    _ASSERTE(SharedMemoryManager::IsCreationDeletionProcessLockAcquired());
+
     NamedMutexSharedData *sharedData = GetSharedData();
-    _ASSERTE(sharedData->IsLockOwnedByCurrentThread());
+    _ASSERTE(IsLockOwnedByCurrentThread());
     _ASSERTE(m_lockCount != 0);
+
+    bool hasRefFromLockOwnerThread = m_hasRefFromLockOwnerThread;
+    if (hasRefFromLockOwnerThread)
+    {
+        m_hasRefFromLockOwnerThread = false;
+    }
 
     sharedData->SetIsAbandoned(true);
     m_lockCount = 0;
     SetLockOwnerThread(nullptr);
     ActuallyReleaseLock();
+
+    if (hasRefFromLockOwnerThread)
+    {
+        m_processDataHeader->DecRefCount();
+    }
 }
 
 void NamedMutexProcessData::ActuallyReleaseLock()
 {
-    NamedMutexSharedData *sharedData = GetSharedData();
-    _ASSERTE(sharedData->IsLockOwnedByCurrentThread());
+    _ASSERTE(IsLockOwnedByCurrentThread());
     _ASSERTE(!GetCurrentPalThread()->synchronizationInfo.OwnsNamedMutex(this));
     _ASSERTE(m_lockCount == 0);
 
+    NamedMutexSharedData *sharedData = GetSharedData();
     sharedData->ClearLockOwner();
 
 #if NAMED_MUTEX_USE_PTHREAD_MUTEX

--- a/src/pal/src/synchobj/mutex.cpp
+++ b/src/pal/src/synchobj/mutex.cpp
@@ -1642,19 +1642,14 @@ void NamedMutexProcessData::Abandon()
     _ASSERTE(IsLockOwnedByCurrentThread());
     _ASSERTE(m_lockCount != 0);
 
-    bool hasRefFromLockOwnerThread = m_hasRefFromLockOwnerThread;
-    if (hasRefFromLockOwnerThread)
-    {
-        m_hasRefFromLockOwnerThread = false;
-    }
-
     sharedData->SetIsAbandoned(true);
     m_lockCount = 0;
     SetLockOwnerThread(nullptr);
     ActuallyReleaseLock();
 
-    if (hasRefFromLockOwnerThread)
+    if (m_hasRefFromLockOwnerThread)
     {
+        m_hasRefFromLockOwnerThread = false;
         m_processDataHeader->DecRefCount();
     }
 }


### PR DESCRIPTION
Port of https://github.com/dotnet/runtime/pull/36268 to 3.1

Below when I refer to "mutex" I'm referring to the underlying mutex object, not an instance of the `Mutex` class.
- When the last reference to a mutex is closed while the lock is held by some thread and a pthread mutex is used, the mutex was attempted to be destroyed but that has undefined behavior
- There doesn't seem to be a way to behave exactly like on Windows for this corner case, where the mutex is destroyed when the last reference to it is released, regardless of which process has the mutex locked and which process releases the last reference to it (they could be two different processes), including in cases of abrupt shutdown
- For this corner case I settled on what seems like a decent solution and compatible with older runtimes:
  - When a process releases its last reference to the mutex
    - If that mutex is locked by the same thread, the lock is abandoned and the process no longer references the mutex
    - If that mutex is locked by a different thread, the lifetime of the mutex is extended with an implicit ref. The implicit ref prevents this or other processes from attempting to destroy the mutex while it is locked. The implicit ref is removed in either of these cases:
      - The mutex gets another reference from within the same process
      - The thread that owns the lock exits and abandons the mutex, at which point that would be the last reference to the mutex and the process would not reference the mutex anymore
  - The implementation based on file locks is less restricted, but for consistency that implementation also follows the same behavior
- There was also a race between an exiting thread abandoning one of its locked named mutexes and another thread releasing the last reference to it, fixed by using the creation/deletion process lock to synchronize

Fix for https://github.com/dotnet/runtime/issues/34271 in 3.1

### Customer impact

- Random crashes were seen on Unixes
- When a named mutex is locked and the last reference to it is released from a different thread in any process, the underlying pthread mutex object is destroyed and that has undefined behavior. Crashes were seen where some data associated with the destroyed pthread mutex continues to be used when acquiring another pthread mutex in racy situations, causing a crash because the memory containing the destroyed pthread mutex is unmapped.
- There was also a race where a thread has acquired the lock of a named mutex, between that thread exiting and abandoning the mutex, and another thread attempting to destroy the mutex

### Regression?

No

### Testing

- PAL named mutex tests on Linux and OSX including in stress mode (1 hour) in debug and release
- System.Threading tests including mutex tests on Linux and OSX with debug and release coreclr
- PAL, coreclr, and libraries tests

### Risk

Low:
- It is a bit of a corner case, where a lock is acquired and the mutex is disposed without releasing the lock, especially necessary for this issue is that the thread that disposes the mutex is different from the one that holds the lock
- Since the fix involves extending the lifetime of a mutex in such a case, the underlying shared named mutex may observably live longer than before. That is necessary for correctness, as the behavior there was incorrect before and leading to the crashes.