### PR TITLE
Support function pointers in field marshalers

### DIFF
--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -164,7 +164,8 @@ do                                                      \
             pfwalk->m_managedPlacement.m_alignment = pfwalk->m_managedPlacement.m_size;
 #endif
         }
-        else if (corElemType == ELEMENT_TYPE_PTR)
+        else if (corElemType == ELEMENT_TYPE_PTR
+                || corElemType == ELEMENT_TYPE_FNPTR)
         {
             pfwalk->m_managedPlacement.m_size = TARGET_POINTER_SIZE;
             pfwalk->m_managedPlacement.m_alignment = TARGET_POINTER_SIZE;
@@ -408,6 +409,7 @@ do                                                      \
             break;
 
         case ELEMENT_TYPE_PTR:
+        case ELEMENT_TYPE_FNPTR:
 #ifdef FEATURE_COMINTEROP
             if (fIsWinRT)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37295

This was fixed in .NET 5 when [field marshalling was completely rewritten](https://github.com/dotnet/coreclr/pull/26340).

## Customer Impact

Users will be unable to have function pointers as fields in structs that are used in interop scenarios. [Function pointers](https://github.com/dotnet/csharplang/blob/master/proposals/function-pointers.md) are now supported in the C# language.

### Workaround

This can naturally be worked around by using `IntPtr`, `UIntPtr`, `void*`, `nint`, or `nuint` as the field and then casting to the appropriate function pointer type at the usage site in managed code. This would severely degrade the UX for usage of function pointers though.

## Regression?

No. This is supporting a new C# feature and previous .NET runtimes never tested/supported this scenario.

## Testing

Validated both 32 and 64 bit struct of the field marshalling scenario. This follows the same behavior as a `void*` pointer so no new functionality is added just reuse of an existing code path for a new type.

## Risk
Low. 

/cc @tannergooding @333fred @jkoritzinsky @jkotas 