### PR TITLE
Modify internal pipeline to simplify 3.1-crossdac mirroring

### DIFF
--- a/eng/pipelines/internal.yml
+++ b/eng/pipelines/internal.yml
@@ -21,83 +21,90 @@ schedules:
     - master
   always: true
 
-# See mappings in https://github.com/dotnet/arcade/blob/055bb2951c3107189551ab912b4e5550928b5afb/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToPackageFeed.proj#L33-L48
-variables:
-- name: _DotNetArtifactsCategory
-  value: CORECLR
+# This condition is typically true.  It represent the normal product build case
+# It is included in the release/3.1 branches to facilitate auto merging of
+# servicing chages into the release/3.1-crossdac branch
+${{ if not(endsWith(variables['Build.SourceBranch'], 'crossdac')) }}:
+  # See mappings in https://github.com/dotnet/arcade/blob/055bb2951c3107189551ab912b4e5550928b5afb/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToPackageFeed.proj#L33-L48
+  variables:
+  - name: _DotNetArtifactsCategory
+    value: CORECLR
 
-stages:
-  - stage: build
-    jobs:
-    #
-    # Release builds
-    #
-    - template: /eng/platform-matrix.yml
-      parameters:
-        jobTemplate: build-job.yml
-        buildConfig: release
-        platformGroup: all
-        jobParameters:
-          # Publishing packages to blob feeds sometimes takes a long time
-          # due to waiting for an exclusive lock on the feed.
-          # See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing.md
-          timeoutInMinutes: 120
+  stages:
+    - stage: build
+      jobs:
+      #
+      # Release builds
+      #
+      - template: /eng/platform-matrix.yml
+        parameters:
+          jobTemplate: build-job.yml
+          buildConfig: release
+          platformGroup: all
+          jobParameters:
+            # Publishing packages to blob feeds sometimes takes a long time
+            # due to waiting for an exclusive lock on the feed.
+            # See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing.md
+            timeoutInMinutes: 120
 
-    #
-    # Publish build information to Build Assets Registry
-    #
-    # This job gathers build assets from the pipeline (from each official
-    # product build job), and publishes them to the build assets
-    # registry. Its dependencies should be updated to include all of the
-    # official builds if we add more platform/arch combinations.
-    - template: /eng/finalize-publish.yml
-      parameters:
-        dependsOn:
-        - build_Linux_arm_release
-        - build_Linux_arm64_release
-        - build_Linux_musl_x64_release
-        - build_Linux_musl_arm64_release
-        - build_Linux_rhel6_x64_release
-        - build_Linux_x64_release
-        - build_OSX_x64_release
-        - build_Windows_NT_x64_release
-        - build_Windows_NT_x86_release
-        - build_Windows_NT_arm_release
-        - build_Windows_NT_arm64_release
+      #
+      # Publish build information to Build Assets Registry
+      #
+      # This job gathers build assets from the pipeline (from each official
+      # product build job), and publishes them to the build assets
+      # registry. Its dependencies should be updated to include all of the
+      # official builds if we add more platform/arch combinations.
+      - template: /eng/finalize-publish.yml
+        parameters:
+          dependsOn:
+          - build_Linux_arm_release
+          - build_Linux_arm64_release
+          - build_Linux_musl_x64_release
+          - build_Linux_musl_arm64_release
+          - build_Linux_rhel6_x64_release
+          - build_Linux_x64_release
+          - build_OSX_x64_release
+          - build_Windows_NT_x64_release
+          - build_Windows_NT_x86_release
+          - build_Windows_NT_arm_release
+          - build_Windows_NT_arm64_release
 
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates/post-build/post-build.yml
-      parameters:
-        # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
-        enableSymbolValidation: false
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/common/templates/post-build/post-build.yml
+        parameters:
+          # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
+          enableSymbolValidation: false
 
-  - stage: test
-    displayName: Test
-    jobs:
-    #
-    # Release test builds
-    #
-    - template: /eng/platform-matrix.yml
-      parameters:
-        jobTemplate: test-job.yml
-        buildConfig: release
-        platformGroup: all
-        helixQueueGroup: all
-        ignoreDependencyOnBuildJobs: true
-        jobParameters:
-          testGroup: outerloop
+    - stage: test
+      displayName: Test
+      jobs:
+      #
+      # Release test builds
+      #
+      - template: /eng/platform-matrix.yml
+        parameters:
+          jobTemplate: test-job.yml
+          buildConfig: release
+          platformGroup: all
+          helixQueueGroup: all
+          ignoreDependencyOnBuildJobs: true
+          jobParameters:
+            testGroup: outerloop
 
-    #
-    # ReadyToRun test builds
-    #
-    - template: /eng/platform-matrix.yml
-      parameters:
-        jobTemplate: test-job.yml
-        buildConfig: release
-        platformGroup: all
-        helixQueueGroup: all
-        ignoreDependencyOnBuildJobs: true
-        jobParameters:
-          testGroup: outerloop
-          readyToRun: true
-          displayNameArgs: R2R
+      #
+      # ReadyToRun test builds
+      #
+      - template: /eng/platform-matrix.yml
+        parameters:
+          jobTemplate: test-job.yml
+          buildConfig: release
+          platformGroup: all
+          helixQueueGroup: all
+          ignoreDependencyOnBuildJobs: true
+          jobParameters:
+            testGroup: outerloop
+            readyToRun: true
+            displayNameArgs: R2R
+
+# Code below this point is reseverved for use of the crossdac branch
+# Please keep this as the last non-blank line in the release/3.1 branch


### PR DESCRIPTION
My idea is that the 3.1-crossdac will disable the normal runtime build and test (as it would be wasteful and redundant), then add its own tests.  

To simplify auto merging I wanted to keep the 3.1 servicing branch aligned with the 3.1-crossdac branch.

So this basically 
+ Adding comments.
+ A condition on `variables['Build.SourceBranch']`
+ Changing indent.

My hope is that this is the only CI change to the release/3.1 branch.