### PR TITLE
[3.1] build.sh skipcrossgen failed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -447,12 +447,8 @@ build_CoreLib()
 
     if [ $__SkipCrossgen == 1 ]; then
         echo "Skipping generating native image"
-
-        if [ $__CrossBuild == 1 ]; then
-            # Crossgen not performed, so treat the IL version as the final version
-            cp $__CoreLibILDir/System.Private.CoreLib.dll $__BinDir/System.Private.CoreLib.dll
-        fi
-
+        # Crossgen not performed, so treat the IL version as the final version
+        cp $__CoreLibILDir/System.Private.CoreLib.dll $__BinDir/System.Private.CoreLib.dll
         return
     fi
 


### PR DESCRIPTION
dotnet/runtime has a new build system and I cannot reproduce this issue with dotnet/runtime. I have no idea whether coreclr 3.1 accept new fixes. If not, please free feel to close the PR. Thanks!

```
$ ./build.sh skipcrossgen
...
Command successfully completed.
Running init-dotnet.sh
Installing dotnet using Arcade...
Running: /disk/aoqi/disk/dotnet/coreclr/.dotnet/dotnet msbuild /nologo /verbosity:minimal /clp:Summary /p:PortableBuild=true /maxcpucount /p:ArcadeBuild=true /home/aoqi/work/dotnet/dotnet/coreclr/src/build.proj /flp:Verbosity=normal;LogFile=/home/aoqi/work/dotnet/dotnet/coreclr/bin/Logs/System.Private.CoreLib_Debug.log /p:__IntermediatesDir=/home/aoqi/work/dotnet/dotnet/coreclr/bin/obj/Linux.x64.Debug /p:__RootBinDir=/home/aoqi/work/dotnet/dotnet/coreclr/bin /p:__BuildArch=x64 /p:__BuildType=Debug /p:__BuildOS=Linux /nodeReuse:false /p:RestoreDuringBuild=true /p:OptimizationDataDir="/home/aoqi/work/dotnet/dotnet/coreclr/.packages/optimization.Linux-x64.IBC.CoreCLR/99.99.99-master-20190912.1/data" /p:EnableProfileGuidedOptimization=true /p:BuildManagedTools=true
  runincontext -> /home/aoqi/work/dotnet/dotnet/coreclr/bin/Product/Linux.x64.Debug/runincontext.dll
  R2RDump -> /home/aoqi/work/dotnet/dotnet/coreclr/bin/Product/Linux.x64.Debug/R2RDump.dll
  System.Private.CoreLib -> /home/aoqi/work/dotnet/dotnet/coreclr/bin/Product/Linux.x64.Debug/IL/System.Private.CoreLib.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:06.72
Command successfully completed.
Skipping generating native image
Generating nuget packages for Linux
DistroRid is linux-x64
ROOTFS_DIR is 
/disk/aoqi/disk/dotnet/coreclr/.dotnet/sdk/3.1.100/MSBuild.dll /nologo -bl:/home/aoqi/work/dotnet/dotnet/coreclr/bin/Logs/Nuget_Debug.binlog -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,/disk/aoqi/disk/dotnet/coreclr/.dotnet/sdk/3.1.100/dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,/disk/aoqi/disk/dotnet/coreclr/.dotnet/sdk/3.1.100/dotnet.dll -maxcpucount /m -verbosity:m /v:minimal /clp:Summary /nr:true /nodeReuse:false /p:TreatWarningsAsErrors=true /p:ContinuousIntegrationBuild=false /p:Configuration=Debug /p:RepoRoot=/disk/aoqi/disk/dotnet/coreclr /p:Restore=true /p:Build=true /p:Rebuild=false /p:Test=false /p:Pack=false /p:IntegrationTest=false /p:PerformanceTest=false /p:Sign=false /p:Publish=false /p:PortableBuild=true /p:ArcadeBuild=true /p:__IntermediatesDir=/home/aoqi/work/dotnet/dotnet/coreclr/bin/obj/Linux.x64.Debug /p:__RootBinDir=/home/aoqi/work/dotnet/dotnet/coreclr/bin /p:__DoCrossArchBuild=0 /p:__BuildArch=x64 /p:__BuildType=Debug /p:__BuildOS=Linux /p:RestoreDuringBuild=true /p:Projects=/home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/packages.builds /warnaserror /disk/aoqi/disk/dotnet/coreclr/.packages/microsoft.dotnet.arcade.sdk/1.0.0-beta.20113.5/tools/Build.proj
  Restore completed in 17.97 ms for /disk/aoqi/disk/dotnet/coreclr/.packages/microsoft.dotnet.arcade.sdk/1.0.0-beta.20113.5/tools/Tools.proj.
  Restore completed in 4.95 ms for /disk/aoqi/disk/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.builds.
  Restore completed in 4.96 ms for /home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/packages.builds.
  Restore completed in 4.97 ms for /disk/aoqi/disk/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds.
  Restore completed in 4.96 ms for /disk/aoqi/disk/dotnet/coreclr/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.builds.
  Restore completed in 4.96 ms for /disk/aoqi/disk/dotnet/coreclr/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.builds.
  Restore completed in 4.92 ms for /disk/aoqi/disk/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Native/Microsoft.NETCore.Native.builds.
  Restore completed in 4.97 ms for /disk/aoqi/disk/dotnet/coreclr/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.builds.
/home/aoqi/work/dotnet/dotnet/coreclr/.packages/microsoft.dotnet.build.tasks.packaging/1.0.0-beta.20113.5/build/Packaging.targets(1260,5): error : Error when creating nuget lib package from /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/runtime.linux-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec. NuGet.Packaging.Core.PackagingException: File not found: '/home/aoqi/work/dotnet/dotnet/coreclr/bin/Product/Linux.x64.Debug/System.Private.CoreLib.dll'. [/home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj]
/home/aoqi/work/dotnet/dotnet/coreclr/.packages/microsoft.dotnet.build.tasks.packaging/1.0.0-beta.20113.5/build/Packaging.targets(1260,5): error :    at NuGet.Packaging.PackageBuilder.AddFiles(String basePath, String source, String destination, String exclude) [/home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj]
/home/aoqi/work/dotnet/dotnet/coreclr/.packages/microsoft.dotnet.build.tasks.packaging/1.0.0-beta.20113.5/build/Packaging.targets(1260,5): error :    at NuGet.Packaging.PackageBuilder.PopulateFiles(String basePath, IEnumerable`1 files) [/home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj]
/home/aoqi/work/dotnet/dotnet/coreclr/.packages/microsoft.dotnet.build.tasks.packaging/1.0.0-beta.20113.5/build/Packaging.targets(1260,5): error :    at Microsoft.DotNet.Build.Tasks.Packaging.NuGetPack.Pack(String nuspecPath, String nupkgPath, Manifest manifest, Boolean packSymbols) in /_/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetPack.cs:line 256 [/home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj]
/home/aoqi/work/dotnet/dotnet/coreclr/.packages/microsoft.dotnet.build.tasks.packaging/1.0.0-beta.20113.5/build/Packaging.targets(1260,5): error : Error when creating nuget packed package from /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/runtime.linux-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec. NuGet.Packaging.Core.PackagingException: File not found: '/home/aoqi/work/dotnet/dotnet/coreclr/bin/Product/Linux.x64.Debug/System.Private.CoreLib.dll'. [/home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj]
/home/aoqi/work/dotnet/dotnet/coreclr/.packages/microsoft.dotnet.build.tasks.packaging/1.0.0-beta.20113.5/build/Packaging.targets(1260,5): error :    at NuGet.Packaging.PackageBuilder.AddFiles(String basePath, String source, String destination, String exclude) [/home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj]
/home/aoqi/work/dotnet/dotnet/coreclr/.packages/microsoft.dotnet.build.tasks.packaging/1.0.0-beta.20113.5/build/Packaging.targets(1260,5): error :    at NuGet.Packaging.PackageBuilder.PopulateFiles(String basePath, IEnumerable`1 files) [/home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj]
/home/aoqi/work/dotnet/dotnet/coreclr/.packages/microsoft.dotnet.build.tasks.packaging/1.0.0-beta.20113.5/build/Packaging.targets(1260,5): error :    at Microsoft.DotNet.Build.Tasks.Packaging.NuGetPack.Pack(String nuspecPath, String nupkgPath, Manifest manifest, Boolean packSymbols) in /_/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetPack.cs:line 256 [/home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj]
/home/aoqi/work/dotnet/dotnet/coreclr/.packages/microsoft.dotnet.build.tasks.packaging/1.0.0-beta.20113.5/build/Packaging.targets(1260,5): error : Error when creating nuget packed package from /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/runtime.linux-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec. NuGet.Packaging.Core.PackagingException: File not found: '/home/aoqi/work/dotnet/dotnet/coreclr/bin/Product/Linux.x64.Debug/System.Private.CoreLib.dll'. [/home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj]
/home/aoqi/work/dotnet/dotnet/coreclr/.packages/microsoft.dotnet.build.tasks.packaging/1.0.0-beta.20113.5/build/Packaging.targets(1260,5): error :    at NuGet.Packaging.PackageBuilder.AddFiles(String basePath, String source, String destination, String exclude) [/home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj]
/home/aoqi/work/dotnet/dotnet/coreclr/.packages/microsoft.dotnet.build.tasks.packaging/1.0.0-beta.20113.5/build/Packaging.targets(1260,5): error :    at NuGet.Packaging.PackageBuilder.PopulateFiles(String basePath, IEnumerable`1 files) [/home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj]
/home/aoqi/work/dotnet/dotnet/coreclr/.packages/microsoft.dotnet.build.tasks.packaging/1.0.0-beta.20113.5/build/Packaging.targets(1260,5): error :    at Microsoft.DotNet.Build.Tasks.Packaging.NuGetPack.Pack(String nuspecPath, String nupkgPath, Manifest manifest, Boolean packSymbols) in /_/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetPack.cs:line 256 [/home/aoqi/work/dotnet/dotnet/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj]
  Microsoft.NETCore.Native -> /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/runtime.linux-x64.Microsoft.NETCore.Native.nuspec
  Microsoft.NETCore.TestHost -> /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/runtime.linux-x64.Microsoft.NETCore.TestHost.nuspec
  Microsoft.NETCore.ILDAsm -> /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/runtime.linux-x64.Microsoft.NETCore.ILDAsm.nuspec
  Microsoft.NETCore.Native -> /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/Microsoft.NETCore.Native.nuspec
  Microsoft.NETCore.ILAsm -> /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/runtime.linux-x64.Microsoft.NETCore.ILAsm.nuspec
  Microsoft.NETCore.ILDAsm -> /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/Microsoft.NETCore.ILDAsm.nuspec
  Microsoft.NETCore.Runtime.CoreCLR -> /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/Microsoft.NETCore.Runtime.CoreCLR.nuspec
  Microsoft.NETCore.TestHost -> /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/Microsoft.NETCore.TestHost.nuspec
  Microsoft.NETCore.ILAsm -> /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/Microsoft.NETCore.ILAsm.nuspec
  Microsoft.NETCore.Jit -> /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/runtime.linux-x64.Microsoft.NETCore.Jit.nuspec
  Microsoft.NETCore.Jit -> /disk/aoqi/disk/dotnet/coreclr/artifacts/packages/Debug/specs/Microsoft.NETCore.Jit.nuspec

Build FAILED.
```