### PR TITLE
[release/2.1] Fix build with clang 10

### DIFF
--- a/src/debug/createdump/createdump.h
+++ b/src/debug/createdump/createdump.h
@@ -54,6 +54,8 @@ typedef int T_CONTEXT;
 #include <map>
 #include <set>
 #include <vector>
+#include <string>
+#include <array>
 #include "datatarget.h"
 #include "threadinfo.h"
 #include "memoryregion.h"

--- a/src/inc/slist.h
+++ b/src/inc/slist.h
@@ -160,13 +160,13 @@ public:
     void Init()
     {
         LIMITED_METHOD_CONTRACT;
-        m_pHead = &m_link;
+        m_pHead = PTR_SLink(&m_link);
         // NOTE :: fHead variable is template argument 
         // the following code is a compiled in, only if the fHead flag
         // is set to false,
         if (!fHead)
         {
-            m_pTail = &m_link;
+            m_pTail = PTR_SLink(&m_link);
         }
     }
 
@@ -274,7 +274,7 @@ public:
         SLink   *ret = SLink::FindAndRemove(m_pHead, GetLink(pObj), &prior);
         
         if (ret == m_pTail)
-            m_pTail = prior;
+            m_pTail = PTR_SLink(prior);
         
         return GetObject(ret);
     }

--- a/src/pal/inc/mbusafecrt.h
+++ b/src/pal/inc/mbusafecrt.h
@@ -31,6 +31,12 @@ typedef int errno_t;
 // define the return value for success 
 #define SAFECRT_SUCCESS 0
 
+#if defined(_MSC_VER)
+#define THROW_DECL
+#else
+#define THROW_DECL throw()
+#endif
+
 #ifdef __cplusplus
     extern "C" {
 #endif
@@ -98,7 +104,7 @@ extern int swscanf_s( const WCHAR *string, const WCHAR *format, ... );
 extern int _snscanf_s( const char *string, size_t count, const char *format, ... );
 extern int _snwscanf_s( const WCHAR *string, size_t count, const WCHAR *format, ... );
 
-extern errno_t memcpy_s( void * dst, size_t sizeInBytes, const void * src, size_t count );
+extern errno_t memcpy_s( void * dst, size_t sizeInBytes, const void * src, size_t count ) THROW_DECL;
 extern errno_t memmove_s( void * dst, size_t sizeInBytes, const void * src, size_t count );
 
 #ifdef __cplusplus

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -137,6 +137,11 @@ extern "C" {
 #define LANG_THAI                        0x1e
 
 /******************* Compiler-specific glue *******************************/
+#if defined(_MSC_VER) || !defined(__cplusplus)
+#define THROW_DECL
+#else
+#define THROW_DECL throw()
+#endif
 
 #ifndef _MSC_VER
 #if defined(CORECLR)
@@ -4207,7 +4212,7 @@ EXTERN_C
 PALIMPORT
 void *PAL_memcpy (void *dest, const void *src, size_t count);
 
-PALIMPORT void * __cdecl memcpy(void *, const void *, size_t);
+PALIMPORT void * __cdecl memcpy(void *, const void *, size_t) THROW_DECL;
 
 #define memcpy PAL_memcpy
 #define IS_PAL_memcpy 1
@@ -4220,7 +4225,7 @@ PALIMPORT int    __cdecl memcmp(const void *, const void *, size_t);
 PALIMPORT void * __cdecl memset(void *, int, size_t);
 PALIMPORT void * __cdecl memmove(void *, const void *, size_t);
 PALIMPORT void * __cdecl memchr(const void *, int, size_t);
-PALIMPORT long long int __cdecl atoll(const char *);
+PALIMPORT long long int __cdecl atoll(const char *) THROW_DECL;
 PALIMPORT size_t __cdecl strlen(const char *);
 PALIMPORT int __cdecl strcmp(const char*, const char *);
 PALIMPORT int __cdecl strncmp(const char*, const char *, size_t);
@@ -4259,7 +4264,7 @@ PALIMPORT int __cdecl toupper(int);
 #define _TRUNCATE ((size_t)-1)
 #endif
 
-PALIMPORT errno_t __cdecl memcpy_s(void *, size_t, const void *, size_t);
+PALIMPORT errno_t __cdecl memcpy_s(void *, size_t, const void *, size_t) THROW_DECL;
 PALIMPORT errno_t __cdecl memmove_s(void *, size_t, const void *, size_t);
 PALIMPORT char * __cdecl _strlwr(char *);
 PALIMPORT int __cdecl _stricmp(const char *, const char *);
@@ -4387,58 +4392,58 @@ PALIMPORT long long __cdecl llabs(long long);
 PALIMPORT int __cdecl _finite(double);
 PALIMPORT int __cdecl _isnan(double);
 PALIMPORT double __cdecl _copysign(double, double);
-PALIMPORT double __cdecl acos(double);
-PALIMPORT double __cdecl acosh(double);
-PALIMPORT double __cdecl asin(double);
-PALIMPORT double __cdecl asinh(double);
-PALIMPORT double __cdecl atan(double);
-PALIMPORT double __cdecl atanh(double);
-PALIMPORT double __cdecl atan2(double, double);
-PALIMPORT double __cdecl cbrt(double);
-PALIMPORT double __cdecl ceil(double);
-PALIMPORT double __cdecl cos(double);
-PALIMPORT double __cdecl cosh(double);
-PALIMPORT double __cdecl exp(double);
-PALIMPORT double __cdecl fabs(double);
-PALIMPORT double __cdecl floor(double);
-PALIMPORT double __cdecl fmod(double, double); 
-PALIMPORT double __cdecl log(double);
-PALIMPORT double __cdecl log10(double);
-PALIMPORT double __cdecl modf(double, double*);
-PALIMPORT double __cdecl pow(double, double);
-PALIMPORT double __cdecl sin(double);
-PALIMPORT double __cdecl sinh(double);
-PALIMPORT double __cdecl sqrt(double);
-PALIMPORT double __cdecl tan(double);
-PALIMPORT double __cdecl tanh(double);
+PALIMPORT double __cdecl acos(double) THROW_DECL;
+PALIMPORT double __cdecl acosh(double) THROW_DECL;
+PALIMPORT double __cdecl asin(double) THROW_DECL;
+PALIMPORT double __cdecl asinh(double) THROW_DECL;
+PALIMPORT double __cdecl atan(double) THROW_DECL;
+PALIMPORT double __cdecl atanh(double) THROW_DECL;
+PALIMPORT double __cdecl atan2(double, double) THROW_DECL;
+PALIMPORT double __cdecl cbrt(double) THROW_DECL;
+PALIMPORT double __cdecl ceil(double) THROW_DECL;
+PALIMPORT double __cdecl cos(double) THROW_DECL;
+PALIMPORT double __cdecl cosh(double) THROW_DECL;
+PALIMPORT double __cdecl exp(double) THROW_DECL;
+PALIMPORT double __cdecl fabs(double) THROW_DECL;
+PALIMPORT double __cdecl floor(double) THROW_DECL;
+PALIMPORT double __cdecl fmod(double, double) THROW_DECL;
+PALIMPORT double __cdecl log(double) THROW_DECL;
+PALIMPORT double __cdecl log10(double) THROW_DECL;
+PALIMPORT double __cdecl modf(double, double*) THROW_DECL;
+PALIMPORT double __cdecl pow(double, double) THROW_DECL;
+PALIMPORT double __cdecl sin(double) THROW_DECL;
+PALIMPORT double __cdecl sinh(double) THROW_DECL;
+PALIMPORT double __cdecl sqrt(double) THROW_DECL;
+PALIMPORT double __cdecl tan(double) THROW_DECL;
+PALIMPORT double __cdecl tanh(double) THROW_DECL;
 
 PALIMPORT int __cdecl _finitef(float);
 PALIMPORT int __cdecl _isnanf(float);
 PALIMPORT float __cdecl _copysignf(float, float);
-PALIMPORT float __cdecl acosf(float);
-PALIMPORT float __cdecl acoshf(float);
-PALIMPORT float __cdecl asinf(float);
-PALIMPORT float __cdecl asinhf(float);
-PALIMPORT float __cdecl atanf(float);
-PALIMPORT float __cdecl atanhf(float);
-PALIMPORT float __cdecl atan2f(float, float);
-PALIMPORT float __cdecl cbrtf(float);
-PALIMPORT float __cdecl ceilf(float);
-PALIMPORT float __cdecl cosf(float);
-PALIMPORT float __cdecl coshf(float);
-PALIMPORT float __cdecl expf(float);
-PALIMPORT float __cdecl fabsf(float);
-PALIMPORT float __cdecl floorf(float);
-PALIMPORT float __cdecl fmodf(float, float); 
-PALIMPORT float __cdecl logf(float);
-PALIMPORT float __cdecl log10f(float);
-PALIMPORT float __cdecl modff(float, float*);
-PALIMPORT float __cdecl powf(float, float);
-PALIMPORT float __cdecl sinf(float);
-PALIMPORT float __cdecl sinhf(float);
-PALIMPORT float __cdecl sqrtf(float);
-PALIMPORT float __cdecl tanf(float);
-PALIMPORT float __cdecl tanhf(float);
+PALIMPORT float __cdecl acosf(float) THROW_DECL;
+PALIMPORT float __cdecl acoshf(float) THROW_DECL;
+PALIMPORT float __cdecl asinf(float) THROW_DECL;
+PALIMPORT float __cdecl asinhf(float) THROW_DECL;
+PALIMPORT float __cdecl atanf(float) THROW_DECL;
+PALIMPORT float __cdecl atanhf(float) THROW_DECL;
+PALIMPORT float __cdecl atan2f(float, float) THROW_DECL;
+PALIMPORT float __cdecl cbrtf(float) THROW_DECL;
+PALIMPORT float __cdecl ceilf(float) THROW_DECL;
+PALIMPORT float __cdecl cosf(float) THROW_DECL;
+PALIMPORT float __cdecl coshf(float) THROW_DECL;
+PALIMPORT float __cdecl expf(float) THROW_DECL;
+PALIMPORT float __cdecl fabsf(float) THROW_DECL;
+PALIMPORT float __cdecl floorf(float) THROW_DECL;
+PALIMPORT float __cdecl fmodf(float, float) THROW_DECL;
+PALIMPORT float __cdecl logf(float) THROW_DECL;
+PALIMPORT float __cdecl log10f(float) THROW_DECL;
+PALIMPORT float __cdecl modff(float, float*) THROW_DECL;
+PALIMPORT float __cdecl powf(float, float) THROW_DECL;
+PALIMPORT float __cdecl sinf(float) THROW_DECL;
+PALIMPORT float __cdecl sinhf(float) THROW_DECL;
+PALIMPORT float __cdecl sqrtf(float) THROW_DECL;
+PALIMPORT float __cdecl tanf(float) THROW_DECL;
+PALIMPORT float __cdecl tanhf(float) THROW_DECL;
 
 #ifndef PAL_STDCPP_COMPAT
 

--- a/src/pal/src/cruntime/math.cpp
+++ b/src/pal/src/cruntime/math.cpp
@@ -117,7 +117,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT double __cdecl PAL_acos(double x)
+PALIMPORT double __cdecl PAL_acos(double x) THROW_DECL
 {
     double ret;
     PERF_ENTRY(acos);
@@ -147,7 +147,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT double __cdecl PAL_acosh(double x)
+PALIMPORT double __cdecl PAL_acosh(double x) THROW_DECL
 {
     double ret;
     PERF_ENTRY(acosh);
@@ -166,7 +166,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT double __cdecl PAL_asin(double x)
+PALIMPORT double __cdecl PAL_asin(double x) THROW_DECL
 {
     double ret;
     PERF_ENTRY(asin);
@@ -196,7 +196,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT double __cdecl PAL_asinh(double x)
+PALIMPORT double __cdecl PAL_asinh(double x) THROW_DECL
 {
     double ret;
     PERF_ENTRY(asinh);
@@ -215,7 +215,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT double __cdecl PAL_atan2(double y, double x)
+PALIMPORT double __cdecl PAL_atan2(double y, double x) THROW_DECL
 {
     double ret;
     PERF_ENTRY(atan2);
@@ -255,7 +255,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT double __cdecl PAL_exp(double x)
+PALIMPORT double __cdecl PAL_exp(double x) THROW_DECL
 {
     double ret;
     PERF_ENTRY(exp);
@@ -306,7 +306,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT double __cdecl PAL_log(double x)
+PALIMPORT double __cdecl PAL_log(double x) THROW_DECL
 {
     double ret;
     PERF_ENTRY(log);
@@ -336,7 +336,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT double __cdecl PAL_log10(double x)
+PALIMPORT double __cdecl PAL_log10(double x) THROW_DECL
 {
     double ret;
     PERF_ENTRY(log10);
@@ -366,7 +366,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT double __cdecl PAL_pow(double x, double y)
+PALIMPORT double __cdecl PAL_pow(double x, double y) THROW_DECL
 {
     double ret;
     PERF_ENTRY(pow);
@@ -527,7 +527,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT float __cdecl PAL_acosf(float x)
+PALIMPORT float __cdecl PAL_acosf(float x) THROW_DECL
 {
     float ret;
     PERF_ENTRY(acosf);
@@ -557,7 +557,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT float __cdecl PAL_acoshf(float x)
+PALIMPORT float __cdecl PAL_acoshf(float x) THROW_DECL
 {
     float ret;
     PERF_ENTRY(acoshf);
@@ -576,7 +576,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT float __cdecl PAL_asinf(float x)
+PALIMPORT float __cdecl PAL_asinf(float x) THROW_DECL
 {
     float ret;
     PERF_ENTRY(asinf);
@@ -606,7 +606,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT float __cdecl PAL_asinhf(float x)
+PALIMPORT float __cdecl PAL_asinhf(float x) THROW_DECL
 {
     float ret;
     PERF_ENTRY(asinhf);
@@ -626,7 +626,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT float __cdecl PAL_atan2f(float y, float x)
+PALIMPORT float __cdecl PAL_atan2f(float y, float x) THROW_DECL
 {
     float ret;
     PERF_ENTRY(atan2f);
@@ -666,7 +666,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT float __cdecl PAL_expf(float x)
+PALIMPORT float __cdecl PAL_expf(float x) THROW_DECL
 {
     float ret;
     PERF_ENTRY(expf);
@@ -698,7 +698,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT float __cdecl PAL_logf(float x)
+PALIMPORT float __cdecl PAL_logf(float x) THROW_DECL
 {
     float ret;
     PERF_ENTRY(logf);
@@ -728,7 +728,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT float __cdecl PAL_log10f(float x)
+PALIMPORT float __cdecl PAL_log10f(float x) THROW_DECL
 {
     float ret;
     PERF_ENTRY(log10f);
@@ -758,7 +758,7 @@ Function:
 
 See MSDN.
 --*/
-PALIMPORT float __cdecl PAL_powf(float x, float y)
+PALIMPORT float __cdecl PAL_powf(float x, float y) THROW_DECL
 {
     float ret;
     PERF_ENTRY(powf);

--- a/src/pal/src/safecrt/memcpy_s.cpp
+++ b/src/pal/src/safecrt/memcpy_s.cpp
@@ -54,7 +54,7 @@ errno_t __cdecl memcpy_s(
     size_t sizeInBytes,
     const void * src,
     size_t count
-)
+) THROW_DECL
 {
     if (count == 0)
     {


### PR DESCRIPTION
This contains a grab bag of fixes to fix the build with clang 10.

- https://github.com/dotnet/coreclr/pull/23075

  Fix missing includes in coreclr/src/debug/createdump/

- https://github.com/dotnet/runtime/pull/33096

  SList::Init: add missing constructor

- A subset of https://github.com/dotnet/coreclr/pull/22129

  Just the parts that introduce the THROW_DECL macro in pal.h

- https://github.com/dotnet/runtime/pull/32837

  This fixes THROW_DECL introduce in the previous PR to work with clang, which
  is required in clang 10.

- One new change:

  In a significant divergance, this commits adds more THROW_DECL macros
  to all the math functions to address a ton of errors pointed out when
  building SOS:

   ```
    In file included from /home/omajid/devel/dotnet/coreclr/src/ToolBox/SOS/Strike/strike.cpp:116:
    In file included from /home/omajid/devel/dotnet/coreclr/src/vm/hillclimbing.h:19:
    In file included from /home/omajid/devel/dotnet/coreclr/src/inc/complex.h:16:
    In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/10/../../../../include/c++/10/math.h:36:
    In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/10/../../../../include/c++/10/cmath:45:
    In file included from /usr/include/math.h:290:
    /usr/include/bits/mathcalls.h:53:13: error: exception specification in declaration does not match previous declaration
    __MATHCALL (acos,, (_Mdouble_ __x));
                ^
    /home/omajid/devel/dotnet/coreclr/src/pal/inc/pal.h:4395:26: note: previous declaration is here
    PALIMPORT double __cdecl acos(double);
                             ^
   ```

  Then, to make sure the declarations and implementations match, it adds
  THROW_DECL to the definitions in src/pal/src/cruntime/math.cpp

Co-authored-by: Mike McLaughlin <mikem@microsoft.com>
Co-authored-by: Sinan Kaya <sinan.kaya@microsoft.com>
Co-authored-by: Tom Deseyn <tom.deseyn@gmail.com>