### PR TITLE
Fix DataTargetReader::AlignBase()

### DIFF
--- a/src/md/datasource/datatargetreader.cpp
+++ b/src/md/datasource/datatargetreader.cpp
@@ -163,13 +163,10 @@ void DataTargetReader::Align(DWORD alignmentBytes)
 
 void DataTargetReader::AlignBase()
 {
-#ifdef _MSC_VER
-    // Windows MSVC compiler aligns structs based on the largest field size
+    // Align structs based on the largest field size
+    // This is the default for MSVC compilers
+    // This is forced on other platforms by the DAC_ALIGNAS macro
     Align(m_currentStructureAlign);
-#else
-    // clang (on all platforms) aligns structs always on 4 byte boundaries
-    Align(4);
-#endif
 }
 
 HRESULT DataTargetReader::GetRemotePointerSize(ULONG32* pPointerSize)


### PR DESCRIPTION
## Summary

#28033 added `DAC_ALIGNAS` macro to force MSVC and clang/gcc compilers layouts to match.  Unfortunately `DataTargetReader::AlignBase()` hard coded the difference in layouts.  This PR updates `DataTargetReader::AlignBase()` to remove the obsolete assumption.

## Customer impact

Customer reported being unable to examine stack traces using the out of process stack unwinder.  This breaks their diagnostic tools.

## Regression

Yes:  Introduced by #28033 
The regression was missed because the regression was only for Linux targets and `FEATURE_METADATA_VERIFY_LAYOUTS` is disabled on Linux.

## Testing

Enabled `FEATURE_METADATA_VERIFY_LAYOUTS` in draft PR #28063 to verify layout assumptions on Linux too.  Not in this PR simply to reduce size of PR to more easily meet servicing BAR.

Also tested with a custom built version of .NET Core 3.1.5 with this patch and the originals customers reported issue.

## Risk

Low code is only used in DBI for debugging. 