### PR TITLE
More release/3.1 crossdac incremental changes

### DIFF
--- a/build-crossdac.sh
+++ b/build-crossdac.sh
@@ -10,7 +10,7 @@ chmod u+x dotnet-install.sh
 
 # Fetch prebuilt runtime pieces
 
-RUNTIME_URL_PREFIX=$(./dotnet-install.sh --dry-run --runtime dotnet --version ${VERSION_IDENTIFIER} --arch arm64 | grep 'Primary named payload URL:' | sed -e 's/^.*URL: //' -e 's/linux-musl/linux/' -e 's/linux-arm64.tar.gz//')
+RUNTIME_URL_PREFIX=$(./dotnet-install.sh --dry-run --runtime dotnet --channel 3.1 --version ${VERSION_IDENTIFIER} --arch arm64 | grep 'Primary named payload URL:' | sed -e 's/^.*URL: //' -e 's/linux-musl/linux/' -e 's/linux-arm64.tar.gz//')
 
 for rid in linux-arm linux-arm64 linux-musl-arm64 linux-x64 linux-musl-x64
 do

--- a/eng/build-crossdac-job.yml
+++ b/eng/build-crossdac-job.yml
@@ -6,6 +6,7 @@ parameters:
   container: ''
   timeoutInMinutes: ''
   coreClrBuildId: 'latest'
+  symStoreCrossDacIndex: ''
 
 ### Product build
 jobs:
@@ -49,6 +50,8 @@ jobs:
         value: '-officialbuildid=$(Build.BuildNumber)'
     - name: coreClrBuildId
       value: ${{ parameters.coreClrBuildId }}
+    - name: symStoreCrossDacIndex
+      value: ${{ parameters.symStoreCrossDacIndex }}
 
     steps:
 
@@ -137,7 +140,7 @@ jobs:
             SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
 
       # Build packages
-      - script: build-packages.cmd -CrossDacOnly -BuildArch=$(archType) -BuildType=$(_BuildConfig) $(officialBuildIdArg) -ci
+      - script: build-packages.cmd -CrossDacOnly -BuildArch=$(archType) -BuildType=$(_BuildConfig) $(officialBuildIdArg) -ci /p:SymStoreCrossDacIndex=$(symStoreCrossDacIndex)
         displayName: Build packages
 
       # Publish official build

--- a/eng/pipelines/internal.yml
+++ b/eng/pipelines/internal.yml
@@ -10,7 +10,7 @@ variables:
 - name: _DotNetArtifactsCategory
   value: CORECLR
 - name: CrossDacCoreClrVersion
-  value: ''
+  value: 'latest'
 
 stages:
   - stage: Prepare
@@ -24,6 +24,8 @@ stages:
         buildConfig: release
         platforms:
         - Linux_arm64 # Needs an ubuntu container
+        jobParameters:
+          coreClrBuildId: variables['CrossDacCoreClrVersion']
 
   - stage: Build
     jobs:
@@ -45,7 +47,7 @@ stages:
           # due to waiting for an exclusive lock on the feed.
           # See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing.md
           timeoutInMinutes: 120
-          coreClrBuildId: variables['coreClrVersion']
+          coreClrBuildId: variables['CrossDacCoreClrVersion']
 
     #
     # Publish build information to Build Assets Registry

--- a/eng/pipelines/internal.yml
+++ b/eng/pipelines/internal.yml
@@ -11,6 +11,8 @@ variables:
   value: CORECLR
 - name: CrossDacCoreClrVersion
   value: 'latest'
+- name: SymStoreCrossDacIndex
+  value: 'false'
 
 stages:
   - stage: Prepare
@@ -48,6 +50,7 @@ stages:
           # See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing.md
           timeoutInMinutes: 120
           coreClrBuildId: variables['CrossDacCoreClrVersion']
+          symStoreCrossDacIndex: variables['SymStoreCrossDacIndex']
 
     #
     # Publish build information to Build Assets Registry


### PR DESCRIPTION
+ allow the branch to continue after 5.0 releases
+ Fixup `CrossDacCoreClrVersion` variable routing
+ Add `SymStoreCrossDacIndex` to add libcoreclr.so to packages and enable SymStore indexing