### PR TITLE
Enable FEATURE_METADATA_VERIFY_LAYOUTS and fix debugging regression

### DIFF
--- a/src/md/datasource/datatargetreader.cpp
+++ b/src/md/datasource/datatargetreader.cpp
@@ -163,13 +163,10 @@ void DataTargetReader::Align(DWORD alignmentBytes)
 
 void DataTargetReader::AlignBase()
 {
-#ifdef _MSC_VER
-    // Windows MSVC compiler aligns structs based on the largest field size
+    // Align structs based on the largest field size
+    // This is the default for MSVC compilers
+    // This is forced on other platforms by the DAC_ALIGNAS macro
     Align(m_currentStructureAlign);
-#else
-    // clang (on all platforms) aligns structs always on 4 byte boundaries
-    Align(4);
-#endif
 }
 
 HRESULT DataTargetReader::GetRemotePointerSize(ULONG32* pPointerSize)

--- a/src/md/hotdata/hotheap.h
+++ b/src/md/hotdata/hotheap.h
@@ -14,6 +14,8 @@
 
 #include "external.h"
 
+class VerifyLayoutsMD;
+
 namespace MetaData
 {
 
@@ -26,7 +28,7 @@ struct HotHeapHeader;
 // 
 class HotHeap
 {
-    friend class VerifyLayoutsMD;
+    friend class ::VerifyLayoutsMD;
 private:
     struct HotHeapHeader *m_pHotHeapHeader;
     

--- a/src/md/inc/VerifyLayouts.inc
+++ b/src/md/inc/VerifyLayouts.inc
@@ -143,7 +143,11 @@ FIELD(MDInternalRW, m_pSemReadWrite, sizeof(void*))
 FIELD(MDInternalRW, m_fOwnSem, 4)
 END_TYPE(MDInternalRW, sizeof(void*))
 
+#ifdef _MSC_VER // Corresponds to `#ifdef _MSC_VER` in DataTargetReader::AlignBase()
 BEGIN_TYPE(CLiteWeightStgdbRW, sizeof(CLiteWeightStgdb<CMiniMdRW>))
+#else // _MSC_VER
+BEGIN_TYPE(CLiteWeightStgdbRW, sizeof(CLiteWeightStgdb<CMiniMdRW>) - 4)
+#endif // _MSC_VER
 FIELD(CLiteWeightStgdbRW, m_cbSaveSize, 4)
 FIELD(CLiteWeightStgdbRW, m_bSaveCompressed, 4)
 FIELD(CLiteWeightStgdbRW, m_pImage, sizeof(void*))
@@ -236,7 +240,11 @@ ALIGN_FIELD(StgGuidPool, m_Hash, sizeof(CGuidPoolHash), sizeof(void*))
 FIELD(StgGuidPool, m_bHash, sizeof(BOOL))
 END_TYPE(StgGuidPool, sizeof(void*))
 
+#ifdef _MSC_VER // Corresponds to `#ifdef _MSC_VER` in DataTargetReader::AlignBase()
 BEGIN_TYPE(RecordPool, sizeof(StgPool))
+#else // _MSC_VER
+BEGIN_TYPE(RecordPool, sizeof(StgPool) - 4)
+#endif // _MSC_VER
 FIELD(RecordPool, m_cbRec, 4)
 END_TYPE(RecordPool, sizeof(void*))
 
@@ -276,7 +284,11 @@ ALIGN_FIELD(StgPoolReadOnly, m_HotHeap, sizeof(MetaData::HotHeap), sizeof(void*)
 END_TYPE(StgPoolReadOnly, sizeof(void*))
 
 USING_ALIAS(MapSHash__ULONG__ULONG, MapSHash<ULONG, ULONG>) // Create a using alias to avoid commas in the type name
+#ifdef _MSC_VER // Corresponds to `#ifdef _MSC_VER` in Target_MapSHash::ReadFrom(DataTargetReader & reader)
 BEGIN_TYPE(MapSHash__ULONG__ULONG, sizeof(void*))
+#else // _MSC_VER
+BEGIN_TYPE(MapSHash__ULONG__ULONG, 0)
+#endif // _MSC_VER
 FIELD(MapSHash__ULONG__ULONG, m_table, sizeof(void*))
 FIELD(MapSHash__ULONG__ULONG, m_tableSize, 4)
 FIELD(MapSHash__ULONG__ULONG, m_tableCount, 4)

--- a/src/md/inc/VerifyLayouts.inc
+++ b/src/md/inc/VerifyLayouts.inc
@@ -143,11 +143,7 @@ FIELD(MDInternalRW, m_pSemReadWrite, sizeof(void*))
 FIELD(MDInternalRW, m_fOwnSem, 4)
 END_TYPE(MDInternalRW, sizeof(void*))
 
-#ifdef _MSC_VER // Corresponds to `#ifdef _MSC_VER` in DataTargetReader::AlignBase()
 BEGIN_TYPE(CLiteWeightStgdbRW, sizeof(CLiteWeightStgdb<CMiniMdRW>))
-#else // _MSC_VER
-BEGIN_TYPE(CLiteWeightStgdbRW, sizeof(CLiteWeightStgdb<CMiniMdRW>) - 4)
-#endif // _MSC_VER
 FIELD(CLiteWeightStgdbRW, m_cbSaveSize, 4)
 FIELD(CLiteWeightStgdbRW, m_bSaveCompressed, 4)
 FIELD(CLiteWeightStgdbRW, m_pImage, sizeof(void*))
@@ -240,11 +236,7 @@ ALIGN_FIELD(StgGuidPool, m_Hash, sizeof(CGuidPoolHash), sizeof(void*))
 FIELD(StgGuidPool, m_bHash, sizeof(BOOL))
 END_TYPE(StgGuidPool, sizeof(void*))
 
-#ifdef _MSC_VER // Corresponds to `#ifdef _MSC_VER` in DataTargetReader::AlignBase()
 BEGIN_TYPE(RecordPool, sizeof(StgPool))
-#else // _MSC_VER
-BEGIN_TYPE(RecordPool, sizeof(StgPool) - 4)
-#endif // _MSC_VER
 FIELD(RecordPool, m_cbRec, 4)
 END_TYPE(RecordPool, sizeof(void*))
 

--- a/src/md/inc/VerifyLayouts.inc
+++ b/src/md/inc/VerifyLayouts.inc
@@ -75,29 +75,20 @@
 //    Make sure that the define is registered in the list of defines and the debugger reading code knows how to dynamically
 //    adjust for it (See VerifyLayouts.h comment item (b) and (c))
 //
-// 2) If your type names use characters that aren't valid identifiers (such as the '<' and '>' chars in templates)
-//    then you need to provide an escaped name. There are variations of the macros above to do that:
-//    BEGIN_TYPE_ESCAPED(typeName, escaptedTypeName, firstFieldOffset)
-//    FIELD_ESCAPED(typeName, escapedTypeName, fieldName, fieldSize)
-//    ALIGN_FIELD_ESCAPED(typeName, escapedTypeName, fieldName, fieldSize, fieldAlign)
-//    END_TYPE_ESCAPED(typeName, escapedTypeName, typeAlignment)
+// 2) If your type names use characters that aren't valid identifiers (such as the '<', '>' and ',' chars in templates)
+//    then you need to provide an escaped name. Use the USING_ALIAS macros to do that:
+//    USING_ALIAS(escapedTypeName, typeName)
 //
 //    If CFoo above had instead been CFoo<ULONG> we would write:
-//    BEGIN_TYPE_ESCAPED(CFoo<ULONG>, CFoo__ULONG__, 0)
-//    FIELD_ESCAPED(CFoo<ULONG>, CFoo__ULONG__, m_ptrField, sizeof(void*))
-//    END_TYPE_ESCAPED(CFoo<ULONG>, CFoo__ULONG__, sizeof(void*))
+//    USING_ALIAS(CFoo__ULONG__, CFoo<ULONG>)
+//    BEGIN_TYPE(CFoo__ULONG__, 0)
+//    FIELD(CFoo__ULONG__, m_ptrField, sizeof(void*))
+//    END_TYPE(CFoo__ULONG__, sizeof(void*))
 //
 //    The escapedTypeName is relatively arbitrary, but convention is to replace the illegal characters with double underscore
 //    The name does show up in build error messages, so it should close to the real name for people to understand
 //
-// 3) If your type name has commas in it (such as in a list of template arguments) the macros could interpret it as seperate
-//    arguments (no good). To fix this use the IGNORE_COMMAS() macro to escape any typeNames with commas. If CFoo above had
-//    been CFoo<ULONG,INT> you could rewrite the defines as:
-//    BEGIN_TYPE_ESCAPED(IGNORE_COMMAS(CFoo<ULONG,INT>), CFoo__ULONG__INT__, 0)
-//    FIELD_ESCAPED(IGNORE_COMMAS(CFoo<ULONG,INT>), CFoo__ULONG__INT__, m_ptrField, sizeof(void*))
-//    END_TYPE_ESCAPED(IGNORE_COMMAS(CFoo<ULONG,INT>), CFoo__ULONG__INT__, sizeof(void*))
-//
-//  4) If you have a bitfield in your type, the offsetof macro can't be used which will break the static asserts.
+//  3) If you have a bitfield in your type, the offsetof macro can't be used which will break the static asserts.
 //     There is a special BITFIELD macro that can work around it:
 //     BITFIELD(typeName, fieldName, expectedFieldOffset, fieldSize, fieldAlign)
 //
@@ -168,11 +159,12 @@ FIELD(CLiteWeightStgdbRW, m_dwDatabaseLFS, 4)
 FIELD(CLiteWeightStgdbRW, m_pStgIO, sizeof(void*))
 END_TYPE(CLiteWeightStgdbRW, 8)
 
-BEGIN_TYPE_ESCAPED(CLiteWeightStgdb<CMiniMdRW>, CLiteWeightStgdb__CMiniMdRW__, 0)
-ALIGN_FIELD_ESCAPED(CLiteWeightStgdb<CMiniMdRW>, CLiteWeightStgdb__CMiniMdRW__, m_MiniMd, sizeof(CMiniMdRW), sizeof(void*))
-FIELD_ESCAPED(CLiteWeightStgdb<CMiniMdRW>, CLiteWeightStgdb__CMiniMdRW__, m_pvMd, sizeof(void*))
-FIELD_ESCAPED(CLiteWeightStgdb<CMiniMdRW>, CLiteWeightStgdb__CMiniMdRW__, m_cbMd, 4)
-END_TYPE_ESCAPED(CLiteWeightStgdb<CMiniMdRW>, CLiteWeightStgdb__CMiniMdRW__, sizeof(void*))
+USING_ALIAS(CLiteWeightStgdb__CMiniMdRW__, CLiteWeightStgdb<CMiniMdRW>)
+BEGIN_TYPE(CLiteWeightStgdb__CMiniMdRW__, 0)
+ALIGN_FIELD(CLiteWeightStgdb__CMiniMdRW__, m_MiniMd, sizeof(CMiniMdRW), sizeof(void*))
+FIELD(CLiteWeightStgdb__CMiniMdRW__, m_pvMd, sizeof(void*))
+FIELD(CLiteWeightStgdb__CMiniMdRW__, m_cbMd, 4)
+END_TYPE(CLiteWeightStgdb__CMiniMdRW__, sizeof(void*))
 
 BEGIN_TYPE(CMiniMdRW, sizeof(CMiniMdTemplate<CMiniMdRW>))
 FIELD(CMiniMdRW, m_pMemberRefHash, sizeof(void*))
@@ -273,23 +265,24 @@ BEGIN_TYPE(CGuidPoolHash, sizeof(CChainedHash<GUIDHASH>))
 FIELD(CGuidPoolHash, m_Pool, sizeof(void*))
 END_TYPE(CGuidPoolHash, sizeof(void*))
 
-
-BEGIN_TYPE_ESCAPED(MetaData::HotHeap, MetaData__HotHeap, 0)
-FIELD_ESCAPED(MetaData::HotHeap, MetaData__HotHeap, m_pHotHeapHeader, sizeof(void*))
-END_TYPE_ESCAPED(MetaData::HotHeap, MetaData__HotHeap, sizeof(void*))
+USING_ALIAS(MetaData__HotHeap, MetaData::HotHeap)
+BEGIN_TYPE(MetaData__HotHeap, 0)
+FIELD(MetaData__HotHeap, m_pHotHeapHeader, sizeof(void*))
+END_TYPE(MetaData__HotHeap, sizeof(void*))
 
 
 BEGIN_TYPE(StgPoolReadOnly, sizeof(StgPoolSeg) + sizeof(void*))                   //vtable pointer
 ALIGN_FIELD(StgPoolReadOnly, m_HotHeap, sizeof(MetaData::HotHeap), sizeof(void*))
 END_TYPE(StgPoolReadOnly, sizeof(void*))
 
-BEGIN_TYPE_ESCAPED(IGNORE_COMMAS(MapSHash<ULONG, ULONG>), MapSHash__ULONG__ULONG, sizeof(void*))
-FIELD_ESCAPED(IGNORE_COMMAS(MapSHash<ULONG, ULONG>), MapSHash__ULONG__ULONG, m_table, sizeof(void*))
-FIELD_ESCAPED(IGNORE_COMMAS(MapSHash<ULONG, ULONG>), MapSHash__ULONG__ULONG, m_tableSize, 4)
-FIELD_ESCAPED(IGNORE_COMMAS(MapSHash<ULONG, ULONG>), MapSHash__ULONG__ULONG, m_tableCount, 4)
-FIELD_ESCAPED(IGNORE_COMMAS(MapSHash<ULONG, ULONG>), MapSHash__ULONG__ULONG, m_tableOccupied, 4)
-FIELD_ESCAPED(IGNORE_COMMAS(MapSHash<ULONG, ULONG>), MapSHash__ULONG__ULONG, m_tableMax, 4)
-END_TYPE_ESCAPED(IGNORE_COMMAS(MapSHash<ULONG, ULONG>), MapSHash__ULONG__ULONG, sizeof(void*))
+USING_ALIAS(MapSHash__ULONG__ULONG, MapSHash<ULONG, ULONG>) // Create a using alias to avoid commas in the type name
+BEGIN_TYPE(MapSHash__ULONG__ULONG, sizeof(void*))
+FIELD(MapSHash__ULONG__ULONG, m_table, sizeof(void*))
+FIELD(MapSHash__ULONG__ULONG, m_tableSize, 4)
+FIELD(MapSHash__ULONG__ULONG, m_tableCount, 4)
+FIELD(MapSHash__ULONG__ULONG, m_tableOccupied, 4)
+FIELD(MapSHash__ULONG__ULONG, m_tableMax, 4)
+END_TYPE(MapSHash__ULONG__ULONG, sizeof(void*))
 
 
 BEGIN_TYPE(StgPoolSeg, 0)
@@ -299,15 +292,15 @@ FIELD(StgPoolSeg, m_cbSegSize, 4)
 FIELD(StgPoolSeg, m_cbSegNext, 4)
 END_TYPE(StgPoolSeg, sizeof(void*))
 
-
-BEGIN_TYPE_ESCAPED(CChainedHash<STRINGHASH>, CCHainedHash_STRINGHASH, sizeof(void*))         // vtable pointer
-FIELD_ESCAPED(CChainedHash<STRINGHASH>, CCHainedHash_STRINGHASH, m_rgData, sizeof(void*))
-FIELD_ESCAPED(CChainedHash<STRINGHASH>, CCHainedHash_STRINGHASH, m_iBuckets, 4)
-FIELD_ESCAPED(CChainedHash<STRINGHASH>, CCHainedHash_STRINGHASH, m_iSize, 4)
-FIELD_ESCAPED(CChainedHash<STRINGHASH>, CCHainedHash_STRINGHASH, m_iCount, 4)
-FIELD_ESCAPED(CChainedHash<STRINGHASH>, CCHainedHash_STRINGHASH, m_iMaxChain, 4)
-FIELD_ESCAPED(CChainedHash<STRINGHASH>, CCHainedHash_STRINGHASH, m_iFree, 4)
-END_TYPE_ESCAPED(CChainedHash<STRINGHASH>, CCHainedHash_STRINGHASH, sizeof(void*))
+USING_ALIAS(CCHainedHash_STRINGHASH, CChainedHash<STRINGHASH>)
+BEGIN_TYPE(CCHainedHash_STRINGHASH, sizeof(void*))         // vtable pointer
+FIELD(CCHainedHash_STRINGHASH, m_rgData, sizeof(void*))
+FIELD(CCHainedHash_STRINGHASH, m_iBuckets, 4)
+FIELD(CCHainedHash_STRINGHASH, m_iSize, 4)
+FIELD(CCHainedHash_STRINGHASH, m_iCount, 4)
+FIELD(CCHainedHash_STRINGHASH, m_iMaxChain, 4)
+FIELD(CCHainedHash_STRINGHASH, m_iFree, 4)
+END_TYPE(CCHainedHash_STRINGHASH, sizeof(void*))
 
 
 BEGIN_TYPE(CMiniColDef, 0)

--- a/src/md/inc/verifylayouts.h
+++ b/src/md/inc/verifylayouts.h
@@ -102,8 +102,8 @@
 #include <stddef.h> // offsetof
 #include "static_assert.h"
 #include "metamodel.h"
-#include "WinMDInterfaces.h"
-#include "MDInternalRW.h"
+#include "winmdinterfaces.h"
+#include "mdinternalrw.h"
 
 // other types provide friend access to this type so that the
 // offsetof macro can access their private fields
@@ -112,70 +112,64 @@ class VerifyLayoutsMD
     // we have a bunch of arrays with this fixed size, make sure it doesn't change
     static_assert_no_msg(TBL_COUNT == 45);
 
+#define USING_ALIAS(typeName, ...)  using typeName = __VA_ARGS__;
 
+#define FIELD(typeName, fieldName, fieldSize) ALIGN_FIELD(typeName, fieldName, fieldSize, fieldSize)
 
-#define IGNORE_COMMAS(...) __VA_ARGS__ // use this to surround templated types with commas in the name
+#define BEGIN_TYPE(typeName, initialFieldOffset) \
+    static const int expected_offset_of_first_field_in_##typeName = initialFieldOffset; \
+    static const int actual_offset_of_first_field_in_##typeName =
 
-#define BEGIN_TYPE(typeName, initialFieldOffset) BEGIN_TYPE_ESCAPED(typeName, typeName, initialFieldOffset)
-#define FIELD(typeName, fieldName, fieldSize) ALIGN_FIELD_ESCAPED(typeName, typeName, fieldName, fieldSize, fieldSize)
-#define ALIGN_FIELD(typeName, fieldName, fieldSize, fieldAlign) ALIGN_FIELD_ESCAPED(typeName, typeName, fieldName, fieldSize, fieldAlign)
-#define FIELD_ESCAPED(typeName, escapedTypeName, fieldName, fieldSize) ALIGN_FIELD_ESCAPED(typeName, escapedTypeName, fieldName, fieldSize, fieldSize)
-#define END_TYPE(typeName, typeAlign) END_TYPE_ESCAPED(typeName, typeName, typeAlign)
-
-#define BEGIN_TYPE_ESCAPED(typeName, typeNameEscaped, initialFieldOffset) \
-    static const int expected_offset_of_first_field_in_##typeNameEscaped## = initialFieldOffset; \
-    static const int actual_offset_of_first_field_in_##typeNameEscaped## =
-
-#define ALIGN_FIELD_ESCAPED(typeName, typeNameEscaped, fieldName, fieldSize, fieldAlign) \
-    offsetof(IGNORE_COMMAS(typeName), fieldName); \
-    static const int offset_of_field_after_##typeNameEscaped##_##fieldName =
+#define ALIGN_FIELD(typeName, fieldName, fieldSize, fieldAlign) \
+    offsetof(typeName, fieldName); \
+    static const int offset_of_field_after_##typeName##_##fieldName =
 
 #define BITFIELD(typeName, fieldName, fieldOffset, fieldSize) \
     fieldOffset; \
     static const int offset_of_field_after_##typeName##_##fieldName =
 
-#define END_TYPE_ESCAPED(typeName, typeNameEscaped, typeAlignentSize) \
+#define END_TYPE(typeName, typeAlignentSize) \
     sizeof(typeName);
 
 #include "VerifyLayouts.inc"
 
-#undef BEGIN_TYPE_ESCAPED
-#undef ALIGN_FIELD_ESCAPED
-#undef END_TYPE_ESCAPED
+#undef BEGIN_TYPE
+#undef ALIGN_FIELD
+#undef END_TYPE
 #undef BITFIELD
 
-#define BEGIN_TYPE_ESCAPED(typeName, escapedTypeName, initialFieldOffset) \
-    static const int alignment_of_first_field_in_##escapedTypeName =
-#define ALIGN_FIELD_ESCAPED(typeName, escapedTypeName, fieldName, fieldSize, fieldAlign) \
+#define BEGIN_TYPE(typeName, initialFieldOffset) \
+    static const int alignment_of_first_field_in_##typeName =
+#define ALIGN_FIELD(typeName, fieldName, fieldSize, fieldAlign) \
     fieldAlign; \
-    static const int alignment_of_field_after_##escapedTypeName##_##fieldName =
+    static const int alignment_of_field_after_##typeName##_##fieldName =
 #define BITFIELD(typeName, fieldName, fieldOffset, fieldSize) \
     fieldSize; \
     static const int alignment_of_field_after_##typeName##_##fieldName =
-#define END_TYPE_ESCAPED(typeName, escapedTypeName, typeAlignmentSize) \
+#define END_TYPE(typeName, typeAlignmentSize) \
     typeAlignmentSize;
 
 #include "VerifyLayouts.inc"
 
-#undef BEGIN_TYPE_ESCAPED
-#undef ALIGN_FIELD_ESCAPED
-#undef END_TYPE_ESCAPED
+#undef BEGIN_TYPE
+#undef ALIGN_FIELD
+#undef END_TYPE
 #undef BITFIELD
 
     
-#define BEGIN_TYPE_ESCAPED(typeName, escapedTypeName, initialFieldOffset) \
-    static_assert_no_msg(expected_offset_of_first_field_in_##escapedTypeName == actual_offset_of_first_field_in_##escapedTypeName);
+#define BEGIN_TYPE(typeName, initialFieldOffset) \
+    static_assert_no_msg(expected_offset_of_first_field_in_##typeName == actual_offset_of_first_field_in_##typeName);
 
 
 #define ALIGN_UP(value, alignment) (((value) + (alignment) - 1)&~((alignment) - 1))
-#define ALIGN_FIELD_ESCAPED(typeName, escapedTypeName, fieldName, fieldSize, fieldAlign) \
-    static_assert_no_msg(offset_of_field_after_##escapedTypeName##_##fieldName == \
-    ALIGN_UP(offsetof(IGNORE_COMMAS(typeName), fieldName) + fieldSize, alignment_of_field_after_##escapedTypeName##_##fieldName));
+#define ALIGN_FIELD(typeName, fieldName, fieldSize, fieldAlign) \
+    static_assert_no_msg(offset_of_field_after_##typeName##_##fieldName == \
+    ALIGN_UP(offsetof(typeName, fieldName) + fieldSize, alignment_of_field_after_##typeName##_##fieldName));
 #define BITFIELD(typeName, fieldName, fieldOffset, fieldSize) \
     static_assert_no_msg(offset_of_field_after_##typeName##_##fieldName == \
     ALIGN_UP(fieldOffset + fieldSize, alignment_of_field_after_##typeName##_##fieldName));
         
-#define END_TYPE_ESCAPED(typeName, escapedTypeName, typeAlignmentSize)
+#define END_TYPE(typeName, typeAlignmentSize)
 #include "VerifyLayouts.inc"
 
 };

--- a/src/md/inc/verifylayouts.h
+++ b/src/md/inc/verifylayouts.h
@@ -133,10 +133,15 @@ class VerifyLayoutsMD
 
 #include "VerifyLayouts.inc"
 
+// Only declare using once
+#undef USING_ALIAS
+#define USING_ALIAS(a, ...)
+
 #undef BEGIN_TYPE
 #undef ALIGN_FIELD
 #undef END_TYPE
 #undef BITFIELD
+
 
 #define BEGIN_TYPE(typeName, initialFieldOffset) \
     static const int alignment_of_first_field_in_##typeName =

--- a/src/md/md_wks.cmake
+++ b/src/md/md_wks.cmake
@@ -1,6 +1,4 @@
 add_definitions(-DFEATURE_METADATA_EMIT)
 add_definitions(-DFEATURE_METADATA_INTERNAL_APIS)
 add_definitions(-DFEATURE_METADATA_IN_VM)
-if(WIN32)
-  add_definitions(-DFEATURE_METADATA_VERIFY_LAYOUTS)
-endif(WIN32)
+add_definitions(-DFEATURE_METADATA_VERIFY_LAYOUTS)


### PR DESCRIPTION
#28035 Changed the layout of several types used in the DBI. The code to verify these layouts was only enabled on Windows. Therefore these layout changes were not detected and the TargetTypes/DataTargetReader code responsible for binary translation was not updated

This is a draft patch to document the process used to find and verify the layout changes.  I suspect this is too big a patch to take in 3.1 servicing.  The https://github.com/dotnet/coreclr/commit/7c68ef0ca51618797043174fe547064cb872e013 patch will likely be the ultimate servicing patch

/cc @hoyosjs @noahfalk @jeffschwMSFT @jkotas @chuckries 