### PR TITLE
[.NET Core 3.1] Fix memory leaked caused by Marshal.GetFunctionPointerForDelegate

### DIFF
--- a/src/vm/dllimportcallback.cpp
+++ b/src/vm/dllimportcallback.cpp
@@ -961,10 +961,17 @@ void UMEntryThunk::Terminate()
     CONTRACTL
     {
         NOTHROW;
+        MODE_ANY;
     }
     CONTRACTL_END;
 
     m_code.Poison();
+
+    if (GetObjectHandle())
+    {
+        DestroyLongWeakHandle(GetObjectHandle());
+        m_pObjectHandle = 0;
+    }
 
     s_thunkFreeList.AddToList(this);
 }

--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -310,22 +310,6 @@ public:
 #endif
     }
 
-    ~UMEntryThunk()
-    {
-        CONTRACTL
-        {
-            NOTHROW;
-            GC_NOTRIGGER;
-            MODE_ANY;
-        }
-        CONTRACTL_END;
-
-        if (GetObjectHandle())
-        {
-            DestroyLongWeakHandle(GetObjectHandle());
-        }
-    }
-
     void Terminate();
 
     VOID RunTimeInit()


### PR DESCRIPTION
## Summary

Memory is leaked every time [`Marshal.GetFunctionPointerForDelegate`](https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.getfunctionpointerfordelegate) is called.

## Customer impact

See https://github.com/dotnet/runtime/issues/353 for user reported issue and impact.

There is no workaround.

User request for port to .NET Core 3.1 - https://github.com/dotnet/runtime/issues/353#issuecomment-670270129.

.NET 5 PR: https://github.com/dotnet/runtime/pull/692.

## Regression

This issue is not present in .NET Framework.

## Testing

Exact code change was ported from .NET Core 5.0 branch. Minimal validation was done for .NET Core 3.x - build and running validation that delegate creation works.

## Risk

Low. The code has been in .NET Core pre-Previews and has had lots of time in use. Additionally, since this fix was introduced so early in .NET 5 the runtime code was nearly identical to .NET Core 3.1.