### PR TITLE
3.1.5/3.1.6 crossdac fixes

### DIFF
--- a/src/md/datasource/datatargetreader.cpp
+++ b/src/md/datasource/datatargetreader.cpp
@@ -163,13 +163,10 @@ void DataTargetReader::Align(DWORD alignmentBytes)
 
 void DataTargetReader::AlignBase()
 {
-#ifdef _MSC_VER
-    // Windows MSVC compiler aligns structs based on the largest field size
+    // Align structs based on the largest field size
+    // This is the default for MSVC compilers
+    // This is forced on other platforms by the DAC_ALIGNAS macro
     Align(m_currentStructureAlign);
-#else
-    // clang (on all platforms) aligns structs always on 4 byte boundaries
-    Align(4);
-#endif
 }
 
 HRESULT DataTargetReader::GetRemotePointerSize(ULONG32* pPointerSize)

--- a/src/pal/src/exception/remote-unwind-xdac.cpp
+++ b/src/pal/src/exception/remote-unwind-xdac.cpp
@@ -82,10 +82,12 @@ typedef BOOL(*UnwindReadMemoryCallback)(PVOID address, PVOID buffer, SIZE_T size
 #define ERROR(x, ...)
 
 
-#ifdef TARGET_64BIT
+#if defined(BIT64)
 #define ElfW(foo) Elf64_ ## foo
-#else // TARGET_64BIT
+#elif defined(BIT32)
 #define ElfW(foo) Elf32_ ## foo
+#else
+#error TARGET bitness must be defined
 #endif // TARGET_64BIT
 
 #define PALAPI


### PR DESCRIPTION
Fix native stack unwind.
Merges v3.1.8 DataTargetReader::AlignBase() fix early
