### PR TITLE
[release/2.1] Fix CancellationTokenRegistration.Token after CTS.Dispose

### DIFF
--- a/src/mscorlib/src/System/Threading/CancellationTokenRegistration.cs
+++ b/src/mscorlib/src/System/Threading/CancellationTokenRegistration.cs
@@ -41,7 +41,16 @@ namespace System.Threading
         /// registration isn't associated with a token (such as after the registration has been disposed),
         /// this will return a default token.
         /// </summary>
-        public CancellationToken Token => _node?.Partition.Source.Token ?? default(CancellationToken);
+        public CancellationToken Token
+        {
+            get
+            {
+                CancellationTokenSource.CallbackNode node = _node;
+                return node != null ?
+                    new CancellationToken(node.Partition.Source) : // avoid CTS.Token, which throws after disposal
+                    default;
+            }
+        }
 
         /// <summary>
         /// Disposes of the registration and unregisters the target callback from the associated 


### PR DESCRIPTION
Ports https://github.com/dotnet/coreclr/pull/21417 from 2.2 to 2.1

#### Description

CTR.Token should never throw, but it's currently throwing an ObjectDisposedException if the associated CancellationTokenSource has been disposed.

Details: We added the CancellationTokenRegistration.Token property in .NET Core 2.1.  Since the CTR already knows with what token it's associated, allowing you to get the token from the CTR saves you from also needing to separately store the token, which lets you improve memory utilization by not carrying it around effectively twice.  We took advantage of that, for example, in FileStream's Read/WriteAsync operations, to decrease the size of the object allocated for those operations.  However, the CTR.Token property is incorrectly throwing an ObjectDisposedException if the associated CancellationTokenSource has been disposed, which introduces an ODE where there wasn't previously one (just accessing a CancellationToken you already had stored).  This is causing regressions in code that created a token source, registered with its token, and then disposed the source.

#### Customer Impact

e.g.
Exceptions on background threads that crash the process when performing operations like:
```C#
var cts = new CancellationTokenSource();
Task<int> t = fileStream.ReadAsync(..., cts.Token);
cts.Dispose();
int result = await t;
```

We fixed this in 2.2 but so far held off on backporting to 2.1 pending more customer data since it's an LTS release. Since then we've had 2 more reports (see https://github.com/dotnet/runtime/issues/37641) most recently a customer that says:

> It may take the rest of the year to reach 3.1. In the meantime our servers are crashing and clients are getting mad! I can only apologize to them, mitigate the issues as best as possible and then blame you for not updating an LTS version!

Since the change is very low risk -- it's been in the product since 2.2 -- we are proposing we now backport to 2.1

#### Regression?

Yes.  It's not a regression in CancellationTokenRegistration.Token, which was only introduced in 2.1, but rather a regression in that it's behavior isn't matching code it was used to replace, so it's for example a regression in FileStream.Read/WriteAsync.

#### Packaging reviewed? 

Change affects System.Private.CoreLib only.

#### Risk

Minimal.  The new code is effectively the same as the old, except avoiding a ThrowIfDisposed call.
cc: @danmosemsft 