### PR TITLE
Hardcode path to ICU on macOS

### DIFF
--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -32,7 +32,7 @@ else()
         return()
     endif()
 
-    add_definitions(-DOSX_ICU_LIBRARY_PATH=\"${ICUCORE}\")
+    add_definitions(-DOSX_ICU_LIBRARY_PATH=\"/usr/lib/libicucore.dylib\")
 endif()
 
 include(configure.cmake)


### PR DESCRIPTION
Port of https://github.com/dotnet/runtime/commit/05f17e3170d014efe63202c4e7e7b641e8f8fef6.