### PR TITLE
Don't prune the IManagedActivationFactory type

### DIFF
--- a/src/System.Private.CoreLib/ILLinkTrim.xml
+++ b/src/System.Private.CoreLib/ILLinkTrim.xml
@@ -69,6 +69,7 @@
     <type fullname="System.Runtime.InteropServices.CustomMarshalers.*" />
     <!-- Accessed by the WinRT Host -->
     <type fullname="Internal.Runtime.InteropServices.WindowsRuntime.ActivationFactoryLoader" />
+    <type fullname="System.Runtime.InteropServices.WindowsRuntime.IManagedActivationFactory" />
     <!-- Workaround for https://github.com/mono/linker/issues/378 -->
     <type fullname="System.Runtime.InteropServices.IDispatch" />
     <type fullname="Internal.Runtime.InteropServices.IClassFactory2" />


### PR DESCRIPTION
Fixes a user reported issue for consuming XAML Islands in .NET 3.1. The result is a random failure typically during XAML load. The managed definition of [`IManagedActivationFactory`](https://github.com/dotnet/coreclr/blob/68ec8a211852cc9cf662d19bac251f364719702f/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/ManagedActivationFactory.cs#L10-L16) has been pruned of its function and thus when a call is made to a class implementing that interface, random memory is executed since there is no entry in the vtable.

The scenario involving this code was [removed in .NET 5.0](https://github.com/dotnet/runtime/issues/37672) so there is no need to bring the work forward.

## Customer Impact

Users will be unable to use XAML Islands or WinUI with bindings in .NET 3.1.

### Workaround

There is no work around. The Linker removed the function definition and single implementation in question - they no longer exist in the assembly to call.

## Regression?

This is probably a regression, but I have not identified the exact location where the break was introduced.

Confirmed the method is missing and broken in [3.0.1](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-win-x64.exe), but the method is present in 2.2.7.

## Testing

Validated a patched version of `System.Private.CoreLib` against a XAML Island scenario from https://github.com/microsoft/Xaml-Islands-Samples.

## Risk
Low. 

/cc @jeffschwMSFT @jkotas @jkoritzinsky 