### PR TITLE
Port to 3.1 - Fix JIT_CheckedWriteBarrier on macOS

### DIFF
--- a/src/vm/amd64/jithelpers_fast.S
+++ b/src/vm/amd64/jithelpers_fast.S
@@ -33,8 +33,13 @@ LEAF_ENTRY JIT_CheckedWriteBarrier, _TEXT
         // See if this is in GCHeap
         PREPARE_EXTERNAL_VAR g_lowest_address, rax
         cmp     rdi, [rax]
+#ifdef FEATURE_WRITEBARRIER_COPY
+        // jb      NotInHeap
+        .byte 0x72, 0x12
+#else
         // jb      NotInHeap
         .byte 0x72, 0x0e
+#endif
         PREPARE_EXTERNAL_VAR g_highest_address, rax
         cmp     rdi, [rax]
 


### PR DESCRIPTION
Port of https://github.com/dotnet/runtime/pull/38242

In a change to enable Mojave hardened runtime support that was made last
year, a bug was introduced into the JIT_CheckedWriteBarrier. A
conditional relative jump before an updated piece of code that was jumping
after that piece of code was not updated and ended up jumping into the
middle of an instruction. Since that condition occurs only with specific
memory layout and it is very rare, that problem was not discovered until
now.

# Customer impact
The bug is causing consistent crashes on some configurations of OSX machines while it works fine on others. Unity was hit by this problem. It was observed on the new Apple silicon devices when running under Rosetta 2 emulator, but it can occur on any x64 macOS device.

# Regression?
Yes, introduced in 3.1.0

# Testing
The original fix was supplied and tested by Unity

# Risk
Low, this fix fixes an obvious bug in assembler helper code where a conditional jump jumps into the middle of an instruction and the app crashes. 
