### PR TITLE
Merge v3.1.7

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET Core product branding version -->
-    <ProductVersion>3.1.5</ProductVersion>
+    <ProductVersion>3.1.7</ProductVersion>
     <!-- File version numbers -->
     <MajorVersion>4</MajorVersion>
     <MinorVersion>7</MinorVersion>

--- a/src/System.Private.CoreLib/ILLinkTrim.xml
+++ b/src/System.Private.CoreLib/ILLinkTrim.xml
@@ -69,6 +69,7 @@
     <type fullname="System.Runtime.InteropServices.CustomMarshalers.*" />
     <!-- Accessed by the WinRT Host -->
     <type fullname="Internal.Runtime.InteropServices.WindowsRuntime.ActivationFactoryLoader" />
+    <type fullname="System.Runtime.InteropServices.WindowsRuntime.IManagedActivationFactory" />
     <!-- Workaround for https://github.com/mono/linker/issues/378 -->
     <type fullname="System.Runtime.InteropServices.IDispatch" />
     <type fullname="Internal.Runtime.InteropServices.IClassFactory2" />

--- a/src/debug/ee/amd64/amd64InstrDecode.h
+++ b/src/debug/ee/amd64/amd64InstrDecode.h
@@ -1,0 +1,10054 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+// File machine generated. See gen_amd64InstrDecode/README.md
+
+
+namespace Amd64InstrDecode
+{
+    // The enumeration below encodes the various amd64 instruction forms
+    // Each enumeration is an '_' separated set of flags
+    //      None     // No flags set
+    //      MOp      // Instruction supports modrm RIP memory operations
+    //      M1st     // Memory op is first operand normally src/dst
+    //      MOnly    // Memory op is only operand.  May not be a write...
+    //      MUnknown // Memory op size is unknown.  Size not included in disassemby
+    //      MAddr    // Memory op is address load effective address
+    //      M1B      // Memory op is 1  byte
+    //      M2B      // Memory op is 2  bytes
+    //      M4B      // Memory op is 4  bytes
+    //      M8B      // Memory op is 8  bytes
+    //      M16B     // Memory op is 16 bytes
+    //      M32B     // Memory op is 32 bytes
+    //      M6B      // Memory op is 6  bytes
+    //      M10B     // Memory op is 10 bytes
+    //      I1B      // Instruction includes 1  byte  of immediates
+    //      I2B      // Instruction includes 2  bytes of immediates
+    //      I3B      // Instruction includes 3  bytes of immediates
+    //      I4B      // Instruction includes 4  bytes of immediates
+    //      I8B      // Instruction includes 8  bytes of immediates
+    //      Unknown  // Instruction samples did not include a modrm configured to produce RIP addressing
+    //      L        // Flags depend on L bit in encoding.  L_<flagsLTrue>_or_<flagsLFalse>
+    //      W        // Flags depend on W bit in encoding.  W_<flagsWTrue>_or_<flagsWFalse>
+    //      P        // Flags depend on OpSize prefix for encoding.  P_<flagsNoOpSizePrefix>_or_<flagsOpSizePrefix>
+    //      WP       // Flags depend on W bit in encoding and OpSize prefix.  WP_<flagsWTrue>_or__<flagsNoOpSizePrefix>_or_<flagsOpSizePrefix>
+    //      or       // Flag option separator used in W, L, P, and WP above
+    enum InstrForm : uint8_t
+    {
+       None,
+       I1B,
+       I1B_W_None_or_MOp_M16B,
+       I2B,
+       I3B,
+       I4B,
+       I8B,
+       M1st_I1B_L_M16B_or_M8B,
+       M1st_I1B_W_M8B_or_M4B,
+       M1st_I1B_WP_M8B_or_M4B_or_M2B,
+       M1st_L_M32B_or_M16B,
+       M1st_M16B,
+       M1st_M16B_I1B,
+       M1st_M1B,
+       M1st_M1B_I1B,
+       M1st_M2B,
+       M1st_M2B_I1B,
+       M1st_M4B,
+       M1st_M4B_I1B,
+       M1st_M8B,
+       M1st_MUnknown,
+       M1st_W_M4B_or_M1B,
+       M1st_W_M8B_or_M2B,
+       M1st_W_M8B_or_M4B,
+       M1st_WP_M8B_I4B_or_M4B_I4B_or_M2B_I2B,
+       M1st_WP_M8B_or_M4B_or_M2B,
+       MOnly_M10B,
+       MOnly_M1B,
+       MOnly_M2B,
+       MOnly_M4B,
+       MOnly_M8B,
+       MOnly_MUnknown,
+       MOnly_P_M6B_or_M4B,
+       MOnly_W_M16B_or_M8B,
+       MOnly_W_M8B_or_M4B,
+       MOnly_WP_M8B_or_M4B_or_M2B,
+       MOnly_WP_M8B_or_M8B_or_M2B,
+       MOp_I1B_L_M32B_or_M16B,
+       MOp_I1B_W_M8B_or_M4B,
+       MOp_I1B_WP_M8B_or_M4B_or_M2B,
+       MOp_I4B_W_M8B_or_M4B,
+       MOp_L_M16B_or_M8B,
+       MOp_L_M32B_or_M16B,
+       MOp_L_M32B_or_M8B,
+       MOp_L_M4B_or_M2B,
+       MOp_L_M8B_or_M4B,
+       MOp_M16B,
+       MOp_M16B_I1B,
+       MOp_M1B,
+       MOp_M1B_I1B,
+       MOp_M2B,
+       MOp_M2B_I1B,
+       MOp_M32B,
+       MOp_M32B_I1B,
+       MOp_M4B,
+       MOp_M4B_I1B,
+       MOp_M4B_I4B,
+       MOp_M6B,
+       MOp_M8B,
+       MOp_M8B_I1B,
+       MOp_MAddr,
+       MOp_MUnknown,
+       MOp_W_M4B_or_M1B,
+       MOp_W_M8B_or_M2B,
+       MOp_W_M8B_or_M4B,
+       MOp_WP_M8B_I4B_or_M4B_I4B_or_M2B_I2B,
+       MOp_WP_M8B_or_M4B_or_M2B,
+       WP_I4B_or_I4B_or_I2B,
+       WP_I8B_or_I4B_or_I2B,
+       Extension = 0x80, // The instruction encoding form depends on the modrm.reg field. Extension table location in encoded in lower bits
+    };
+
+    // The following instrForm maps correspond to the amd64 instr maps
+    // The comments are for debugging convenience.  The comments use a packed opcode followed by a list of observed mnemonics
+    // The opcode is packed to be human readable.  PackedOpcode = opcode << 4 + pp
+    //   - For Vex* and Xop* the pp is directly included in the encoding
+    //   - For the Secondary, F38, and F3A pages the pp is not defined in the encoding, but affects instr form.
+    //          - pp = 0 implies no prefix.
+    //          - pp = 1 implies 0x66 OpSize prefix only.
+    //          - pp = 2 implies 0xF3 prefix.
+    //          - pp = 3 implies 0xF2 prefix.
+    //   - For the primary and 3DNow pp is not used. And is always 0 in the comments
+
+
+    // Instruction which change forms based on modrm.reg are encoded in this extension table.
+    // Since there are 8 modrm.reg values, they occur is groups of 8.
+    // Each group is referenced from the other tables below using Extension|(index >> 3).
+    static const InstrForm instrFormExtension[153]
+    {
+        MOnly_M4B,                               // Primary:0xd90/0 fld
+        None,
+        MOnly_M4B,                               // Primary:0xd90/2 fst
+        MOnly_M4B,                               // Primary:0xd90/3 fstp
+        MOnly_MUnknown,                          // Primary:0xd90/4 fldenv,fldenvw
+        MOnly_M2B,                               // Primary:0xd90/5 fldcw
+        MOnly_MUnknown,                          // Primary:0xd90/6 fnstenv,fnstenvw
+        MOnly_M2B,                               // Primary:0xd90/7 fnstcw
+        MOnly_M4B,                               // Primary:0xdb0/0 fild
+        MOnly_M4B,                               // Primary:0xdb0/1 fisttp
+        MOnly_M4B,                               // Primary:0xdb0/2 fist
+        MOnly_M4B,                               // Primary:0xdb0/3 fistp
+        None,
+        MOnly_M10B,                              // Primary:0xdb0/5 fld
+        None,
+        MOnly_M10B,                              // Primary:0xdb0/7 fstp
+        MOnly_M8B,                               // Primary:0xdd0/0 fld
+        MOnly_M8B,                               // Primary:0xdd0/1 fisttp
+        MOnly_M8B,                               // Primary:0xdd0/2 fst
+        MOnly_M8B,                               // Primary:0xdd0/3 fstp
+        MOnly_MUnknown,                          // Primary:0xdd0/4 frstor,frstorw
+        None,
+        MOnly_MUnknown,                          // Primary:0xdd0/6 fnsave,fnsavew
+        MOnly_M2B,                               // Primary:0xdd0/7 fnstsw
+        MOnly_M2B,                               // Primary:0xdf0/0 fild
+        MOnly_M2B,                               // Primary:0xdf0/1 fisttp
+        MOnly_M2B,                               // Primary:0xdf0/2 fist
+        MOnly_M2B,                               // Primary:0xdf0/3 fistp
+        MOnly_M10B,                              // Primary:0xdf0/4 fbld
+        MOnly_M8B,                               // Primary:0xdf0/5 fild
+        MOnly_M10B,                              // Primary:0xdf0/6 fbstp
+        MOnly_M8B,                               // Primary:0xdf0/7 fistp
+        M1st_M1B_I1B,                            // Primary:0xf60/0 test
+        None,
+        MOnly_M1B,                               // Primary:0xf60/2 not
+        MOnly_M1B,                               // Primary:0xf60/3 neg
+        MOnly_M1B,                               // Primary:0xf60/4 mul
+        MOnly_M1B,                               // Primary:0xf60/5 imul
+        MOnly_M1B,                               // Primary:0xf60/6 div
+        MOnly_M1B,                               // Primary:0xf60/7 idiv
+        M1st_WP_M8B_I4B_or_M4B_I4B_or_M2B_I2B,   // Primary:0xf70/0 test
+        None,
+        MOnly_WP_M8B_or_M4B_or_M2B,              // Primary:0xf70/2 not
+        MOnly_WP_M8B_or_M4B_or_M2B,              // Primary:0xf70/3 neg
+        MOnly_WP_M8B_or_M4B_or_M2B,              // Primary:0xf70/4 mul
+        MOnly_WP_M8B_or_M4B_or_M2B,              // Primary:0xf70/5 imul
+        MOnly_WP_M8B_or_M4B_or_M2B,              // Primary:0xf70/6 div
+        MOnly_WP_M8B_or_M4B_or_M2B,              // Primary:0xf70/7 idiv
+        MOnly_WP_M8B_or_M4B_or_M2B,              // Primary:0xff0/0 inc
+        MOnly_WP_M8B_or_M4B_or_M2B,              // Primary:0xff0/1 dec
+        MOnly_WP_M8B_or_M8B_or_M2B,              // Primary:0xff0/2 call
+        MOnly_P_M6B_or_M4B,                      // Primary:0xff0/3 call
+        MOnly_WP_M8B_or_M8B_or_M2B,              // Primary:0xff0/4 jmp
+        MOnly_P_M6B_or_M4B,                      // Primary:0xff0/5 jmp
+        MOnly_WP_M8B_or_M8B_or_M2B,              // Primary:0xff0/6 push
+        None,
+        MOnly_M10B,                              // Secondary:0x010/0 sgdt
+        MOnly_M10B,                              // Secondary:0x010/1 sidt
+        MOnly_M10B,                              // Secondary:0x010/2 lgdt
+        MOnly_M10B,                              // Secondary:0x010/3 lidt
+        MOnly_M2B,                               // Secondary:0x010/4 smsw
+        None,
+        MOnly_M2B,                               // Secondary:0x010/6 lmsw
+        MOnly_M1B,                               // Secondary:0x010/7 invlpg
+        MOnly_M10B,                              // Secondary:0x011/0 sgdt
+        MOnly_M10B,                              // Secondary:0x011/1 sidt
+        MOnly_M10B,                              // Secondary:0x011/2 lgdt
+        MOnly_M10B,                              // Secondary:0x011/3 lidt
+        MOnly_M2B,                               // Secondary:0x011/4 smsw
+        None,
+        MOnly_M2B,                               // Secondary:0x011/6 lmsw
+        MOnly_M1B,                               // Secondary:0x011/7 invlpg
+        MOnly_M10B,                              // Secondary:0x012/0 sgdt
+        MOnly_M10B,                              // Secondary:0x012/1 sidt
+        MOnly_M10B,                              // Secondary:0x012/2 lgdt
+        MOnly_M10B,                              // Secondary:0x012/3 lidt
+        MOnly_M2B,                               // Secondary:0x012/4 smsw
+        None,
+        MOnly_M2B,                               // Secondary:0x012/6 lmsw
+        MOnly_M1B,                               // Secondary:0x012/7 invlpg
+        MOnly_M10B,                              // Secondary:0x013/0 sgdt
+        MOnly_M10B,                              // Secondary:0x013/1 sidt
+        MOnly_M10B,                              // Secondary:0x013/2 lgdt
+        MOnly_M10B,                              // Secondary:0x013/3 lidt
+        MOnly_M2B,                               // Secondary:0x013/4 smsw
+        None,
+        MOnly_M2B,                               // Secondary:0x013/6 lmsw
+        MOnly_M1B,                               // Secondary:0x013/7 invlpg
+        MOnly_MUnknown,                          // Secondary:0xae0/0 fxsave,fxsave64
+        MOnly_MUnknown,                          // Secondary:0xae0/1 fxrstor,fxrstor64
+        MOnly_M4B,                               // Secondary:0xae0/2 ldmxcsr
+        MOnly_M4B,                               // Secondary:0xae0/3 stmxcsr
+        MOnly_MUnknown,                          // Secondary:0xae0/4 xsave,xsave64
+        MOnly_MUnknown,                          // Secondary:0xae0/5 xrstor,xrstor64
+        MOnly_MUnknown,                          // Secondary:0xae0/6 xsaveopt,xsaveopt64
+        MOnly_M1B,                               // Secondary:0xae0/7 clflush
+        MOnly_MUnknown,                          // Secondary:0xae1/0 fxsave
+        MOnly_MUnknown,                          // Secondary:0xae1/1 fxrstor
+        MOnly_M4B,                               // Secondary:0xae1/2 ldmxcsr
+        MOnly_M4B,                               // Secondary:0xae1/3 stmxcsr
+        MOnly_MUnknown,                          // Secondary:0xae1/4 xsave
+        MOnly_MUnknown,                          // Secondary:0xae1/5 xrstor
+        MOnly_M1B,                               // Secondary:0xae1/6 clwb
+        MOnly_M1B,                               // Secondary:0xae1/7 clflushopt
+        MOnly_MUnknown,                          // Secondary:0xae2/0 fxsave
+        MOnly_MUnknown,                          // Secondary:0xae2/1 fxrstor
+        MOnly_M4B,                               // Secondary:0xae2/2 ldmxcsr
+        MOnly_M4B,                               // Secondary:0xae2/3 stmxcsr
+        MOnly_MUnknown,                          // Secondary:0xae2/4 xsave
+        MOnly_MUnknown,                          // Secondary:0xae2/5 xrstor
+        None,
+        None,
+        MOnly_MUnknown,                          // Secondary:0xae3/0 fxsave
+        MOnly_MUnknown,                          // Secondary:0xae3/1 fxrstor
+        MOnly_M4B,                               // Secondary:0xae3/2 ldmxcsr
+        MOnly_M4B,                               // Secondary:0xae3/3 stmxcsr
+        MOnly_MUnknown,                          // Secondary:0xae3/4 xsave
+        MOnly_MUnknown,                          // Secondary:0xae3/5 xrstor
+        None,
+        None,
+        None,
+        MOnly_W_M16B_or_M8B,                     // Secondary:0xc70/1 cmpxchg16b,cmpxchg8b
+        None,
+        MOnly_MUnknown,                          // Secondary:0xc70/3 xrstors,xrstors64
+        MOnly_MUnknown,                          // Secondary:0xc70/4 xsavec,xsavec64
+        MOnly_MUnknown,                          // Secondary:0xc70/5 xsaves,xsaves64
+        MOnly_M8B,                               // Secondary:0xc70/6 vmptrld
+        MOnly_M8B,                               // Secondary:0xc70/7 vmptrst
+        None,
+        MOnly_M8B,                               // Secondary:0xc71/1 cmpxchg8b
+        None,
+        MOnly_MUnknown,                          // Secondary:0xc71/3 xrstors
+        MOnly_MUnknown,                          // Secondary:0xc71/4 xsavec
+        MOnly_MUnknown,                          // Secondary:0xc71/5 xsaves
+        MOnly_M8B,                               // Secondary:0xc71/6 vmclear
+        MOnly_M8B,                               // Secondary:0xc71/7 vmptrst
+        None,
+        MOnly_M8B,                               // Secondary:0xc72/1 cmpxchg8b
+        None,
+        MOnly_MUnknown,                          // Secondary:0xc72/3 xrstors
+        MOnly_MUnknown,                          // Secondary:0xc72/4 xsavec
+        MOnly_MUnknown,                          // Secondary:0xc72/5 xsaves
+        MOnly_M8B,                               // Secondary:0xc72/6 vmxon
+        MOnly_M8B,                               // Secondary:0xc72/7 vmptrst
+        None,
+        MOnly_M8B,                               // Secondary:0xc73/1 cmpxchg8b
+        None,
+        MOnly_MUnknown,                          // Secondary:0xc73/3 xrstors
+        MOnly_MUnknown,                          // Secondary:0xc73/4 xsavec
+        MOnly_MUnknown,                          // Secondary:0xc73/5 xsaves
+        None,
+        MOnly_M8B,                               // Secondary:0xc73/7 vmptrst
+    };
+
+    static const InstrForm instrFormPrimary[256]
+    {
+        M1st_M1B,                                // 0x000 add
+        M1st_WP_M8B_or_M4B_or_M2B,               // 0x010 add
+        MOp_M1B,                                 // 0x020 add
+        MOp_WP_M8B_or_M4B_or_M2B,                // 0x030 add
+        I1B,                                     // 0x040 add
+        WP_I4B_or_I4B_or_I2B,                    // 0x050 add
+        None,                                    // 0x060
+        None,                                    // 0x070
+        M1st_M1B,                                // 0x080 or
+        M1st_WP_M8B_or_M4B_or_M2B,               // 0x090 or
+        MOp_M1B,                                 // 0x0a0 or
+        MOp_WP_M8B_or_M4B_or_M2B,                // 0x0b0 or
+        I1B,                                     // 0x0c0 or
+        WP_I4B_or_I4B_or_I2B,                    // 0x0d0 or
+        None,                                    // 0x0e0
+        None,                                    // 0x0f0
+        M1st_M1B,                                // 0x100 adc
+        M1st_WP_M8B_or_M4B_or_M2B,               // 0x110 adc
+        MOp_M1B,                                 // 0x120 adc
+        MOp_WP_M8B_or_M4B_or_M2B,                // 0x130 adc
+        I1B,                                     // 0x140 adc
+        WP_I4B_or_I4B_or_I2B,                    // 0x150 adc
+        None,                                    // 0x160
+        None,                                    // 0x170
+        M1st_M1B,                                // 0x180 sbb
+        M1st_WP_M8B_or_M4B_or_M2B,               // 0x190 sbb
+        MOp_M1B,                                 // 0x1a0 sbb
+        MOp_WP_M8B_or_M4B_or_M2B,                // 0x1b0 sbb
+        I1B,                                     // 0x1c0 sbb
+        WP_I4B_or_I4B_or_I2B,                    // 0x1d0 sbb
+        None,                                    // 0x1e0
+        None,                                    // 0x1f0
+        M1st_M1B,                                // 0x200 and
+        M1st_WP_M8B_or_M4B_or_M2B,               // 0x210 and
+        MOp_M1B,                                 // 0x220 and
+        MOp_WP_M8B_or_M4B_or_M2B,                // 0x230 and
+        I1B,                                     // 0x240 and
+        WP_I4B_or_I4B_or_I2B,                    // 0x250 and
+        None,                                    // 0x260
+        None,                                    // 0x270
+        M1st_M1B,                                // 0x280 sub
+        M1st_WP_M8B_or_M4B_or_M2B,               // 0x290 sub
+        MOp_M1B,                                 // 0x2a0 sub
+        MOp_WP_M8B_or_M4B_or_M2B,                // 0x2b0 sub
+        I1B,                                     // 0x2c0 sub
+        WP_I4B_or_I4B_or_I2B,                    // 0x2d0 sub
+        None,                                    // 0x2e0
+        None,                                    // 0x2f0
+        M1st_M1B,                                // 0x300 xor
+        M1st_WP_M8B_or_M4B_or_M2B,               // 0x310 xor
+        MOp_M1B,                                 // 0x320 xor
+        MOp_WP_M8B_or_M4B_or_M2B,                // 0x330 xor
+        I1B,                                     // 0x340 xor
+        WP_I4B_or_I4B_or_I2B,                    // 0x350 xor
+        None,                                    // 0x360
+        None,                                    // 0x370
+        M1st_M1B,                                // 0x380 cmp
+        M1st_WP_M8B_or_M4B_or_M2B,               // 0x390 cmp
+        MOp_M1B,                                 // 0x3a0 cmp
+        MOp_WP_M8B_or_M4B_or_M2B,                // 0x3b0 cmp
+        I1B,                                     // 0x3c0 cmp
+        WP_I4B_or_I4B_or_I2B,                    // 0x3d0 cmp
+        None,                                    // 0x3e0
+        None,                                    // 0x3f0
+        None,                                    // 0x400
+        None,                                    // 0x410
+        None,                                    // 0x420
+        None,                                    // 0x430
+        None,                                    // 0x440
+        None,                                    // 0x450
+        None,                                    // 0x460
+        None,                                    // 0x470
+        None,                                    // 0x480
+        None,                                    // 0x490
+        None,                                    // 0x4a0
+        None,                                    // 0x4b0
+        None,                                    // 0x4c0
+        None,                                    // 0x4d0
+        None,                                    // 0x4e0
+        None,                                    // 0x4f0
+        None,                                    // 0x500 push
+        None,                                    // 0x510 push
+        None,                                    // 0x520 push
+        None,                                    // 0x530 push
+        None,                                    // 0x540 push
+        None,                                    // 0x550 push
+        None,                                    // 0x560 push
+        None,                                    // 0x570 push
+        None,                                    // 0x580 pop
+        None,                                    // 0x590 pop
+        None,                                    // 0x5a0 pop
+        None,                                    // 0x5b0 pop
+        None,                                    // 0x5c0 pop
+        None,                                    // 0x5d0 pop
+        None,                                    // 0x5e0 pop
+        None,                                    // 0x5f0 pop
+        None,                                    // 0x600
+        None,                                    // 0x610
+        None,                                    // 0x620
+        MOp_M4B,                                 // 0x630 movsxd
+        None,                                    // 0x640
+        None,                                    // 0x650
+        None,                                    // 0x660
+        None,                                    // 0x670
+        WP_I4B_or_I4B_or_I2B,                    // 0x680 push,pushw
+        MOp_WP_M8B_I4B_or_M4B_I4B_or_M2B_I2B,    // 0x690 imul
+        I1B,                                     // 0x6a0 push,pushw
+        MOp_I1B_WP_M8B_or_M4B_or_M2B,            // 0x6b0 imul
+        None,                                    // 0x6c0 ins
+        None,                                    // 0x6d0 ins
+        None,                                    // 0x6e0 outs
+        None,                                    // 0x6f0 outs
+        I1B,                                     // 0x700 jo
+        I1B,                                     // 0x710 jno
+        I1B,                                     // 0x720 jb
+        I1B,                                     // 0x730 jae
+        I1B,                                     // 0x740 je
+        I1B,                                     // 0x750 jne
+        I1B,                                     // 0x760 jbe
+        I1B,                                     // 0x770 ja
+        I1B,                                     // 0x780 js
+        I1B,                                     // 0x790 jns
+        I1B,                                     // 0x7a0 jp
+        I1B,                                     // 0x7b0 jnp
+        I1B,                                     // 0x7c0 jl
+        I1B,                                     // 0x7d0 jge
+        I1B,                                     // 0x7e0 jle
+        I1B,                                     // 0x7f0 jg
+        M1st_M1B_I1B,                            // 0x800 adc,add,and,cmp,or,sbb,sub,xor
+        M1st_WP_M8B_I4B_or_M4B_I4B_or_M2B_I2B,   // 0x810 adc,add,and,cmp,or,sbb,sub,xor
+        None,                                    // 0x820
+        M1st_I1B_WP_M8B_or_M4B_or_M2B,           // 0x830 adc,add,and,cmp,or,sbb,sub,xor
+        M1st_M1B,                                // 0x840 test
+        M1st_WP_M8B_or_M4B_or_M2B,               // 0x850 test
+        M1st_M1B,                                // 0x860 xchg
+        M1st_WP_M8B_or_M4B_or_M2B,               // 0x870 xchg
+        M1st_M1B,                                // 0x880 mov
+        M1st_WP_M8B_or_M4B_or_M2B,               // 0x890 mov
+        MOp_M1B,                                 // 0x8a0 mov
+        MOp_WP_M8B_or_M4B_or_M2B,                // 0x8b0 mov
+        M1st_M2B,                                // 0x8c0 mov
+        MOp_MAddr,                               // 0x8d0 lea
+        MOp_M2B,                                 // 0x8e0 mov
+        MOnly_WP_M8B_or_M8B_or_M2B,              // 0x8f0 pop
+        None,                                    // 0x900 nop,xchg
+        None,                                    // 0x910 xchg
+        None,                                    // 0x920 xchg
+        None,                                    // 0x930 xchg
+        None,                                    // 0x940 xchg
+        None,                                    // 0x950 xchg
+        None,                                    // 0x960 xchg
+        None,                                    // 0x970 xchg
+        None,                                    // 0x980 cbw,cdqe,cwde
+        None,                                    // 0x990 cdq,cqo,cwd
+        None,                                    // 0x9a0
+        None,                                    // 0x9b0 fwait
+        None,                                    // 0x9c0 pushf,pushfw
+        None,                                    // 0x9d0 popf,popfw
+        None,                                    // 0x9e0 sahf
+        None,                                    // 0x9f0 lahf
+        I8B,                                     // 0xa00 movabs
+        I8B,                                     // 0xa10 movabs
+        I8B,                                     // 0xa20 movabs
+        I8B,                                     // 0xa30 movabs
+        None,                                    // 0xa40 movs
+        None,                                    // 0xa50 movs
+        None,                                    // 0xa60 cmps
+        None,                                    // 0xa70 cmps
+        I1B,                                     // 0xa80 test
+        WP_I4B_or_I4B_or_I2B,                    // 0xa90 test
+        None,                                    // 0xaa0 stos
+        None,                                    // 0xab0 stos
+        None,                                    // 0xac0 lods
+        None,                                    // 0xad0 lods
+        None,                                    // 0xae0 scas
+        None,                                    // 0xaf0 scas
+        I1B,                                     // 0xb00 mov
+        I1B,                                     // 0xb10 mov
+        I1B,                                     // 0xb20 mov
+        I1B,                                     // 0xb30 mov
+        I1B,                                     // 0xb40 mov
+        I1B,                                     // 0xb50 mov
+        I1B,                                     // 0xb60 mov
+        I1B,                                     // 0xb70 mov
+        WP_I8B_or_I4B_or_I2B,                    // 0xb80 mov,movabs
+        WP_I8B_or_I4B_or_I2B,                    // 0xb90 mov,movabs
+        WP_I8B_or_I4B_or_I2B,                    // 0xba0 mov,movabs
+        WP_I8B_or_I4B_or_I2B,                    // 0xbb0 mov,movabs
+        WP_I8B_or_I4B_or_I2B,                    // 0xbc0 mov,movabs
+        WP_I8B_or_I4B_or_I2B,                    // 0xbd0 mov,movabs
+        WP_I8B_or_I4B_or_I2B,                    // 0xbe0 mov,movabs
+        WP_I8B_or_I4B_or_I2B,                    // 0xbf0 mov,movabs
+        M1st_M1B_I1B,                            // 0xc00 rcl,rcr,rol,ror,sar,shl,shr
+        M1st_I1B_WP_M8B_or_M4B_or_M2B,           // 0xc10 rcl,rcr,rol,ror,sar,shl,shr
+        I2B,                                     // 0xc20 ret,retw
+        None,                                    // 0xc30 ret,retw
+        None,                                    // 0xc40
+        None,                                    // 0xc50
+        M1st_M1B_I1B,                            // 0xc60 mov
+        M1st_WP_M8B_I4B_or_M4B_I4B_or_M2B_I2B,   // 0xc70 mov
+        I3B,                                     // 0xc80 enter,enterw
+        None,                                    // 0xc90 leave,leavew
+        I2B,                                     // 0xca0 retf,retfw
+        None,                                    // 0xcb0 retf,retfw
+        None,                                    // 0xcc0 int3
+        I1B,                                     // 0xcd0 int
+        None,                                    // 0xce0
+        None,                                    // 0xcf0 iret,iretq,iretw
+        M1st_M1B,                                // 0xd00 rcl,rcr,rol,ror,sar,shl,shr
+        M1st_WP_M8B_or_M4B_or_M2B,               // 0xd10 rcl,rcr,rol,ror,sar,shl,shr
+        M1st_M1B,                                // 0xd20 rcl,rcr,rol,ror,sar,shl,shr
+        M1st_WP_M8B_or_M4B_or_M2B,               // 0xd30 rcl,rcr,rol,ror,sar,shl,shr
+        None,                                    // 0xd40
+        None,                                    // 0xd50
+        None,                                    // 0xd60
+        None,                                    // 0xd70 xlat
+        MOnly_M4B,                               // 0xd80 fadd,fcom,fcomp,fdiv,fdivr,fmul,fsub,fsubr
+        InstrForm(int(Extension)|0x00),          // 0xd90
+        MOnly_M4B,                               // 0xda0 fiadd,ficom,ficomp,fidiv,fidivr,fimul,fisub,fisubr
+        InstrForm(int(Extension)|0x01),          // 0xdb0
+        MOnly_M8B,                               // 0xdc0 fadd,fcom,fcomp,fdiv,fdivr,fmul,fsub,fsubr
+        InstrForm(int(Extension)|0x02),          // 0xdd0
+        MOnly_M2B,                               // 0xde0 fiadd,ficom,ficomp,fidiv,fidivr,fimul,fisub,fisubr
+        InstrForm(int(Extension)|0x03),          // 0xdf0
+        I1B,                                     // 0xe00 loopne
+        I1B,                                     // 0xe10 loope
+        I1B,                                     // 0xe20 loop
+        I1B,                                     // 0xe30 jrcxz
+        I1B,                                     // 0xe40 in
+        I1B,                                     // 0xe50 in
+        I1B,                                     // 0xe60 out
+        I1B,                                     // 0xe70 out
+        WP_I4B_or_I4B_or_I2B,                    // 0xe80 call
+        WP_I4B_or_I4B_or_I2B,                    // 0xe90 jmp
+        None,                                    // 0xea0
+        I1B,                                     // 0xeb0 jmp
+        None,                                    // 0xec0 in
+        None,                                    // 0xed0 in
+        None,                                    // 0xee0 out
+        None,                                    // 0xef0 out
+        None,                                    // 0xf00
+        None,                                    // 0xf10 icebp
+        None,                                    // 0xf20
+        None,                                    // 0xf30
+        None,                                    // 0xf40 hlt
+        None,                                    // 0xf50 cmc
+        InstrForm(int(Extension)|0x04),          // 0xf60
+        InstrForm(int(Extension)|0x05),          // 0xf70
+        None,                                    // 0xf80 clc
+        None,                                    // 0xf90 stc
+        None,                                    // 0xfa0 cli
+        None,                                    // 0xfb0 sti
+        None,                                    // 0xfc0 cld
+        None,                                    // 0xfd0 std
+        MOnly_M1B,                               // 0xfe0 dec,inc
+        InstrForm(int(Extension)|0x06),          // 0xff0
+    };
+
+    static const InstrForm instrForm3DNow[256]
+    {
+        MOp_M8B_I1B,                             // 0x000
+        MOp_M8B_I1B,                             // 0x010
+        MOp_M8B_I1B,                             // 0x020
+        MOp_M8B_I1B,                             // 0x030
+        MOp_M8B_I1B,                             // 0x040
+        MOp_M8B_I1B,                             // 0x050
+        MOp_M8B_I1B,                             // 0x060
+        MOp_M8B_I1B,                             // 0x070
+        MOp_M8B_I1B,                             // 0x080
+        MOp_M8B_I1B,                             // 0x090
+        MOp_M8B_I1B,                             // 0x0a0
+        MOp_M8B_I1B,                             // 0x0b0
+        MOp_M8B_I1B,                             // 0x0c0 pi2fw
+        MOp_M8B_I1B,                             // 0x0d0 pi2fd
+        MOp_M8B_I1B,                             // 0x0e0
+        MOp_M8B_I1B,                             // 0x0f0
+        MOp_M8B_I1B,                             // 0x100
+        MOp_M8B_I1B,                             // 0x110
+        MOp_M8B_I1B,                             // 0x120
+        MOp_M8B_I1B,                             // 0x130
+        MOp_M8B_I1B,                             // 0x140
+        MOp_M8B_I1B,                             // 0x150
+        MOp_M8B_I1B,                             // 0x160
+        MOp_M8B_I1B,                             // 0x170
+        MOp_M8B_I1B,                             // 0x180
+        MOp_M8B_I1B,                             // 0x190
+        MOp_M8B_I1B,                             // 0x1a0
+        MOp_M8B_I1B,                             // 0x1b0
+        MOp_M8B_I1B,                             // 0x1c0 pf2iw
+        MOp_M8B_I1B,                             // 0x1d0 pf2id
+        MOp_M8B_I1B,                             // 0x1e0
+        MOp_M8B_I1B,                             // 0x1f0
+        MOp_M8B_I1B,                             // 0x200
+        MOp_M8B_I1B,                             // 0x210
+        MOp_M8B_I1B,                             // 0x220
+        MOp_M8B_I1B,                             // 0x230
+        MOp_M8B_I1B,                             // 0x240
+        MOp_M8B_I1B,                             // 0x250
+        MOp_M8B_I1B,                             // 0x260
+        MOp_M8B_I1B,                             // 0x270
+        MOp_M8B_I1B,                             // 0x280
+        MOp_M8B_I1B,                             // 0x290
+        MOp_M8B_I1B,                             // 0x2a0
+        MOp_M8B_I1B,                             // 0x2b0
+        MOp_M8B_I1B,                             // 0x2c0
+        MOp_M8B_I1B,                             // 0x2d0
+        MOp_M8B_I1B,                             // 0x2e0
+        MOp_M8B_I1B,                             // 0x2f0
+        MOp_M8B_I1B,                             // 0x300
+        MOp_M8B_I1B,                             // 0x310
+        MOp_M8B_I1B,                             // 0x320
+        MOp_M8B_I1B,                             // 0x330
+        MOp_M8B_I1B,                             // 0x340
+        MOp_M8B_I1B,                             // 0x350
+        MOp_M8B_I1B,                             // 0x360
+        MOp_M8B_I1B,                             // 0x370
+        MOp_M8B_I1B,                             // 0x380
+        MOp_M8B_I1B,                             // 0x390
+        MOp_M8B_I1B,                             // 0x3a0
+        MOp_M8B_I1B,                             // 0x3b0
+        MOp_M8B_I1B,                             // 0x3c0
+        MOp_M8B_I1B,                             // 0x3d0
+        MOp_M8B_I1B,                             // 0x3e0
+        MOp_M8B_I1B,                             // 0x3f0
+        MOp_M8B_I1B,                             // 0x400
+        MOp_M8B_I1B,                             // 0x410
+        MOp_M8B_I1B,                             // 0x420
+        MOp_M8B_I1B,                             // 0x430
+        MOp_M8B_I1B,                             // 0x440
+        MOp_M8B_I1B,                             // 0x450
+        MOp_M8B_I1B,                             // 0x460
+        MOp_M8B_I1B,                             // 0x470
+        MOp_M8B_I1B,                             // 0x480
+        MOp_M8B_I1B,                             // 0x490
+        MOp_M8B_I1B,                             // 0x4a0
+        MOp_M8B_I1B,                             // 0x4b0
+        MOp_M8B_I1B,                             // 0x4c0
+        MOp_M8B_I1B,                             // 0x4d0
+        MOp_M8B_I1B,                             // 0x4e0
+        MOp_M8B_I1B,                             // 0x4f0
+        MOp_M8B_I1B,                             // 0x500
+        MOp_M8B_I1B,                             // 0x510
+        MOp_M8B_I1B,                             // 0x520
+        MOp_M8B_I1B,                             // 0x530
+        MOp_M8B_I1B,                             // 0x540
+        MOp_M8B_I1B,                             // 0x550
+        MOp_M8B_I1B,                             // 0x560
+        MOp_M8B_I1B,                             // 0x570
+        MOp_M8B_I1B,                             // 0x580
+        MOp_M8B_I1B,                             // 0x590
+        MOp_M8B_I1B,                             // 0x5a0
+        MOp_M8B_I1B,                             // 0x5b0
+        MOp_M8B_I1B,                             // 0x5c0
+        MOp_M8B_I1B,                             // 0x5d0
+        MOp_M8B_I1B,                             // 0x5e0
+        MOp_M8B_I1B,                             // 0x5f0
+        MOp_M8B_I1B,                             // 0x600
+        MOp_M8B_I1B,                             // 0x610
+        MOp_M8B_I1B,                             // 0x620
+        MOp_M8B_I1B,                             // 0x630
+        MOp_M8B_I1B,                             // 0x640
+        MOp_M8B_I1B,                             // 0x650
+        MOp_M8B_I1B,                             // 0x660
+        MOp_M8B_I1B,                             // 0x670
+        MOp_M8B_I1B,                             // 0x680
+        MOp_M8B_I1B,                             // 0x690
+        MOp_M8B_I1B,                             // 0x6a0
+        MOp_M8B_I1B,                             // 0x6b0
+        MOp_M8B_I1B,                             // 0x6c0
+        MOp_M8B_I1B,                             // 0x6d0
+        MOp_M8B_I1B,                             // 0x6e0
+        MOp_M8B_I1B,                             // 0x6f0
+        MOp_M8B_I1B,                             // 0x700
+        MOp_M8B_I1B,                             // 0x710
+        MOp_M8B_I1B,                             // 0x720
+        MOp_M8B_I1B,                             // 0x730
+        MOp_M8B_I1B,                             // 0x740
+        MOp_M8B_I1B,                             // 0x750
+        MOp_M8B_I1B,                             // 0x760
+        MOp_M8B_I1B,                             // 0x770
+        MOp_M8B_I1B,                             // 0x780
+        MOp_M8B_I1B,                             // 0x790
+        MOp_M8B_I1B,                             // 0x7a0
+        MOp_M8B_I1B,                             // 0x7b0
+        MOp_M8B_I1B,                             // 0x7c0
+        MOp_M8B_I1B,                             // 0x7d0
+        MOp_M8B_I1B,                             // 0x7e0
+        MOp_M8B_I1B,                             // 0x7f0
+        MOp_M8B_I1B,                             // 0x800
+        MOp_M8B_I1B,                             // 0x810
+        MOp_M8B_I1B,                             // 0x820
+        MOp_M8B_I1B,                             // 0x830
+        MOp_M8B_I1B,                             // 0x840
+        MOp_M8B_I1B,                             // 0x850
+        MOp_M8B_I1B,                             // 0x860
+        MOp_M8B_I1B,                             // 0x870
+        MOp_M8B_I1B,                             // 0x880
+        MOp_M8B_I1B,                             // 0x890
+        MOp_M8B_I1B,                             // 0x8a0 pfnacc
+        MOp_M8B_I1B,                             // 0x8b0
+        MOp_M8B_I1B,                             // 0x8c0
+        MOp_M8B_I1B,                             // 0x8d0
+        MOp_M8B_I1B,                             // 0x8e0 pfpnacc
+        MOp_M8B_I1B,                             // 0x8f0
+        MOp_M8B_I1B,                             // 0x900 pfcmpge
+        MOp_M8B_I1B,                             // 0x910
+        MOp_M8B_I1B,                             // 0x920
+        MOp_M8B_I1B,                             // 0x930
+        MOp_M8B_I1B,                             // 0x940 pfmin
+        MOp_M8B_I1B,                             // 0x950
+        MOp_M8B_I1B,                             // 0x960 pfrcp
+        MOp_M8B_I1B,                             // 0x970 pfrsqrt
+        MOp_M8B_I1B,                             // 0x980
+        MOp_M8B_I1B,                             // 0x990
+        MOp_M8B_I1B,                             // 0x9a0 pfsub
+        MOp_M8B_I1B,                             // 0x9b0
+        MOp_M8B_I1B,                             // 0x9c0
+        MOp_M8B_I1B,                             // 0x9d0
+        MOp_M8B_I1B,                             // 0x9e0 pfadd
+        MOp_M8B_I1B,                             // 0x9f0
+        MOp_M8B_I1B,                             // 0xa00 pfcmpgt
+        MOp_M8B_I1B,                             // 0xa10
+        MOp_M8B_I1B,                             // 0xa20
+        MOp_M8B_I1B,                             // 0xa30
+        MOp_M8B_I1B,                             // 0xa40 pfmax
+        MOp_M8B_I1B,                             // 0xa50
+        MOp_M8B_I1B,                             // 0xa60 pfrcpit1
+        MOp_M8B_I1B,                             // 0xa70 pfrsqit1
+        MOp_M8B_I1B,                             // 0xa80
+        MOp_M8B_I1B,                             // 0xa90
+        MOp_M8B_I1B,                             // 0xaa0 pfsubr
+        MOp_M8B_I1B,                             // 0xab0
+        MOp_M8B_I1B,                             // 0xac0
+        MOp_M8B_I1B,                             // 0xad0
+        MOp_M8B_I1B,                             // 0xae0 pfacc
+        MOp_M8B_I1B,                             // 0xaf0
+        MOp_M8B_I1B,                             // 0xb00 pfcmpeq
+        MOp_M8B_I1B,                             // 0xb10
+        MOp_M8B_I1B,                             // 0xb20
+        MOp_M8B_I1B,                             // 0xb30
+        MOp_M8B_I1B,                             // 0xb40 pfmul
+        MOp_M8B_I1B,                             // 0xb50
+        MOp_M8B_I1B,                             // 0xb60 pfrcpit2
+        MOp_M8B_I1B,                             // 0xb70 pmulhrw
+        MOp_M8B_I1B,                             // 0xb80
+        MOp_M8B_I1B,                             // 0xb90
+        MOp_M8B_I1B,                             // 0xba0
+        MOp_M8B_I1B,                             // 0xbb0 pswapd
+        MOp_M8B_I1B,                             // 0xbc0
+        MOp_M8B_I1B,                             // 0xbd0
+        MOp_M8B_I1B,                             // 0xbe0
+        MOp_M8B_I1B,                             // 0xbf0 pavgusb
+        MOp_M8B_I1B,                             // 0xc00
+        MOp_M8B_I1B,                             // 0xc10
+        MOp_M8B_I1B,                             // 0xc20
+        MOp_M8B_I1B,                             // 0xc30
+        MOp_M8B_I1B,                             // 0xc40
+        MOp_M8B_I1B,                             // 0xc50
+        MOp_M8B_I1B,                             // 0xc60
+        MOp_M8B_I1B,                             // 0xc70
+        MOp_M8B_I1B,                             // 0xc80
+        MOp_M8B_I1B,                             // 0xc90
+        MOp_M8B_I1B,                             // 0xca0
+        MOp_M8B_I1B,                             // 0xcb0
+        MOp_M8B_I1B,                             // 0xcc0
+        MOp_M8B_I1B,                             // 0xcd0
+        MOp_M8B_I1B,                             // 0xce0
+        MOp_M8B_I1B,                             // 0xcf0
+        MOp_M8B_I1B,                             // 0xd00
+        MOp_M8B_I1B,                             // 0xd10
+        MOp_M8B_I1B,                             // 0xd20
+        MOp_M8B_I1B,                             // 0xd30
+        MOp_M8B_I1B,                             // 0xd40
+        MOp_M8B_I1B,                             // 0xd50
+        MOp_M8B_I1B,                             // 0xd60
+        MOp_M8B_I1B,                             // 0xd70
+        MOp_M8B_I1B,                             // 0xd80
+        MOp_M8B_I1B,                             // 0xd90
+        MOp_M8B_I1B,                             // 0xda0
+        MOp_M8B_I1B,                             // 0xdb0
+        MOp_M8B_I1B,                             // 0xdc0
+        MOp_M8B_I1B,                             // 0xdd0
+        MOp_M8B_I1B,                             // 0xde0
+        MOp_M8B_I1B,                             // 0xdf0
+        MOp_M8B_I1B,                             // 0xe00
+        MOp_M8B_I1B,                             // 0xe10
+        MOp_M8B_I1B,                             // 0xe20
+        MOp_M8B_I1B,                             // 0xe30
+        MOp_M8B_I1B,                             // 0xe40
+        MOp_M8B_I1B,                             // 0xe50
+        MOp_M8B_I1B,                             // 0xe60
+        MOp_M8B_I1B,                             // 0xe70
+        MOp_M8B_I1B,                             // 0xe80
+        MOp_M8B_I1B,                             // 0xe90
+        MOp_M8B_I1B,                             // 0xea0
+        MOp_M8B_I1B,                             // 0xeb0
+        MOp_M8B_I1B,                             // 0xec0
+        MOp_M8B_I1B,                             // 0xed0
+        MOp_M8B_I1B,                             // 0xee0
+        MOp_M8B_I1B,                             // 0xef0
+        MOp_M8B_I1B,                             // 0xf00
+        MOp_M8B_I1B,                             // 0xf10
+        MOp_M8B_I1B,                             // 0xf20
+        MOp_M8B_I1B,                             // 0xf30
+        MOp_M8B_I1B,                             // 0xf40
+        MOp_M8B_I1B,                             // 0xf50
+        MOp_M8B_I1B,                             // 0xf60
+        MOp_M8B_I1B,                             // 0xf70
+        MOp_M8B_I1B,                             // 0xf80
+        MOp_M8B_I1B,                             // 0xf90
+        MOp_M8B_I1B,                             // 0xfa0
+        MOp_M8B_I1B,                             // 0xfb0
+        MOp_M8B_I1B,                             // 0xfc0
+        MOp_M8B_I1B,                             // 0xfd0
+        MOp_M8B_I1B,                             // 0xfe0
+        MOp_M8B_I1B,                             // 0xff0
+    };
+
+    static const InstrForm instrFormSecondary[1024]
+    {
+        MOnly_M2B,                               // 0x000 lldt,ltr,sldt,str,verr,verw
+        MOnly_M2B,                               // 0x001 lldt,ltr,sldt,str,verr,verw
+        MOnly_M2B,                               // 0x002 lldt,ltr,sldt,str,verr,verw
+        MOnly_M2B,                               // 0x003 lldt,ltr,sldt,str,verr,verw
+        InstrForm(int(Extension)|0x07),          // 0x010
+        InstrForm(int(Extension)|0x08),          // 0x011
+        InstrForm(int(Extension)|0x09),          // 0x012
+        InstrForm(int(Extension)|0x0a),          // 0x013
+        MOp_M2B,                                 // 0x020 lar
+        MOp_M2B,                                 // 0x021 lar
+        MOp_M2B,                                 // 0x022 lar
+        MOp_M2B,                                 // 0x023 lar
+        MOp_M2B,                                 // 0x030 lsl
+        MOp_M2B,                                 // 0x031 lsl
+        MOp_M2B,                                 // 0x032 lsl
+        MOp_M2B,                                 // 0x033 lsl
+        None,                                    // 0x040
+        None,                                    // 0x041
+        None,                                    // 0x042
+        None,                                    // 0x043
+        None,                                    // 0x050 syscall
+        None,                                    // 0x051 syscall
+        None,                                    // 0x052 syscall
+        None,                                    // 0x053 syscall
+        None,                                    // 0x060 clts
+        None,                                    // 0x061 clts
+        None,                                    // 0x062 clts
+        None,                                    // 0x063 clts
+        None,                                    // 0x070 sysret,sysretq
+        None,                                    // 0x071 sysretw
+        None,                                    // 0x072 sysret
+        None,                                    // 0x073 sysret
+        None,                                    // 0x080 invd
+        None,                                    // 0x081 invd
+        None,                                    // 0x082 invd
+        None,                                    // 0x083 invd
+        None,                                    // 0x090 wbinvd
+        None,                                    // 0x091 wbinvd
+        None,                                    // 0x092 wbinvd
+        None,                                    // 0x093 wbinvd
+        None,                                    // 0x0a0
+        None,                                    // 0x0a1
+        None,                                    // 0x0a2
+        None,                                    // 0x0a3
+        None,                                    // 0x0b0 ud2
+        None,                                    // 0x0b1 ud2
+        None,                                    // 0x0b2 ud2
+        None,                                    // 0x0b3 ud2
+        None,                                    // 0x0c0
+        None,                                    // 0x0c1
+        None,                                    // 0x0c2
+        None,                                    // 0x0c3
+        MOnly_M1B,                               // 0x0d0 prefetch,prefetchw,prefetchwt1
+        MOnly_M1B,                               // 0x0d1 prefetch,prefetchw,prefetchwt1
+        MOnly_M1B,                               // 0x0d2 prefetch,prefetchw,prefetchwt1
+        MOnly_M1B,                               // 0x0d3 prefetch,prefetchw,prefetchwt1
+        None,                                    // 0x0e0 femms
+        None,                                    // 0x0e1 femms
+        None,                                    // 0x0e2 femms
+        None,                                    // 0x0e3 femms
+        None,                                    // 0x0f0
+        None,                                    // 0x0f1
+        None,                                    // 0x0f2
+        None,                                    // 0x0f3
+        MOp_M16B,                                // 0x100 movups
+        MOp_M16B,                                // 0x101 movupd
+        MOp_M4B,                                 // 0x102 movss
+        MOp_M8B,                                 // 0x103 movsd
+        M1st_M16B,                               // 0x110 movups
+        M1st_M16B,                               // 0x111 movupd
+        M1st_M4B,                                // 0x112 movss
+        M1st_M8B,                                // 0x113 movsd
+        MOp_M8B,                                 // 0x120 movlps
+        MOp_M8B,                                 // 0x121 movlpd
+        MOp_M16B,                                // 0x122 movsldup
+        MOp_M8B,                                 // 0x123 movddup
+        M1st_M8B,                                // 0x130 movlps
+        M1st_M8B,                                // 0x131 movlpd
+        None,                                    // 0x132
+        None,                                    // 0x133
+        MOp_M16B,                                // 0x140 unpcklps
+        MOp_M16B,                                // 0x141 unpcklpd
+        None,                                    // 0x142
+        None,                                    // 0x143
+        MOp_M16B,                                // 0x150 unpckhps
+        MOp_M16B,                                // 0x151 unpckhpd
+        None,                                    // 0x152
+        None,                                    // 0x153
+        MOp_M8B,                                 // 0x160 movhps
+        MOp_M8B,                                 // 0x161 movhpd
+        MOp_M16B,                                // 0x162 movshdup
+        None,                                    // 0x163
+        M1st_M8B,                                // 0x170 movhps
+        M1st_M8B,                                // 0x171 movhpd
+        None,                                    // 0x172
+        None,                                    // 0x173
+        MOnly_M1B,                               // 0x180 nop/reserved,prefetchnta,prefetcht0,prefetcht1,prefetcht2
+        MOnly_M1B,                               // 0x181 nop/reserved,prefetchnta,prefetcht0,prefetcht1,prefetcht2
+        MOnly_M1B,                               // 0x182 nop/reserved,prefetchnta,prefetcht0,prefetcht1,prefetcht2
+        MOnly_M1B,                               // 0x183 nop/reserved,prefetchnta,prefetcht0,prefetcht1,prefetcht2
+        MOnly_W_M8B_or_M4B,                      // 0x190 nop
+        MOnly_M2B,                               // 0x191 nop
+        MOnly_M4B,                               // 0x192 nop
+        MOnly_M4B,                               // 0x193 nop
+        MOp_MUnknown,                            // 0x1a0 bndldx
+        MOp_MUnknown,                            // 0x1a1 bndmov
+        MOp_MUnknown,                            // 0x1a2 bndcl
+        MOp_MUnknown,                            // 0x1a3 bndcu
+        M1st_MUnknown,                           // 0x1b0 bndstx
+        M1st_MUnknown,                           // 0x1b1 bndmov
+        MOp_MUnknown,                            // 0x1b2 bndmk
+        MOp_MUnknown,                            // 0x1b3 bndcn
+        MOnly_W_M8B_or_M4B,                      // 0x1c0 nop
+        MOnly_M2B,                               // 0x1c1 nop
+        MOnly_M4B,                               // 0x1c2 nop
+        MOnly_M4B,                               // 0x1c3 nop
+        MOnly_W_M8B_or_M4B,                      // 0x1d0 nop
+        MOnly_M2B,                               // 0x1d1 nop
+        MOnly_M4B,                               // 0x1d2 nop
+        MOnly_M4B,                               // 0x1d3 nop
+        MOnly_W_M8B_or_M4B,                      // 0x1e0 nop
+        MOnly_M2B,                               // 0x1e1 nop
+        MOnly_M4B,                               // 0x1e2 nop
+        MOnly_M4B,                               // 0x1e3 nop
+        MOnly_W_M8B_or_M4B,                      // 0x1f0 nop
+        MOnly_M2B,                               // 0x1f1 nop
+        MOnly_M4B,                               // 0x1f2 nop
+        MOnly_M4B,                               // 0x1f3 nop
+        I1B,                                     // 0x200 mov
+        I1B,                                     // 0x201 mov
+        I1B,                                     // 0x202 mov
+        I1B,                                     // 0x203 mov
+        I1B,                                     // 0x210 mov
+        I1B,                                     // 0x211 mov
+        I1B,                                     // 0x212 mov
+        I1B,                                     // 0x213 mov
+        I1B,                                     // 0x220 mov
+        I1B,                                     // 0x221 mov
+        I1B,                                     // 0x222 mov
+        I1B,                                     // 0x223 mov
+        I1B,                                     // 0x230 mov
+        I1B,                                     // 0x231 mov
+        I1B,                                     // 0x232 mov
+        I1B,                                     // 0x233 mov
+        None,                                    // 0x240
+        None,                                    // 0x241
+        None,                                    // 0x242
+        None,                                    // 0x243
+        None,                                    // 0x250
+        None,                                    // 0x251
+        None,                                    // 0x252
+        None,                                    // 0x253
+        None,                                    // 0x260
+        None,                                    // 0x261
+        None,                                    // 0x262
+        None,                                    // 0x263
+        None,                                    // 0x270
+        None,                                    // 0x271
+        None,                                    // 0x272
+        None,                                    // 0x273
+        MOp_M16B,                                // 0x280 movaps
+        MOp_M16B,                                // 0x281 movapd
+        None,                                    // 0x282
+        None,                                    // 0x283
+        M1st_M16B,                               // 0x290 movaps
+        M1st_M16B,                               // 0x291 movapd
+        None,                                    // 0x292
+        None,                                    // 0x293
+        MOp_M8B,                                 // 0x2a0 cvtpi2ps
+        MOp_M8B,                                 // 0x2a1 cvtpi2pd
+        MOp_M4B,                                 // 0x2a2 cvtsi2ss
+        MOp_M4B,                                 // 0x2a3 cvtsi2sd
+        M1st_M16B,                               // 0x2b0 movntps
+        M1st_M16B,                               // 0x2b1 movntpd
+        M1st_M4B,                                // 0x2b2 movntss
+        M1st_M8B,                                // 0x2b3 movntsd
+        MOp_M8B,                                 // 0x2c0 cvttps2pi
+        MOp_M16B,                                // 0x2c1 cvttpd2pi
+        MOp_M4B,                                 // 0x2c2 cvttss2si
+        MOp_M8B,                                 // 0x2c3 cvttsd2si
+        MOp_M8B,                                 // 0x2d0 cvtps2pi
+        MOp_M16B,                                // 0x2d1 cvtpd2pi
+        MOp_M4B,                                 // 0x2d2 cvtss2si
+        MOp_M8B,                                 // 0x2d3 cvtsd2si
+        MOp_M4B,                                 // 0x2e0 ucomiss
+        MOp_M8B,                                 // 0x2e1 ucomisd
+        None,                                    // 0x2e2
+        None,                                    // 0x2e3
+        MOp_M4B,                                 // 0x2f0 comiss
+        MOp_M8B,                                 // 0x2f1 comisd
+        None,                                    // 0x2f2
+        None,                                    // 0x2f3
+        None,                                    // 0x300 wrmsr
+        None,                                    // 0x301 wrmsr
+        None,                                    // 0x302 wrmsr
+        None,                                    // 0x303 wrmsr
+        None,                                    // 0x310 rdtsc
+        None,                                    // 0x311 rdtsc
+        None,                                    // 0x312 rdtsc
+        None,                                    // 0x313 rdtsc
+        None,                                    // 0x320 rdmsr
+        None,                                    // 0x321 rdmsr
+        None,                                    // 0x322 rdmsr
+        None,                                    // 0x323 rdmsr
+        None,                                    // 0x330 rdpmc
+        None,                                    // 0x331 rdpmc
+        None,                                    // 0x332 rdpmc
+        None,                                    // 0x333 rdpmc
+        None,                                    // 0x340 sysenter
+        None,                                    // 0x341 sysenter
+        None,                                    // 0x342 sysenter
+        None,                                    // 0x343 sysenter
+        None,                                    // 0x350 sysexit
+        None,                                    // 0x351 sysexit
+        None,                                    // 0x352 sysexit
+        None,                                    // 0x353 sysexit
+        None,                                    // 0x360
+        None,                                    // 0x361
+        None,                                    // 0x362
+        None,                                    // 0x363
+        None,                                    // 0x370 getsec
+        None,                                    // 0x371 getsec
+        None,                                    // 0x372 getsec
+        None,                                    // 0x373 getsec
+        None,                                    // 0x380
+        None,                                    // 0x381
+        None,                                    // 0x382
+        None,                                    // 0x383
+        None,                                    // 0x390
+        None,                                    // 0x391
+        None,                                    // 0x392
+        None,                                    // 0x393
+        None,                                    // 0x3a0
+        None,                                    // 0x3a1
+        None,                                    // 0x3a2
+        None,                                    // 0x3a3
+        None,                                    // 0x3b0
+        None,                                    // 0x3b1
+        None,                                    // 0x3b2
+        None,                                    // 0x3b3
+        None,                                    // 0x3c0
+        None,                                    // 0x3c1
+        None,                                    // 0x3c2
+        None,                                    // 0x3c3
+        None,                                    // 0x3d0
+        None,                                    // 0x3d1
+        None,                                    // 0x3d2
+        None,                                    // 0x3d3
+        None,                                    // 0x3e0
+        None,                                    // 0x3e1
+        None,                                    // 0x3e2
+        None,                                    // 0x3e3
+        None,                                    // 0x3f0
+        None,                                    // 0x3f1
+        None,                                    // 0x3f2
+        None,                                    // 0x3f3
+        MOp_W_M8B_or_M4B,                        // 0x400 cmovo
+        MOp_M2B,                                 // 0x401 cmovo
+        MOp_M4B,                                 // 0x402 cmovo
+        MOp_M4B,                                 // 0x403 cmovo
+        MOp_W_M8B_or_M4B,                        // 0x410 cmovno
+        MOp_M2B,                                 // 0x411 cmovno
+        MOp_M4B,                                 // 0x412 cmovno
+        MOp_M4B,                                 // 0x413 cmovno
+        MOp_W_M8B_or_M4B,                        // 0x420 cmovb
+        MOp_M2B,                                 // 0x421 cmovb
+        MOp_M4B,                                 // 0x422 cmovb
+        MOp_M4B,                                 // 0x423 cmovb
+        MOp_W_M8B_or_M4B,                        // 0x430 cmovae
+        MOp_M2B,                                 // 0x431 cmovae
+        MOp_M4B,                                 // 0x432 cmovae
+        MOp_M4B,                                 // 0x433 cmovae
+        MOp_W_M8B_or_M4B,                        // 0x440 cmove
+        MOp_M2B,                                 // 0x441 cmove
+        MOp_M4B,                                 // 0x442 cmove
+        MOp_M4B,                                 // 0x443 cmove
+        MOp_W_M8B_or_M4B,                        // 0x450 cmovne
+        MOp_M2B,                                 // 0x451 cmovne
+        MOp_M4B,                                 // 0x452 cmovne
+        MOp_M4B,                                 // 0x453 cmovne
+        MOp_W_M8B_or_M4B,                        // 0x460 cmovbe
+        MOp_M2B,                                 // 0x461 cmovbe
+        MOp_M4B,                                 // 0x462 cmovbe
+        MOp_M4B,                                 // 0x463 cmovbe
+        MOp_W_M8B_or_M4B,                        // 0x470 cmova
+        MOp_M2B,                                 // 0x471 cmova
+        MOp_M4B,                                 // 0x472 cmova
+        MOp_M4B,                                 // 0x473 cmova
+        MOp_W_M8B_or_M4B,                        // 0x480 cmovs
+        MOp_M2B,                                 // 0x481 cmovs
+        MOp_M4B,                                 // 0x482 cmovs
+        MOp_M4B,                                 // 0x483 cmovs
+        MOp_W_M8B_or_M4B,                        // 0x490 cmovns
+        MOp_M2B,                                 // 0x491 cmovns
+        MOp_M4B,                                 // 0x492 cmovns
+        MOp_M4B,                                 // 0x493 cmovns
+        MOp_W_M8B_or_M4B,                        // 0x4a0 cmovp
+        MOp_M2B,                                 // 0x4a1 cmovp
+        MOp_M4B,                                 // 0x4a2 cmovp
+        MOp_M4B,                                 // 0x4a3 cmovp
+        MOp_W_M8B_or_M4B,                        // 0x4b0 cmovnp
+        MOp_M2B,                                 // 0x4b1 cmovnp
+        MOp_M4B,                                 // 0x4b2 cmovnp
+        MOp_M4B,                                 // 0x4b3 cmovnp
+        MOp_W_M8B_or_M4B,                        // 0x4c0 cmovl
+        MOp_M2B,                                 // 0x4c1 cmovl
+        MOp_M4B,                                 // 0x4c2 cmovl
+        MOp_M4B,                                 // 0x4c3 cmovl
+        MOp_W_M8B_or_M4B,                        // 0x4d0 cmovge
+        MOp_M2B,                                 // 0x4d1 cmovge
+        MOp_M4B,                                 // 0x4d2 cmovge
+        MOp_M4B,                                 // 0x4d3 cmovge
+        MOp_W_M8B_or_M4B,                        // 0x4e0 cmovle
+        MOp_M2B,                                 // 0x4e1 cmovle
+        MOp_M4B,                                 // 0x4e2 cmovle
+        MOp_M4B,                                 // 0x4e3 cmovle
+        MOp_W_M8B_or_M4B,                        // 0x4f0 cmovg
+        MOp_M2B,                                 // 0x4f1 cmovg
+        MOp_M4B,                                 // 0x4f2 cmovg
+        MOp_M4B,                                 // 0x4f3 cmovg
+        None,                                    // 0x500
+        None,                                    // 0x501
+        None,                                    // 0x502
+        None,                                    // 0x503
+        MOp_M16B,                                // 0x510 sqrtps
+        MOp_M16B,                                // 0x511 sqrtpd
+        MOp_M4B,                                 // 0x512 sqrtss
+        MOp_M8B,                                 // 0x513 sqrtsd
+        MOp_M16B,                                // 0x520 rsqrtps
+        None,                                    // 0x521
+        MOp_M4B,                                 // 0x522 rsqrtss
+        None,                                    // 0x523
+        MOp_M16B,                                // 0x530 rcpps
+        None,                                    // 0x531
+        MOp_M4B,                                 // 0x532 rcpss
+        None,                                    // 0x533
+        MOp_M16B,                                // 0x540 andps
+        MOp_M16B,                                // 0x541 andpd
+        None,                                    // 0x542
+        None,                                    // 0x543
+        MOp_M16B,                                // 0x550 andnps
+        MOp_M16B,                                // 0x551 andnpd
+        None,                                    // 0x552
+        None,                                    // 0x553
+        MOp_M16B,                                // 0x560 orps
+        MOp_M16B,                                // 0x561 orpd
+        None,                                    // 0x562
+        None,                                    // 0x563
+        MOp_M16B,                                // 0x570 xorps
+        MOp_M16B,                                // 0x571 xorpd
+        None,                                    // 0x572
+        None,                                    // 0x573
+        MOp_M16B,                                // 0x580 addps
+        MOp_M16B,                                // 0x581 addpd
+        MOp_M4B,                                 // 0x582 addss
+        MOp_M8B,                                 // 0x583 addsd
+        MOp_M16B,                                // 0x590 mulps
+        MOp_M16B,                                // 0x591 mulpd
+        MOp_M4B,                                 // 0x592 mulss
+        MOp_M8B,                                 // 0x593 mulsd
+        MOp_M8B,                                 // 0x5a0 cvtps2pd
+        MOp_M16B,                                // 0x5a1 cvtpd2ps
+        MOp_M4B,                                 // 0x5a2 cvtss2sd
+        MOp_M8B,                                 // 0x5a3 cvtsd2ss
+        MOp_M16B,                                // 0x5b0 cvtdq2ps
+        MOp_M16B,                                // 0x5b1 cvtps2dq
+        MOp_M16B,                                // 0x5b2 cvttps2dq
+        None,                                    // 0x5b3
+        MOp_M16B,                                // 0x5c0 subps
+        MOp_M16B,                                // 0x5c1 subpd
+        MOp_M4B,                                 // 0x5c2 subss
+        MOp_M8B,                                 // 0x5c3 subsd
+        MOp_M16B,                                // 0x5d0 minps
+        MOp_M16B,                                // 0x5d1 minpd
+        MOp_M4B,                                 // 0x5d2 minss
+        MOp_M8B,                                 // 0x5d3 minsd
+        MOp_M16B,                                // 0x5e0 divps
+        MOp_M16B,                                // 0x5e1 divpd
+        MOp_M4B,                                 // 0x5e2 divss
+        MOp_M8B,                                 // 0x5e3 divsd
+        MOp_M16B,                                // 0x5f0 maxps
+        MOp_M16B,                                // 0x5f1 maxpd
+        MOp_M4B,                                 // 0x5f2 maxss
+        MOp_M8B,                                 // 0x5f3 maxsd
+        MOp_M4B,                                 // 0x600 punpcklbw
+        MOp_M16B,                                // 0x601 punpcklbw
+        None,                                    // 0x602
+        None,                                    // 0x603
+        MOp_M4B,                                 // 0x610 punpcklwd
+        MOp_M16B,                                // 0x611 punpcklwd
+        None,                                    // 0x612
+        None,                                    // 0x613
+        MOp_M4B,                                 // 0x620 punpckldq
+        MOp_M16B,                                // 0x621 punpckldq
+        None,                                    // 0x622
+        None,                                    // 0x623
+        MOp_M8B,                                 // 0x630 packsswb
+        MOp_M16B,                                // 0x631 packsswb
+        None,                                    // 0x632
+        None,                                    // 0x633
+        MOp_M8B,                                 // 0x640 pcmpgtb
+        MOp_M16B,                                // 0x641 pcmpgtb
+        None,                                    // 0x642
+        None,                                    // 0x643
+        MOp_M8B,                                 // 0x650 pcmpgtw
+        MOp_M16B,                                // 0x651 pcmpgtw
+        None,                                    // 0x652
+        None,                                    // 0x653
+        MOp_M8B,                                 // 0x660 pcmpgtd
+        MOp_M16B,                                // 0x661 pcmpgtd
+        None,                                    // 0x662
+        None,                                    // 0x663
+        MOp_M8B,                                 // 0x670 packuswb
+        MOp_M16B,                                // 0x671 packuswb
+        None,                                    // 0x672
+        None,                                    // 0x673
+        MOp_M8B,                                 // 0x680 punpckhbw
+        MOp_M16B,                                // 0x681 punpckhbw
+        None,                                    // 0x682
+        None,                                    // 0x683
+        MOp_M8B,                                 // 0x690 punpckhwd
+        MOp_M16B,                                // 0x691 punpckhwd
+        None,                                    // 0x692
+        None,                                    // 0x693
+        MOp_M8B,                                 // 0x6a0 punpckhdq
+        MOp_M16B,                                // 0x6a1 punpckhdq
+        None,                                    // 0x6a2
+        None,                                    // 0x6a3
+        MOp_M8B,                                 // 0x6b0 packssdw
+        MOp_M16B,                                // 0x6b1 packssdw
+        None,                                    // 0x6b2
+        None,                                    // 0x6b3
+        None,                                    // 0x6c0
+        MOp_M16B,                                // 0x6c1 punpcklqdq
+        None,                                    // 0x6c2
+        None,                                    // 0x6c3
+        None,                                    // 0x6d0
+        MOp_M16B,                                // 0x6d1 punpckhqdq
+        None,                                    // 0x6d2
+        None,                                    // 0x6d3
+        MOp_W_M8B_or_M4B,                        // 0x6e0 movd,movq
+        MOp_M4B,                                 // 0x6e1 movd
+        None,                                    // 0x6e2
+        None,                                    // 0x6e3
+        MOp_M8B,                                 // 0x6f0 movq
+        MOp_M16B,                                // 0x6f1 movdqa
+        MOp_M16B,                                // 0x6f2 movdqu
+        None,                                    // 0x6f3
+        MOp_M8B_I1B,                             // 0x700 pshufw
+        MOp_M16B_I1B,                            // 0x701 pshufd
+        MOp_M16B_I1B,                            // 0x702 pshufhw
+        MOp_M16B_I1B,                            // 0x703 pshuflw
+        None,                                    // 0x710
+        None,                                    // 0x711
+        None,                                    // 0x712
+        None,                                    // 0x713
+        None,                                    // 0x720
+        None,                                    // 0x721
+        None,                                    // 0x722
+        None,                                    // 0x723
+        None,                                    // 0x730
+        None,                                    // 0x731
+        None,                                    // 0x732
+        None,                                    // 0x733
+        MOp_M8B,                                 // 0x740 pcmpeqb
+        MOp_M16B,                                // 0x741 pcmpeqb
+        None,                                    // 0x742
+        None,                                    // 0x743
+        MOp_M8B,                                 // 0x750 pcmpeqw
+        MOp_M16B,                                // 0x751 pcmpeqw
+        None,                                    // 0x752
+        None,                                    // 0x753
+        MOp_M8B,                                 // 0x760 pcmpeqd
+        MOp_M16B,                                // 0x761 pcmpeqd
+        None,                                    // 0x762
+        None,                                    // 0x763
+        None,                                    // 0x770 emms
+        None,                                    // 0x771
+        None,                                    // 0x772
+        None,                                    // 0x773
+        M1st_M8B,                                // 0x780 vmread
+        None,                                    // 0x781
+        None,                                    // 0x782
+        None,                                    // 0x783
+        MOp_M8B,                                 // 0x790 vmwrite
+        None,                                    // 0x791
+        None,                                    // 0x792
+        None,                                    // 0x793
+        None,                                    // 0x7a0
+        None,                                    // 0x7a1
+        None,                                    // 0x7a2
+        None,                                    // 0x7a3
+        None,                                    // 0x7b0
+        None,                                    // 0x7b1
+        None,                                    // 0x7b2
+        None,                                    // 0x7b3
+        None,                                    // 0x7c0
+        MOp_M16B,                                // 0x7c1 haddpd
+        None,                                    // 0x7c2
+        MOp_M16B,                                // 0x7c3 haddps
+        None,                                    // 0x7d0
+        MOp_M16B,                                // 0x7d1 hsubpd
+        None,                                    // 0x7d2
+        MOp_M16B,                                // 0x7d3 hsubps
+        M1st_W_M8B_or_M4B,                       // 0x7e0 movd,movq
+        M1st_M4B,                                // 0x7e1 movd
+        MOp_M8B,                                 // 0x7e2 movq
+        None,                                    // 0x7e3
+        M1st_M8B,                                // 0x7f0 movq
+        M1st_M16B,                               // 0x7f1 movdqa
+        M1st_M16B,                               // 0x7f2 movdqu
+        None,                                    // 0x7f3
+        I4B,                                     // 0x800 jo
+        I2B,                                     // 0x801 jo
+        I4B,                                     // 0x802 jo
+        I4B,                                     // 0x803 jo
+        I4B,                                     // 0x810 jno
+        I2B,                                     // 0x811 jno
+        I4B,                                     // 0x812 jno
+        I4B,                                     // 0x813 jno
+        I4B,                                     // 0x820 jb
+        I2B,                                     // 0x821 jb
+        I4B,                                     // 0x822 jb
+        I4B,                                     // 0x823 jb
+        I4B,                                     // 0x830 jae
+        I2B,                                     // 0x831 jae
+        I4B,                                     // 0x832 jae
+        I4B,                                     // 0x833 jae
+        I4B,                                     // 0x840 je
+        I2B,                                     // 0x841 je
+        I4B,                                     // 0x842 je
+        I4B,                                     // 0x843 je
+        I4B,                                     // 0x850 jne
+        I2B,                                     // 0x851 jne
+        I4B,                                     // 0x852 jne
+        I4B,                                     // 0x853 jne
+        I4B,                                     // 0x860 jbe
+        I2B,                                     // 0x861 jbe
+        I4B,                                     // 0x862 jbe
+        I4B,                                     // 0x863 jbe
+        I4B,                                     // 0x870 ja
+        I2B,                                     // 0x871 ja
+        I4B,                                     // 0x872 ja
+        I4B,                                     // 0x873 ja
+        I4B,                                     // 0x880 js
+        I2B,                                     // 0x881 js
+        I4B,                                     // 0x882 js
+        I4B,                                     // 0x883 js
+        I4B,                                     // 0x890 jns
+        I2B,                                     // 0x891 jns
+        I4B,                                     // 0x892 jns
+        I4B,                                     // 0x893 jns
+        I4B,                                     // 0x8a0 jp
+        I2B,                                     // 0x8a1 jp
+        I4B,                                     // 0x8a2 jp
+        I4B,                                     // 0x8a3 jp
+        I4B,                                     // 0x8b0 jnp
+        I2B,                                     // 0x8b1 jnp
+        I4B,                                     // 0x8b2 jnp
+        I4B,                                     // 0x8b3 jnp
+        I4B,                                     // 0x8c0 jl
+        I2B,                                     // 0x8c1 jl
+        I4B,                                     // 0x8c2 jl
+        I4B,                                     // 0x8c3 jl
+        I4B,                                     // 0x8d0 jge
+        I2B,                                     // 0x8d1 jge
+        I4B,                                     // 0x8d2 jge
+        I4B,                                     // 0x8d3 jge
+        I4B,                                     // 0x8e0 jle
+        I2B,                                     // 0x8e1 jle
+        I4B,                                     // 0x8e2 jle
+        I4B,                                     // 0x8e3 jle
+        I4B,                                     // 0x8f0 jg
+        I2B,                                     // 0x8f1 jg
+        I4B,                                     // 0x8f2 jg
+        I4B,                                     // 0x8f3 jg
+        MOnly_M1B,                               // 0x900 seto
+        MOnly_M1B,                               // 0x901 seto
+        MOnly_M1B,                               // 0x902 seto
+        MOnly_M1B,                               // 0x903 seto
+        MOnly_M1B,                               // 0x910 setno
+        MOnly_M1B,                               // 0x911 setno
+        MOnly_M1B,                               // 0x912 setno
+        MOnly_M1B,                               // 0x913 setno
+        MOnly_M1B,                               // 0x920 setb
+        MOnly_M1B,                               // 0x921 setb
+        MOnly_M1B,                               // 0x922 setb
+        MOnly_M1B,                               // 0x923 setb
+        MOnly_M1B,                               // 0x930 setae
+        MOnly_M1B,                               // 0x931 setae
+        MOnly_M1B,                               // 0x932 setae
+        MOnly_M1B,                               // 0x933 setae
+        MOnly_M1B,                               // 0x940 sete
+        MOnly_M1B,                               // 0x941 sete
+        MOnly_M1B,                               // 0x942 sete
+        MOnly_M1B,                               // 0x943 sete
+        MOnly_M1B,                               // 0x950 setne
+        MOnly_M1B,                               // 0x951 setne
+        MOnly_M1B,                               // 0x952 setne
+        MOnly_M1B,                               // 0x953 setne
+        MOnly_M1B,                               // 0x960 setbe
+        MOnly_M1B,                               // 0x961 setbe
+        MOnly_M1B,                               // 0x962 setbe
+        MOnly_M1B,                               // 0x963 setbe
+        MOnly_M1B,                               // 0x970 seta
+        MOnly_M1B,                               // 0x971 seta
+        MOnly_M1B,                               // 0x972 seta
+        MOnly_M1B,                               // 0x973 seta
+        MOnly_M1B,                               // 0x980 sets
+        MOnly_M1B,                               // 0x981 sets
+        MOnly_M1B,                               // 0x982 sets
+        MOnly_M1B,                               // 0x983 sets
+        MOnly_M1B,                               // 0x990 setns
+        MOnly_M1B,                               // 0x991 setns
+        MOnly_M1B,                               // 0x992 setns
+        MOnly_M1B,                               // 0x993 setns
+        MOnly_M1B,                               // 0x9a0 setp
+        MOnly_M1B,                               // 0x9a1 setp
+        MOnly_M1B,                               // 0x9a2 setp
+        MOnly_M1B,                               // 0x9a3 setp
+        MOnly_M1B,                               // 0x9b0 setnp
+        MOnly_M1B,                               // 0x9b1 setnp
+        MOnly_M1B,                               // 0x9b2 setnp
+        MOnly_M1B,                               // 0x9b3 setnp
+        MOnly_M1B,                               // 0x9c0 setl
+        MOnly_M1B,                               // 0x9c1 setl
+        MOnly_M1B,                               // 0x9c2 setl
+        MOnly_M1B,                               // 0x9c3 setl
+        MOnly_M1B,                               // 0x9d0 setge
+        MOnly_M1B,                               // 0x9d1 setge
+        MOnly_M1B,                               // 0x9d2 setge
+        MOnly_M1B,                               // 0x9d3 setge
+        MOnly_M1B,                               // 0x9e0 setle
+        MOnly_M1B,                               // 0x9e1 setle
+        MOnly_M1B,                               // 0x9e2 setle
+        MOnly_M1B,                               // 0x9e3 setle
+        MOnly_M1B,                               // 0x9f0 setg
+        MOnly_M1B,                               // 0x9f1 setg
+        MOnly_M1B,                               // 0x9f2 setg
+        MOnly_M1B,                               // 0x9f3 setg
+        None,                                    // 0xa00 push
+        None,                                    // 0xa01 pushw
+        None,                                    // 0xa02 push
+        None,                                    // 0xa03 push
+        None,                                    // 0xa10 pop
+        None,                                    // 0xa11 popw
+        None,                                    // 0xa12 pop
+        None,                                    // 0xa13 pop
+        None,                                    // 0xa20 cpuid
+        None,                                    // 0xa21 cpuid
+        None,                                    // 0xa22 cpuid
+        None,                                    // 0xa23 cpuid
+        M1st_W_M8B_or_M4B,                       // 0xa30 bt
+        M1st_M2B,                                // 0xa31 bt
+        M1st_M4B,                                // 0xa32 bt
+        M1st_M4B,                                // 0xa33 bt
+        M1st_I1B_W_M8B_or_M4B,                   // 0xa40 shld
+        M1st_M2B_I1B,                            // 0xa41 shld
+        M1st_M4B_I1B,                            // 0xa42 shld
+        M1st_M4B_I1B,                            // 0xa43 shld
+        M1st_W_M8B_or_M4B,                       // 0xa50 shld
+        M1st_M2B,                                // 0xa51 shld
+        M1st_M4B,                                // 0xa52 shld
+        M1st_M4B,                                // 0xa53 shld
+        None,                                    // 0xa60
+        None,                                    // 0xa61
+        None,                                    // 0xa62
+        None,                                    // 0xa63
+        None,                                    // 0xa70
+        None,                                    // 0xa71
+        None,                                    // 0xa72
+        None,                                    // 0xa73
+        None,                                    // 0xa80 push
+        None,                                    // 0xa81 pushw
+        None,                                    // 0xa82 push
+        None,                                    // 0xa83 push
+        None,                                    // 0xa90 pop
+        None,                                    // 0xa91 popw
+        None,                                    // 0xa92 pop
+        None,                                    // 0xa93 pop
+        None,                                    // 0xaa0 rsm
+        None,                                    // 0xaa1 rsm
+        None,                                    // 0xaa2 rsm
+        None,                                    // 0xaa3 rsm
+        M1st_W_M8B_or_M4B,                       // 0xab0 bts
+        M1st_M2B,                                // 0xab1 bts
+        M1st_M4B,                                // 0xab2 bts
+        M1st_M4B,                                // 0xab3 bts
+        M1st_I1B_W_M8B_or_M4B,                   // 0xac0 shrd
+        M1st_M2B_I1B,                            // 0xac1 shrd
+        M1st_M4B_I1B,                            // 0xac2 shrd
+        M1st_M4B_I1B,                            // 0xac3 shrd
+        M1st_W_M8B_or_M4B,                       // 0xad0 shrd
+        M1st_M2B,                                // 0xad1 shrd
+        M1st_M4B,                                // 0xad2 shrd
+        M1st_M4B,                                // 0xad3 shrd
+        InstrForm(int(Extension)|0x0b),          // 0xae0
+        InstrForm(int(Extension)|0x0c),          // 0xae1
+        InstrForm(int(Extension)|0x0d),          // 0xae2
+        InstrForm(int(Extension)|0x0e),          // 0xae3
+        MOp_W_M8B_or_M4B,                        // 0xaf0 imul
+        MOp_M2B,                                 // 0xaf1 imul
+        MOp_M4B,                                 // 0xaf2 imul
+        MOp_M4B,                                 // 0xaf3 imul
+        M1st_M1B,                                // 0xb00 cmpxchg
+        M1st_M1B,                                // 0xb01 cmpxchg
+        M1st_M1B,                                // 0xb02 cmpxchg
+        M1st_M1B,                                // 0xb03 cmpxchg
+        M1st_W_M8B_or_M4B,                       // 0xb10 cmpxchg
+        M1st_M2B,                                // 0xb11 cmpxchg
+        M1st_M4B,                                // 0xb12 cmpxchg
+        M1st_M4B,                                // 0xb13 cmpxchg
+        MOp_M6B,                                 // 0xb20 lss
+        MOp_M4B,                                 // 0xb21 lss
+        MOp_M6B,                                 // 0xb22 lss
+        MOp_M6B,                                 // 0xb23 lss
+        M1st_W_M8B_or_M4B,                       // 0xb30 btr
+        M1st_M2B,                                // 0xb31 btr
+        M1st_M4B,                                // 0xb32 btr
+        M1st_M4B,                                // 0xb33 btr
+        MOp_M6B,                                 // 0xb40 lfs
+        MOp_M4B,                                 // 0xb41 lfs
+        MOp_M6B,                                 // 0xb42 lfs
+        MOp_M6B,                                 // 0xb43 lfs
+        MOp_M6B,                                 // 0xb50 lgs
+        MOp_M4B,                                 // 0xb51 lgs
+        MOp_M6B,                                 // 0xb52 lgs
+        MOp_M6B,                                 // 0xb53 lgs
+        MOp_M1B,                                 // 0xb60 movzx
+        MOp_M1B,                                 // 0xb61 movzx
+        MOp_M1B,                                 // 0xb62 movzx
+        MOp_M1B,                                 // 0xb63 movzx
+        MOp_M2B,                                 // 0xb70 movzx
+        MOp_M2B,                                 // 0xb71 movzx
+        MOp_M2B,                                 // 0xb72 movzx
+        MOp_M2B,                                 // 0xb73 movzx
+        None,                                    // 0xb80
+        None,                                    // 0xb81
+        MOp_M4B,                                 // 0xb82 popcnt
+        None,                                    // 0xb83
+        None,                                    // 0xb90 ud1
+        None,                                    // 0xb91 ud1
+        None,                                    // 0xb92 ud1
+        None,                                    // 0xb93 ud1
+        M1st_I1B_W_M8B_or_M4B,                   // 0xba0 bt,btc,btr,bts
+        M1st_M2B_I1B,                            // 0xba1 bt,btc,btr,bts
+        M1st_M4B_I1B,                            // 0xba2 bt,btc,btr,bts
+        M1st_M4B_I1B,                            // 0xba3 bt,btc,btr,bts
+        M1st_W_M8B_or_M4B,                       // 0xbb0 btc
+        M1st_M2B,                                // 0xbb1 btc
+        M1st_M4B,                                // 0xbb2 btc
+        M1st_M4B,                                // 0xbb3 btc
+        MOp_W_M8B_or_M4B,                        // 0xbc0 bsf
+        MOp_M2B,                                 // 0xbc1 bsf
+        MOp_M4B,                                 // 0xbc2 tzcnt
+        None,                                    // 0xbc3
+        MOp_W_M8B_or_M4B,                        // 0xbd0 bsr
+        MOp_M2B,                                 // 0xbd1 bsr
+        MOp_M4B,                                 // 0xbd2 lzcnt
+        None,                                    // 0xbd3
+        MOp_M1B,                                 // 0xbe0 movsx
+        MOp_M1B,                                 // 0xbe1 movsx
+        MOp_M1B,                                 // 0xbe2 movsx
+        MOp_M1B,                                 // 0xbe3 movsx
+        MOp_M2B,                                 // 0xbf0 movsx
+        MOp_M2B,                                 // 0xbf1 movsx
+        MOp_M2B,                                 // 0xbf2 movsx
+        MOp_M2B,                                 // 0xbf3 movsx
+        M1st_M1B,                                // 0xc00 xadd
+        M1st_M1B,                                // 0xc01 xadd
+        M1st_M1B,                                // 0xc02 xadd
+        M1st_M1B,                                // 0xc03 xadd
+        M1st_W_M8B_or_M4B,                       // 0xc10 xadd
+        M1st_M2B,                                // 0xc11 xadd
+        M1st_M4B,                                // 0xc12 xadd
+        M1st_M4B,                                // 0xc13 xadd
+        MOp_M16B_I1B,                            // 0xc20 cmpps
+        MOp_M16B_I1B,                            // 0xc21 cmppd
+        MOp_M4B_I1B,                             // 0xc22 cmpss
+        MOp_M8B_I1B,                             // 0xc23 cmpsd
+        M1st_W_M8B_or_M4B,                       // 0xc30 movnti
+        None,                                    // 0xc31
+        None,                                    // 0xc32
+        None,                                    // 0xc33
+        MOp_M2B_I1B,                             // 0xc40 pinsrw
+        MOp_M2B_I1B,                             // 0xc41 pinsrw
+        None,                                    // 0xc42
+        None,                                    // 0xc43
+        None,                                    // 0xc50
+        None,                                    // 0xc51
+        None,                                    // 0xc52
+        None,                                    // 0xc53
+        MOp_M16B_I1B,                            // 0xc60 shufps
+        MOp_M16B_I1B,                            // 0xc61 shufpd
+        None,                                    // 0xc62
+        None,                                    // 0xc63
+        InstrForm(int(Extension)|0x0f),          // 0xc70
+        InstrForm(int(Extension)|0x10),          // 0xc71
+        InstrForm(int(Extension)|0x11),          // 0xc72
+        InstrForm(int(Extension)|0x12),          // 0xc73
+        None,                                    // 0xc80 bswap
+        None,                                    // 0xc81 bswap
+        None,                                    // 0xc82 bswap
+        None,                                    // 0xc83 bswap
+        None,                                    // 0xc90 bswap
+        None,                                    // 0xc91 bswap
+        None,                                    // 0xc92 bswap
+        None,                                    // 0xc93 bswap
+        None,                                    // 0xca0 bswap
+        None,                                    // 0xca1 bswap
+        None,                                    // 0xca2 bswap
+        None,                                    // 0xca3 bswap
+        None,                                    // 0xcb0 bswap
+        None,                                    // 0xcb1 bswap
+        None,                                    // 0xcb2 bswap
+        None,                                    // 0xcb3 bswap
+        None,                                    // 0xcc0 bswap
+        None,                                    // 0xcc1 bswap
+        None,                                    // 0xcc2 bswap
+        None,                                    // 0xcc3 bswap
+        None,                                    // 0xcd0 bswap
+        None,                                    // 0xcd1 bswap
+        None,                                    // 0xcd2 bswap
+        None,                                    // 0xcd3 bswap
+        None,                                    // 0xce0 bswap
+        None,                                    // 0xce1 bswap
+        None,                                    // 0xce2 bswap
+        None,                                    // 0xce3 bswap
+        None,                                    // 0xcf0 bswap
+        None,                                    // 0xcf1 bswap
+        None,                                    // 0xcf2 bswap
+        None,                                    // 0xcf3 bswap
+        None,                                    // 0xd00
+        MOp_M16B,                                // 0xd01 addsubpd
+        None,                                    // 0xd02
+        MOp_M16B,                                // 0xd03 addsubps
+        MOp_M8B,                                 // 0xd10 psrlw
+        MOp_M16B,                                // 0xd11 psrlw
+        None,                                    // 0xd12
+        None,                                    // 0xd13
+        MOp_M8B,                                 // 0xd20 psrld
+        MOp_M16B,                                // 0xd21 psrld
+        None,                                    // 0xd22
+        None,                                    // 0xd23
+        MOp_M8B,                                 // 0xd30 psrlq
+        MOp_M16B,                                // 0xd31 psrlq
+        None,                                    // 0xd32
+        None,                                    // 0xd33
+        MOp_M8B,                                 // 0xd40 paddq
+        MOp_M16B,                                // 0xd41 paddq
+        None,                                    // 0xd42
+        None,                                    // 0xd43
+        MOp_M8B,                                 // 0xd50 pmullw
+        MOp_M16B,                                // 0xd51 pmullw
+        None,                                    // 0xd52
+        None,                                    // 0xd53
+        None,                                    // 0xd60
+        M1st_M8B,                                // 0xd61 movq
+        None,                                    // 0xd62
+        None,                                    // 0xd63
+        None,                                    // 0xd70
+        None,                                    // 0xd71
+        None,                                    // 0xd72
+        None,                                    // 0xd73
+        MOp_M8B,                                 // 0xd80 psubusb
+        MOp_M16B,                                // 0xd81 psubusb
+        None,                                    // 0xd82
+        None,                                    // 0xd83
+        MOp_M8B,                                 // 0xd90 psubusw
+        MOp_M16B,                                // 0xd91 psubusw
+        None,                                    // 0xd92
+        None,                                    // 0xd93
+        MOp_M8B,                                 // 0xda0 pminub
+        MOp_M16B,                                // 0xda1 pminub
+        None,                                    // 0xda2
+        None,                                    // 0xda3
+        MOp_M8B,                                 // 0xdb0 pand
+        MOp_M16B,                                // 0xdb1 pand
+        None,                                    // 0xdb2
+        None,                                    // 0xdb3
+        MOp_M8B,                                 // 0xdc0 paddusb
+        MOp_M16B,                                // 0xdc1 paddusb
+        None,                                    // 0xdc2
+        None,                                    // 0xdc3
+        MOp_M8B,                                 // 0xdd0 paddusw
+        MOp_M16B,                                // 0xdd1 paddusw
+        None,                                    // 0xdd2
+        None,                                    // 0xdd3
+        MOp_M8B,                                 // 0xde0 pmaxub
+        MOp_M16B,                                // 0xde1 pmaxub
+        None,                                    // 0xde2
+        None,                                    // 0xde3
+        MOp_M8B,                                 // 0xdf0 pandn
+        MOp_M16B,                                // 0xdf1 pandn
+        None,                                    // 0xdf2
+        None,                                    // 0xdf3
+        MOp_M8B,                                 // 0xe00 pavgb
+        MOp_M16B,                                // 0xe01 pavgb
+        None,                                    // 0xe02
+        None,                                    // 0xe03
+        MOp_M8B,                                 // 0xe10 psraw
+        MOp_M16B,                                // 0xe11 psraw
+        None,                                    // 0xe12
+        None,                                    // 0xe13
+        MOp_M8B,                                 // 0xe20 psrad
+        MOp_M16B,                                // 0xe21 psrad
+        None,                                    // 0xe22
+        None,                                    // 0xe23
+        MOp_M8B,                                 // 0xe30 pavgw
+        MOp_M16B,                                // 0xe31 pavgw
+        None,                                    // 0xe32
+        None,                                    // 0xe33
+        MOp_M8B,                                 // 0xe40 pmulhuw
+        MOp_M16B,                                // 0xe41 pmulhuw
+        None,                                    // 0xe42
+        None,                                    // 0xe43
+        MOp_M8B,                                 // 0xe50 pmulhw
+        MOp_M16B,                                // 0xe51 pmulhw
+        None,                                    // 0xe52
+        None,                                    // 0xe53
+        None,                                    // 0xe60
+        MOp_M16B,                                // 0xe61 cvttpd2dq
+        MOp_M8B,                                 // 0xe62 cvtdq2pd
+        MOp_M16B,                                // 0xe63 cvtpd2dq
+        M1st_M8B,                                // 0xe70 movntq
+        M1st_M16B,                               // 0xe71 movntdq
+        None,                                    // 0xe72
+        None,                                    // 0xe73
+        MOp_M8B,                                 // 0xe80 psubsb
+        MOp_M16B,                                // 0xe81 psubsb
+        None,                                    // 0xe82
+        None,                                    // 0xe83
+        MOp_M8B,                                 // 0xe90 psubsw
+        MOp_M16B,                                // 0xe91 psubsw
+        None,                                    // 0xe92
+        None,                                    // 0xe93
+        MOp_M8B,                                 // 0xea0 pminsw
+        MOp_M16B,                                // 0xea1 pminsw
+        None,                                    // 0xea2
+        None,                                    // 0xea3
+        MOp_M8B,                                 // 0xeb0 por
+        MOp_M16B,                                // 0xeb1 por
+        None,                                    // 0xeb2
+        None,                                    // 0xeb3
+        MOp_M8B,                                 // 0xec0 paddsb
+        MOp_M16B,                                // 0xec1 paddsb
+        None,                                    // 0xec2
+        None,                                    // 0xec3
+        MOp_M8B,                                 // 0xed0 paddsw
+        MOp_M16B,                                // 0xed1 paddsw
+        None,                                    // 0xed2
+        None,                                    // 0xed3
+        MOp_M8B,                                 // 0xee0 pmaxsw
+        MOp_M16B,                                // 0xee1 pmaxsw
+        None,                                    // 0xee2
+        None,                                    // 0xee3
+        MOp_M8B,                                 // 0xef0 pxor
+        MOp_M16B,                                // 0xef1 pxor
+        None,                                    // 0xef2
+        None,                                    // 0xef3
+        None,                                    // 0xf00
+        None,                                    // 0xf01
+        None,                                    // 0xf02
+        MOp_M16B,                                // 0xf03 lddqu
+        MOp_M8B,                                 // 0xf10 psllw
+        MOp_M16B,                                // 0xf11 psllw
+        None,                                    // 0xf12
+        None,                                    // 0xf13
+        MOp_M8B,                                 // 0xf20 pslld
+        MOp_M16B,                                // 0xf21 pslld
+        None,                                    // 0xf22
+        None,                                    // 0xf23
+        MOp_M8B,                                 // 0xf30 psllq
+        MOp_M16B,                                // 0xf31 psllq
+        None,                                    // 0xf32
+        None,                                    // 0xf33
+        MOp_M8B,                                 // 0xf40 pmuludq
+        MOp_M16B,                                // 0xf41 pmuludq
+        None,                                    // 0xf42
+        None,                                    // 0xf43
+        MOp_M8B,                                 // 0xf50 pmaddwd
+        MOp_M16B,                                // 0xf51 pmaddwd
+        None,                                    // 0xf52
+        None,                                    // 0xf53
+        MOp_M8B,                                 // 0xf60 psadbw
+        MOp_M16B,                                // 0xf61 psadbw
+        None,                                    // 0xf62
+        None,                                    // 0xf63
+        None,                                    // 0xf70
+        None,                                    // 0xf71
+        None,                                    // 0xf72
+        None,                                    // 0xf73
+        MOp_M8B,                                 // 0xf80 psubb
+        MOp_M16B,                                // 0xf81 psubb
+        None,                                    // 0xf82
+        None,                                    // 0xf83
+        MOp_M8B,                                 // 0xf90 psubw
+        MOp_M16B,                                // 0xf91 psubw
+        None,                                    // 0xf92
+        None,                                    // 0xf93
+        MOp_M8B,                                 // 0xfa0 psubd
+        MOp_M16B,                                // 0xfa1 psubd
+        None,                                    // 0xfa2
+        None,                                    // 0xfa3
+        MOp_M8B,                                 // 0xfb0 psubq
+        MOp_M16B,                                // 0xfb1 psubq
+        None,                                    // 0xfb2
+        None,                                    // 0xfb3
+        MOp_M8B,                                 // 0xfc0 paddb
+        MOp_M16B,                                // 0xfc1 paddb
+        None,                                    // 0xfc2
+        None,                                    // 0xfc3
+        MOp_M8B,                                 // 0xfd0 paddw
+        MOp_M16B,                                // 0xfd1 paddw
+        None,                                    // 0xfd2
+        None,                                    // 0xfd3
+        MOp_M8B,                                 // 0xfe0 paddd
+        MOp_M16B,                                // 0xfe1 paddd
+        None,                                    // 0xfe2
+        None,                                    // 0xfe3
+        None,                                    // 0xff0
+        None,                                    // 0xff1
+        None,                                    // 0xff2
+        None,                                    // 0xff3
+    };
+
+    static const InstrForm instrFormF38[1024]
+    {
+        MOp_M8B,                                 // 0x000 pshufb
+        MOp_M16B,                                // 0x001 pshufb
+        None,                                    // 0x002
+        None,                                    // 0x003
+        MOp_M8B,                                 // 0x010 phaddw
+        MOp_M16B,                                // 0x011 phaddw
+        None,                                    // 0x012
+        None,                                    // 0x013
+        MOp_M8B,                                 // 0x020 phaddd
+        MOp_M16B,                                // 0x021 phaddd
+        None,                                    // 0x022
+        None,                                    // 0x023
+        MOp_M8B,                                 // 0x030 phaddsw
+        MOp_M16B,                                // 0x031 phaddsw
+        None,                                    // 0x032
+        None,                                    // 0x033
+        MOp_M8B,                                 // 0x040 pmaddubsw
+        MOp_M16B,                                // 0x041 pmaddubsw
+        None,                                    // 0x042
+        None,                                    // 0x043
+        MOp_M8B,                                 // 0x050 phsubw
+        MOp_M16B,                                // 0x051 phsubw
+        None,                                    // 0x052
+        None,                                    // 0x053
+        MOp_M8B,                                 // 0x060 phsubd
+        MOp_M16B,                                // 0x061 phsubd
+        None,                                    // 0x062
+        None,                                    // 0x063
+        MOp_M8B,                                 // 0x070 phsubsw
+        MOp_M16B,                                // 0x071 phsubsw
+        None,                                    // 0x072
+        None,                                    // 0x073
+        MOp_M8B,                                 // 0x080 psignb
+        MOp_M16B,                                // 0x081 psignb
+        None,                                    // 0x082
+        None,                                    // 0x083
+        MOp_M8B,                                 // 0x090 psignw
+        MOp_M16B,                                // 0x091 psignw
+        None,                                    // 0x092
+        None,                                    // 0x093
+        MOp_M8B,                                 // 0x0a0 psignd
+        MOp_M16B,                                // 0x0a1 psignd
+        None,                                    // 0x0a2
+        None,                                    // 0x0a3
+        MOp_M8B,                                 // 0x0b0 pmulhrsw
+        MOp_M16B,                                // 0x0b1 pmulhrsw
+        None,                                    // 0x0b2
+        None,                                    // 0x0b3
+        None,                                    // 0x0c0
+        None,                                    // 0x0c1
+        None,                                    // 0x0c2
+        None,                                    // 0x0c3
+        None,                                    // 0x0d0
+        None,                                    // 0x0d1
+        None,                                    // 0x0d2
+        None,                                    // 0x0d3
+        None,                                    // 0x0e0
+        None,                                    // 0x0e1
+        None,                                    // 0x0e2
+        None,                                    // 0x0e3
+        None,                                    // 0x0f0
+        None,                                    // 0x0f1
+        None,                                    // 0x0f2
+        None,                                    // 0x0f3
+        None,                                    // 0x100
+        MOp_M16B,                                // 0x101 pblendvb
+        None,                                    // 0x102
+        None,                                    // 0x103
+        None,                                    // 0x110
+        None,                                    // 0x111
+        None,                                    // 0x112
+        None,                                    // 0x113
+        None,                                    // 0x120
+        None,                                    // 0x121
+        None,                                    // 0x122
+        None,                                    // 0x123
+        None,                                    // 0x130
+        None,                                    // 0x131
+        None,                                    // 0x132
+        None,                                    // 0x133
+        None,                                    // 0x140
+        MOp_M16B,                                // 0x141 blendvps
+        None,                                    // 0x142
+        None,                                    // 0x143
+        None,                                    // 0x150
+        MOp_M16B,                                // 0x151 blendvpd
+        None,                                    // 0x152
+        None,                                    // 0x153
+        None,                                    // 0x160
+        None,                                    // 0x161
+        None,                                    // 0x162
+        None,                                    // 0x163
+        None,                                    // 0x170
+        MOp_M16B,                                // 0x171 ptest
+        None,                                    // 0x172
+        None,                                    // 0x173
+        None,                                    // 0x180
+        None,                                    // 0x181
+        None,                                    // 0x182
+        None,                                    // 0x183
+        None,                                    // 0x190
+        None,                                    // 0x191
+        None,                                    // 0x192
+        None,                                    // 0x193
+        None,                                    // 0x1a0
+        None,                                    // 0x1a1
+        None,                                    // 0x1a2
+        None,                                    // 0x1a3
+        None,                                    // 0x1b0
+        None,                                    // 0x1b1
+        None,                                    // 0x1b2
+        None,                                    // 0x1b3
+        MOp_M8B,                                 // 0x1c0 pabsb
+        MOp_M16B,                                // 0x1c1 pabsb
+        None,                                    // 0x1c2
+        None,                                    // 0x1c3
+        MOp_M8B,                                 // 0x1d0 pabsw
+        MOp_M16B,                                // 0x1d1 pabsw
+        None,                                    // 0x1d2
+        None,                                    // 0x1d3
+        MOp_M8B,                                 // 0x1e0 pabsd
+        MOp_M16B,                                // 0x1e1 pabsd
+        None,                                    // 0x1e2
+        None,                                    // 0x1e3
+        None,                                    // 0x1f0
+        None,                                    // 0x1f1
+        None,                                    // 0x1f2
+        None,                                    // 0x1f3
+        None,                                    // 0x200
+        MOp_M8B,                                 // 0x201 pmovsxbw
+        None,                                    // 0x202
+        None,                                    // 0x203
+        None,                                    // 0x210
+        MOp_M4B,                                 // 0x211 pmovsxbd
+        None,                                    // 0x212
+        None,                                    // 0x213
+        None,                                    // 0x220
+        MOp_M2B,                                 // 0x221 pmovsxbq
+        None,                                    // 0x222
+        None,                                    // 0x223
+        None,                                    // 0x230
+        MOp_M8B,                                 // 0x231 pmovsxwd
+        None,                                    // 0x232
+        None,                                    // 0x233
+        None,                                    // 0x240
+        MOp_M4B,                                 // 0x241 pmovsxwq
+        None,                                    // 0x242
+        None,                                    // 0x243
+        None,                                    // 0x250
+        MOp_M8B,                                 // 0x251 pmovsxdq
+        None,                                    // 0x252
+        None,                                    // 0x253
+        None,                                    // 0x260
+        None,                                    // 0x261
+        None,                                    // 0x262
+        None,                                    // 0x263
+        None,                                    // 0x270
+        None,                                    // 0x271
+        None,                                    // 0x272
+        None,                                    // 0x273
+        None,                                    // 0x280
+        MOp_M16B,                                // 0x281 pmuldq
+        None,                                    // 0x282
+        None,                                    // 0x283
+        None,                                    // 0x290
+        MOp_M16B,                                // 0x291 pcmpeqq
+        None,                                    // 0x292
+        None,                                    // 0x293
+        None,                                    // 0x2a0
+        MOp_M16B,                                // 0x2a1 movntdqa
+        None,                                    // 0x2a2
+        None,                                    // 0x2a3
+        None,                                    // 0x2b0
+        MOp_M16B,                                // 0x2b1 packusdw
+        None,                                    // 0x2b2
+        None,                                    // 0x2b3
+        None,                                    // 0x2c0
+        None,                                    // 0x2c1
+        None,                                    // 0x2c2
+        None,                                    // 0x2c3
+        None,                                    // 0x2d0
+        None,                                    // 0x2d1
+        None,                                    // 0x2d2
+        None,                                    // 0x2d3
+        None,                                    // 0x2e0
+        None,                                    // 0x2e1
+        None,                                    // 0x2e2
+        None,                                    // 0x2e3
+        None,                                    // 0x2f0
+        None,                                    // 0x2f1
+        None,                                    // 0x2f2
+        None,                                    // 0x2f3
+        None,                                    // 0x300
+        MOp_M8B,                                 // 0x301 pmovzxbw
+        None,                                    // 0x302
+        None,                                    // 0x303
+        None,                                    // 0x310
+        MOp_M4B,                                 // 0x311 pmovzxbd
+        None,                                    // 0x312
+        None,                                    // 0x313
+        None,                                    // 0x320
+        MOp_M2B,                                 // 0x321 pmovzxbq
+        None,                                    // 0x322
+        None,                                    // 0x323
+        None,                                    // 0x330
+        MOp_M8B,                                 // 0x331 pmovzxwd
+        None,                                    // 0x332
+        None,                                    // 0x333
+        None,                                    // 0x340
+        MOp_M4B,                                 // 0x341 pmovzxwq
+        None,                                    // 0x342
+        None,                                    // 0x343
+        None,                                    // 0x350
+        MOp_M8B,                                 // 0x351 pmovzxdq
+        None,                                    // 0x352
+        None,                                    // 0x353
+        None,                                    // 0x360
+        None,                                    // 0x361
+        None,                                    // 0x362
+        None,                                    // 0x363
+        None,                                    // 0x370
+        MOp_M16B,                                // 0x371 pcmpgtq
+        None,                                    // 0x372
+        None,                                    // 0x373
+        None,                                    // 0x380
+        MOp_M16B,                                // 0x381 pminsb
+        None,                                    // 0x382
+        None,                                    // 0x383
+        None,                                    // 0x390
+        MOp_M16B,                                // 0x391 pminsd
+        None,                                    // 0x392
+        None,                                    // 0x393
+        None,                                    // 0x3a0
+        MOp_M16B,                                // 0x3a1 pminuw
+        None,                                    // 0x3a2
+        None,                                    // 0x3a3
+        None,                                    // 0x3b0
+        MOp_M16B,                                // 0x3b1 pminud
+        None,                                    // 0x3b2
+        None,                                    // 0x3b3
+        None,                                    // 0x3c0
+        MOp_M16B,                                // 0x3c1 pmaxsb
+        None,                                    // 0x3c2
+        None,                                    // 0x3c3
+        None,                                    // 0x3d0
+        MOp_M16B,                                // 0x3d1 pmaxsd
+        None,                                    // 0x3d2
+        None,                                    // 0x3d3
+        None,                                    // 0x3e0
+        MOp_M16B,                                // 0x3e1 pmaxuw
+        None,                                    // 0x3e2
+        None,                                    // 0x3e3
+        None,                                    // 0x3f0
+        MOp_M16B,                                // 0x3f1 pmaxud
+        None,                                    // 0x3f2
+        None,                                    // 0x3f3
+        None,                                    // 0x400
+        MOp_M16B,                                // 0x401 pmulld
+        None,                                    // 0x402
+        None,                                    // 0x403
+        None,                                    // 0x410
+        MOp_M16B,                                // 0x411 phminposuw
+        None,                                    // 0x412
+        None,                                    // 0x413
+        None,                                    // 0x420
+        None,                                    // 0x421
+        None,                                    // 0x422
+        None,                                    // 0x423
+        None,                                    // 0x430
+        None,                                    // 0x431
+        None,                                    // 0x432
+        None,                                    // 0x433
+        None,                                    // 0x440
+        None,                                    // 0x441
+        None,                                    // 0x442
+        None,                                    // 0x443
+        None,                                    // 0x450
+        None,                                    // 0x451
+        None,                                    // 0x452
+        None,                                    // 0x453
+        None,                                    // 0x460
+        None,                                    // 0x461
+        None,                                    // 0x462
+        None,                                    // 0x463
+        None,                                    // 0x470
+        None,                                    // 0x471
+        None,                                    // 0x472
+        None,                                    // 0x473
+        None,                                    // 0x480
+        None,                                    // 0x481
+        None,                                    // 0x482
+        None,                                    // 0x483
+        None,                                    // 0x490
+        None,                                    // 0x491
+        None,                                    // 0x492
+        None,                                    // 0x493
+        None,                                    // 0x4a0
+        None,                                    // 0x4a1
+        None,                                    // 0x4a2
+        None,                                    // 0x4a3
+        None,                                    // 0x4b0
+        None,                                    // 0x4b1
+        None,                                    // 0x4b2
+        None,                                    // 0x4b3
+        None,                                    // 0x4c0
+        None,                                    // 0x4c1
+        None,                                    // 0x4c2
+        None,                                    // 0x4c3
+        None,                                    // 0x4d0
+        None,                                    // 0x4d1
+        None,                                    // 0x4d2
+        None,                                    // 0x4d3
+        None,                                    // 0x4e0
+        None,                                    // 0x4e1
+        None,                                    // 0x4e2
+        None,                                    // 0x4e3
+        None,                                    // 0x4f0
+        None,                                    // 0x4f1
+        None,                                    // 0x4f2
+        None,                                    // 0x4f3
+        None,                                    // 0x500
+        None,                                    // 0x501
+        None,                                    // 0x502
+        None,                                    // 0x503
+        None,                                    // 0x510
+        None,                                    // 0x511
+        None,                                    // 0x512
+        None,                                    // 0x513
+        None,                                    // 0x520
+        None,                                    // 0x521
+        None,                                    // 0x522
+        None,                                    // 0x523
+        None,                                    // 0x530
+        None,                                    // 0x531
+        None,                                    // 0x532
+        None,                                    // 0x533
+        None,                                    // 0x540
+        None,                                    // 0x541
+        None,                                    // 0x542
+        None,                                    // 0x543
+        None,                                    // 0x550
+        None,                                    // 0x551
+        None,                                    // 0x552
+        None,                                    // 0x553
+        None,                                    // 0x560
+        None,                                    // 0x561
+        None,                                    // 0x562
+        None,                                    // 0x563
+        None,                                    // 0x570
+        None,                                    // 0x571
+        None,                                    // 0x572
+        None,                                    // 0x573
+        None,                                    // 0x580
+        None,                                    // 0x581
+        None,                                    // 0x582
+        None,                                    // 0x583
+        None,                                    // 0x590
+        None,                                    // 0x591
+        None,                                    // 0x592
+        None,                                    // 0x593
+        None,                                    // 0x5a0
+        None,                                    // 0x5a1
+        None,                                    // 0x5a2
+        None,                                    // 0x5a3
+        None,                                    // 0x5b0
+        None,                                    // 0x5b1
+        None,                                    // 0x5b2
+        None,                                    // 0x5b3
+        None,                                    // 0x5c0
+        None,                                    // 0x5c1
+        None,                                    // 0x5c2
+        None,                                    // 0x5c3
+        None,                                    // 0x5d0
+        None,                                    // 0x5d1
+        None,                                    // 0x5d2
+        None,                                    // 0x5d3
+        None,                                    // 0x5e0
+        None,                                    // 0x5e1
+        None,                                    // 0x5e2
+        None,                                    // 0x5e3
+        None,                                    // 0x5f0
+        None,                                    // 0x5f1
+        None,                                    // 0x5f2
+        None,                                    // 0x5f3
+        None,                                    // 0x600
+        None,                                    // 0x601
+        None,                                    // 0x602
+        None,                                    // 0x603
+        None,                                    // 0x610
+        None,                                    // 0x611
+        None,                                    // 0x612
+        None,                                    // 0x613
+        None,                                    // 0x620
+        None,                                    // 0x621
+        None,                                    // 0x622
+        None,                                    // 0x623
+        None,                                    // 0x630
+        None,                                    // 0x631
+        None,                                    // 0x632
+        None,                                    // 0x633
+        None,                                    // 0x640
+        None,                                    // 0x641
+        None,                                    // 0x642
+        None,                                    // 0x643
+        None,                                    // 0x650
+        None,                                    // 0x651
+        None,                                    // 0x652
+        None,                                    // 0x653
+        None,                                    // 0x660
+        None,                                    // 0x661
+        None,                                    // 0x662
+        None,                                    // 0x663
+        None,                                    // 0x670
+        None,                                    // 0x671
+        None,                                    // 0x672
+        None,                                    // 0x673
+        None,                                    // 0x680
+        None,                                    // 0x681
+        None,                                    // 0x682
+        None,                                    // 0x683
+        None,                                    // 0x690
+        None,                                    // 0x691
+        None,                                    // 0x692
+        None,                                    // 0x693
+        None,                                    // 0x6a0
+        None,                                    // 0x6a1
+        None,                                    // 0x6a2
+        None,                                    // 0x6a3
+        None,                                    // 0x6b0
+        None,                                    // 0x6b1
+        None,                                    // 0x6b2
+        None,                                    // 0x6b3
+        None,                                    // 0x6c0
+        None,                                    // 0x6c1
+        None,                                    // 0x6c2
+        None,                                    // 0x6c3
+        None,                                    // 0x6d0
+        None,                                    // 0x6d1
+        None,                                    // 0x6d2
+        None,                                    // 0x6d3
+        None,                                    // 0x6e0
+        None,                                    // 0x6e1
+        None,                                    // 0x6e2
+        None,                                    // 0x6e3
+        None,                                    // 0x6f0
+        None,                                    // 0x6f1
+        None,                                    // 0x6f2
+        None,                                    // 0x6f3
+        None,                                    // 0x700
+        None,                                    // 0x701
+        None,                                    // 0x702
+        None,                                    // 0x703
+        None,                                    // 0x710
+        None,                                    // 0x711
+        None,                                    // 0x712
+        None,                                    // 0x713
+        None,                                    // 0x720
+        None,                                    // 0x721
+        None,                                    // 0x722
+        None,                                    // 0x723
+        None,                                    // 0x730
+        None,                                    // 0x731
+        None,                                    // 0x732
+        None,                                    // 0x733
+        None,                                    // 0x740
+        None,                                    // 0x741
+        None,                                    // 0x742
+        None,                                    // 0x743
+        None,                                    // 0x750
+        None,                                    // 0x751
+        None,                                    // 0x752
+        None,                                    // 0x753
+        None,                                    // 0x760
+        None,                                    // 0x761
+        None,                                    // 0x762
+        None,                                    // 0x763
+        None,                                    // 0x770
+        None,                                    // 0x771
+        None,                                    // 0x772
+        None,                                    // 0x773
+        None,                                    // 0x780
+        None,                                    // 0x781
+        None,                                    // 0x782
+        None,                                    // 0x783
+        None,                                    // 0x790
+        None,                                    // 0x791
+        None,                                    // 0x792
+        None,                                    // 0x793
+        None,                                    // 0x7a0
+        None,                                    // 0x7a1
+        None,                                    // 0x7a2
+        None,                                    // 0x7a3
+        None,                                    // 0x7b0
+        None,                                    // 0x7b1
+        None,                                    // 0x7b2
+        None,                                    // 0x7b3
+        None,                                    // 0x7c0
+        None,                                    // 0x7c1
+        None,                                    // 0x7c2
+        None,                                    // 0x7c3
+        None,                                    // 0x7d0
+        None,                                    // 0x7d1
+        None,                                    // 0x7d2
+        None,                                    // 0x7d3
+        None,                                    // 0x7e0
+        None,                                    // 0x7e1
+        None,                                    // 0x7e2
+        None,                                    // 0x7e3
+        None,                                    // 0x7f0
+        None,                                    // 0x7f1
+        None,                                    // 0x7f2
+        None,                                    // 0x7f3
+        None,                                    // 0x800
+        MOp_M16B,                                // 0x801 invept
+        None,                                    // 0x802
+        None,                                    // 0x803
+        None,                                    // 0x810
+        MOp_M16B,                                // 0x811 invvpid
+        None,                                    // 0x812
+        None,                                    // 0x813
+        None,                                    // 0x820
+        MOp_MUnknown,                            // 0x821 invpcid
+        None,                                    // 0x822
+        None,                                    // 0x823
+        None,                                    // 0x830
+        None,                                    // 0x831
+        None,                                    // 0x832
+        None,                                    // 0x833
+        None,                                    // 0x840
+        None,                                    // 0x841
+        None,                                    // 0x842
+        None,                                    // 0x843
+        None,                                    // 0x850
+        None,                                    // 0x851
+        None,                                    // 0x852
+        None,                                    // 0x853
+        None,                                    // 0x860
+        None,                                    // 0x861
+        None,                                    // 0x862
+        None,                                    // 0x863
+        None,                                    // 0x870
+        None,                                    // 0x871
+        None,                                    // 0x872
+        None,                                    // 0x873
+        None,                                    // 0x880
+        None,                                    // 0x881
+        None,                                    // 0x882
+        None,                                    // 0x883
+        None,                                    // 0x890
+        None,                                    // 0x891
+        None,                                    // 0x892
+        None,                                    // 0x893
+        None,                                    // 0x8a0
+        None,                                    // 0x8a1
+        None,                                    // 0x8a2
+        None,                                    // 0x8a3
+        None,                                    // 0x8b0
+        None,                                    // 0x8b1
+        None,                                    // 0x8b2
+        None,                                    // 0x8b3
+        None,                                    // 0x8c0
+        None,                                    // 0x8c1
+        None,                                    // 0x8c2
+        None,                                    // 0x8c3
+        None,                                    // 0x8d0
+        None,                                    // 0x8d1
+        None,                                    // 0x8d2
+        None,                                    // 0x8d3
+        None,                                    // 0x8e0
+        None,                                    // 0x8e1
+        None,                                    // 0x8e2
+        None,                                    // 0x8e3
+        None,                                    // 0x8f0
+        None,                                    // 0x8f1
+        None,                                    // 0x8f2
+        None,                                    // 0x8f3
+        None,                                    // 0x900
+        None,                                    // 0x901
+        None,                                    // 0x902
+        None,                                    // 0x903
+        None,                                    // 0x910
+        None,                                    // 0x911
+        None,                                    // 0x912
+        None,                                    // 0x913
+        None,                                    // 0x920
+        None,                                    // 0x921
+        None,                                    // 0x922
+        None,                                    // 0x923
+        None,                                    // 0x930
+        None,                                    // 0x931
+        None,                                    // 0x932
+        None,                                    // 0x933
+        None,                                    // 0x940
+        None,                                    // 0x941
+        None,                                    // 0x942
+        None,                                    // 0x943
+        None,                                    // 0x950
+        None,                                    // 0x951
+        None,                                    // 0x952
+        None,                                    // 0x953
+        None,                                    // 0x960
+        None,                                    // 0x961
+        None,                                    // 0x962
+        None,                                    // 0x963
+        None,                                    // 0x970
+        None,                                    // 0x971
+        None,                                    // 0x972
+        None,                                    // 0x973
+        None,                                    // 0x980
+        None,                                    // 0x981
+        None,                                    // 0x982
+        None,                                    // 0x983
+        None,                                    // 0x990
+        None,                                    // 0x991
+        None,                                    // 0x992
+        None,                                    // 0x993
+        None,                                    // 0x9a0
+        None,                                    // 0x9a1
+        None,                                    // 0x9a2
+        None,                                    // 0x9a3
+        None,                                    // 0x9b0
+        None,                                    // 0x9b1
+        None,                                    // 0x9b2
+        None,                                    // 0x9b3
+        None,                                    // 0x9c0
+        None,                                    // 0x9c1
+        None,                                    // 0x9c2
+        None,                                    // 0x9c3
+        None,                                    // 0x9d0
+        None,                                    // 0x9d1
+        None,                                    // 0x9d2
+        None,                                    // 0x9d3
+        None,                                    // 0x9e0
+        None,                                    // 0x9e1
+        None,                                    // 0x9e2
+        None,                                    // 0x9e3
+        None,                                    // 0x9f0
+        None,                                    // 0x9f1
+        None,                                    // 0x9f2
+        None,                                    // 0x9f3
+        None,                                    // 0xa00
+        None,                                    // 0xa01
+        None,                                    // 0xa02
+        None,                                    // 0xa03
+        None,                                    // 0xa10
+        None,                                    // 0xa11
+        None,                                    // 0xa12
+        None,                                    // 0xa13
+        None,                                    // 0xa20
+        None,                                    // 0xa21
+        None,                                    // 0xa22
+        None,                                    // 0xa23
+        None,                                    // 0xa30
+        None,                                    // 0xa31
+        None,                                    // 0xa32
+        None,                                    // 0xa33
+        None,                                    // 0xa40
+        None,                                    // 0xa41
+        None,                                    // 0xa42
+        None,                                    // 0xa43
+        None,                                    // 0xa50
+        None,                                    // 0xa51
+        None,                                    // 0xa52
+        None,                                    // 0xa53
+        None,                                    // 0xa60
+        None,                                    // 0xa61
+        None,                                    // 0xa62
+        None,                                    // 0xa63
+        None,                                    // 0xa70
+        None,                                    // 0xa71
+        None,                                    // 0xa72
+        None,                                    // 0xa73
+        None,                                    // 0xa80
+        None,                                    // 0xa81
+        None,                                    // 0xa82
+        None,                                    // 0xa83
+        None,                                    // 0xa90
+        None,                                    // 0xa91
+        None,                                    // 0xa92
+        None,                                    // 0xa93
+        None,                                    // 0xaa0
+        None,                                    // 0xaa1
+        None,                                    // 0xaa2
+        None,                                    // 0xaa3
+        None,                                    // 0xab0
+        None,                                    // 0xab1
+        None,                                    // 0xab2
+        None,                                    // 0xab3
+        None,                                    // 0xac0
+        None,                                    // 0xac1
+        None,                                    // 0xac2
+        None,                                    // 0xac3
+        None,                                    // 0xad0
+        None,                                    // 0xad1
+        None,                                    // 0xad2
+        None,                                    // 0xad3
+        None,                                    // 0xae0
+        None,                                    // 0xae1
+        None,                                    // 0xae2
+        None,                                    // 0xae3
+        None,                                    // 0xaf0
+        None,                                    // 0xaf1
+        None,                                    // 0xaf2
+        None,                                    // 0xaf3
+        None,                                    // 0xb00
+        None,                                    // 0xb01
+        None,                                    // 0xb02
+        None,                                    // 0xb03
+        None,                                    // 0xb10
+        None,                                    // 0xb11
+        None,                                    // 0xb12
+        None,                                    // 0xb13
+        None,                                    // 0xb20
+        None,                                    // 0xb21
+        None,                                    // 0xb22
+        None,                                    // 0xb23
+        None,                                    // 0xb30
+        None,                                    // 0xb31
+        None,                                    // 0xb32
+        None,                                    // 0xb33
+        None,                                    // 0xb40
+        None,                                    // 0xb41
+        None,                                    // 0xb42
+        None,                                    // 0xb43
+        None,                                    // 0xb50
+        None,                                    // 0xb51
+        None,                                    // 0xb52
+        None,                                    // 0xb53
+        None,                                    // 0xb60
+        None,                                    // 0xb61
+        None,                                    // 0xb62
+        None,                                    // 0xb63
+        None,                                    // 0xb70
+        None,                                    // 0xb71
+        None,                                    // 0xb72
+        None,                                    // 0xb73
+        None,                                    // 0xb80
+        None,                                    // 0xb81
+        None,                                    // 0xb82
+        None,                                    // 0xb83
+        None,                                    // 0xb90
+        None,                                    // 0xb91
+        None,                                    // 0xb92
+        None,                                    // 0xb93
+        None,                                    // 0xba0
+        None,                                    // 0xba1
+        None,                                    // 0xba2
+        None,                                    // 0xba3
+        None,                                    // 0xbb0
+        None,                                    // 0xbb1
+        None,                                    // 0xbb2
+        None,                                    // 0xbb3
+        None,                                    // 0xbc0
+        None,                                    // 0xbc1
+        None,                                    // 0xbc2
+        None,                                    // 0xbc3
+        None,                                    // 0xbd0
+        None,                                    // 0xbd1
+        None,                                    // 0xbd2
+        None,                                    // 0xbd3
+        None,                                    // 0xbe0
+        None,                                    // 0xbe1
+        None,                                    // 0xbe2
+        None,                                    // 0xbe3
+        None,                                    // 0xbf0
+        None,                                    // 0xbf1
+        None,                                    // 0xbf2
+        None,                                    // 0xbf3
+        None,                                    // 0xc00
+        None,                                    // 0xc01
+        None,                                    // 0xc02
+        None,                                    // 0xc03
+        None,                                    // 0xc10
+        None,                                    // 0xc11
+        None,                                    // 0xc12
+        None,                                    // 0xc13
+        None,                                    // 0xc20
+        None,                                    // 0xc21
+        None,                                    // 0xc22
+        None,                                    // 0xc23
+        None,                                    // 0xc30
+        None,                                    // 0xc31
+        None,                                    // 0xc32
+        None,                                    // 0xc33
+        None,                                    // 0xc40
+        None,                                    // 0xc41
+        None,                                    // 0xc42
+        None,                                    // 0xc43
+        None,                                    // 0xc50
+        None,                                    // 0xc51
+        None,                                    // 0xc52
+        None,                                    // 0xc53
+        None,                                    // 0xc60
+        None,                                    // 0xc61
+        None,                                    // 0xc62
+        None,                                    // 0xc63
+        None,                                    // 0xc70
+        None,                                    // 0xc71
+        None,                                    // 0xc72
+        None,                                    // 0xc73
+        MOp_M16B,                                // 0xc80 sha1nexte
+        None,                                    // 0xc81
+        None,                                    // 0xc82
+        None,                                    // 0xc83
+        MOp_M16B,                                // 0xc90 sha1msg1
+        None,                                    // 0xc91
+        None,                                    // 0xc92
+        None,                                    // 0xc93
+        MOp_M16B,                                // 0xca0 sha1msg2
+        None,                                    // 0xca1
+        None,                                    // 0xca2
+        None,                                    // 0xca3
+        MOp_M16B,                                // 0xcb0 sha256rnds2
+        None,                                    // 0xcb1
+        None,                                    // 0xcb2
+        None,                                    // 0xcb3
+        MOp_M16B,                                // 0xcc0 sha256msg1
+        None,                                    // 0xcc1
+        None,                                    // 0xcc2
+        None,                                    // 0xcc3
+        MOp_M16B,                                // 0xcd0 sha256msg2
+        None,                                    // 0xcd1
+        None,                                    // 0xcd2
+        None,                                    // 0xcd3
+        None,                                    // 0xce0
+        None,                                    // 0xce1
+        None,                                    // 0xce2
+        None,                                    // 0xce3
+        None,                                    // 0xcf0
+        None,                                    // 0xcf1
+        None,                                    // 0xcf2
+        None,                                    // 0xcf3
+        None,                                    // 0xd00
+        None,                                    // 0xd01
+        None,                                    // 0xd02
+        None,                                    // 0xd03
+        None,                                    // 0xd10
+        None,                                    // 0xd11
+        None,                                    // 0xd12
+        None,                                    // 0xd13
+        None,                                    // 0xd20
+        None,                                    // 0xd21
+        None,                                    // 0xd22
+        None,                                    // 0xd23
+        None,                                    // 0xd30
+        None,                                    // 0xd31
+        None,                                    // 0xd32
+        None,                                    // 0xd33
+        None,                                    // 0xd40
+        None,                                    // 0xd41
+        None,                                    // 0xd42
+        None,                                    // 0xd43
+        None,                                    // 0xd50
+        None,                                    // 0xd51
+        None,                                    // 0xd52
+        None,                                    // 0xd53
+        None,                                    // 0xd60
+        None,                                    // 0xd61
+        None,                                    // 0xd62
+        None,                                    // 0xd63
+        None,                                    // 0xd70
+        None,                                    // 0xd71
+        None,                                    // 0xd72
+        None,                                    // 0xd73
+        None,                                    // 0xd80
+        None,                                    // 0xd81
+        None,                                    // 0xd82
+        None,                                    // 0xd83
+        None,                                    // 0xd90
+        None,                                    // 0xd91
+        None,                                    // 0xd92
+        None,                                    // 0xd93
+        None,                                    // 0xda0
+        None,                                    // 0xda1
+        None,                                    // 0xda2
+        None,                                    // 0xda3
+        None,                                    // 0xdb0
+        MOp_M16B,                                // 0xdb1 aesimc
+        None,                                    // 0xdb2
+        None,                                    // 0xdb3
+        None,                                    // 0xdc0
+        MOp_M16B,                                // 0xdc1 aesenc
+        None,                                    // 0xdc2
+        None,                                    // 0xdc3
+        None,                                    // 0xdd0
+        MOp_M16B,                                // 0xdd1 aesenclast
+        None,                                    // 0xdd2
+        None,                                    // 0xdd3
+        None,                                    // 0xde0
+        MOp_M16B,                                // 0xde1 aesdec
+        None,                                    // 0xde2
+        None,                                    // 0xde3
+        None,                                    // 0xdf0
+        MOp_M16B,                                // 0xdf1 aesdeclast
+        None,                                    // 0xdf2
+        None,                                    // 0xdf3
+        None,                                    // 0xe00
+        None,                                    // 0xe01
+        None,                                    // 0xe02
+        None,                                    // 0xe03
+        None,                                    // 0xe10
+        None,                                    // 0xe11
+        None,                                    // 0xe12
+        None,                                    // 0xe13
+        None,                                    // 0xe20
+        None,                                    // 0xe21
+        None,                                    // 0xe22
+        None,                                    // 0xe23
+        None,                                    // 0xe30
+        None,                                    // 0xe31
+        None,                                    // 0xe32
+        None,                                    // 0xe33
+        None,                                    // 0xe40
+        None,                                    // 0xe41
+        None,                                    // 0xe42
+        None,                                    // 0xe43
+        None,                                    // 0xe50
+        None,                                    // 0xe51
+        None,                                    // 0xe52
+        None,                                    // 0xe53
+        None,                                    // 0xe60
+        None,                                    // 0xe61
+        None,                                    // 0xe62
+        None,                                    // 0xe63
+        None,                                    // 0xe70
+        None,                                    // 0xe71
+        None,                                    // 0xe72
+        None,                                    // 0xe73
+        None,                                    // 0xe80
+        None,                                    // 0xe81
+        None,                                    // 0xe82
+        None,                                    // 0xe83
+        None,                                    // 0xe90
+        None,                                    // 0xe91
+        None,                                    // 0xe92
+        None,                                    // 0xe93
+        None,                                    // 0xea0
+        None,                                    // 0xea1
+        None,                                    // 0xea2
+        None,                                    // 0xea3
+        None,                                    // 0xeb0
+        None,                                    // 0xeb1
+        None,                                    // 0xeb2
+        None,                                    // 0xeb3
+        None,                                    // 0xec0
+        None,                                    // 0xec1
+        None,                                    // 0xec2
+        None,                                    // 0xec3
+        None,                                    // 0xed0
+        None,                                    // 0xed1
+        None,                                    // 0xed2
+        None,                                    // 0xed3
+        None,                                    // 0xee0
+        None,                                    // 0xee1
+        None,                                    // 0xee2
+        None,                                    // 0xee3
+        None,                                    // 0xef0
+        None,                                    // 0xef1
+        None,                                    // 0xef2
+        None,                                    // 0xef3
+        MOp_W_M8B_or_M4B,                        // 0xf00 movbe
+        MOp_W_M8B_or_M2B,                        // 0xf01 movbe
+        None,                                    // 0xf02
+        None,                                    // 0xf03
+        M1st_W_M8B_or_M4B,                       // 0xf10 movbe
+        M1st_W_M8B_or_M2B,                       // 0xf11 movbe
+        None,                                    // 0xf12
+        None,                                    // 0xf13
+        None,                                    // 0xf20
+        None,                                    // 0xf21
+        None,                                    // 0xf22
+        None,                                    // 0xf23
+        None,                                    // 0xf30
+        None,                                    // 0xf31
+        None,                                    // 0xf32
+        None,                                    // 0xf33
+        None,                                    // 0xf40
+        None,                                    // 0xf41
+        None,                                    // 0xf42
+        None,                                    // 0xf43
+        None,                                    // 0xf50
+        None,                                    // 0xf51
+        None,                                    // 0xf52
+        None,                                    // 0xf53
+        None,                                    // 0xf60
+        MOp_W_M8B_or_M4B,                        // 0xf61 adcx
+        None,                                    // 0xf62
+        None,                                    // 0xf63
+        None,                                    // 0xf70
+        None,                                    // 0xf71
+        None,                                    // 0xf72
+        None,                                    // 0xf73
+        None,                                    // 0xf80
+        None,                                    // 0xf81
+        None,                                    // 0xf82
+        None,                                    // 0xf83
+        None,                                    // 0xf90
+        None,                                    // 0xf91
+        None,                                    // 0xf92
+        None,                                    // 0xf93
+        None,                                    // 0xfa0
+        None,                                    // 0xfa1
+        None,                                    // 0xfa2
+        None,                                    // 0xfa3
+        None,                                    // 0xfb0
+        None,                                    // 0xfb1
+        None,                                    // 0xfb2
+        None,                                    // 0xfb3
+        None,                                    // 0xfc0
+        None,                                    // 0xfc1
+        None,                                    // 0xfc2
+        None,                                    // 0xfc3
+        None,                                    // 0xfd0
+        None,                                    // 0xfd1
+        None,                                    // 0xfd2
+        None,                                    // 0xfd3
+        None,                                    // 0xfe0
+        None,                                    // 0xfe1
+        None,                                    // 0xfe2
+        None,                                    // 0xfe3
+        None,                                    // 0xff0
+        None,                                    // 0xff1
+        None,                                    // 0xff2
+        None,                                    // 0xff3
+    };
+
+    static const InstrForm instrFormF3A[1024]
+    {
+        None,                                    // 0x000
+        None,                                    // 0x001
+        None,                                    // 0x002
+        None,                                    // 0x003
+        None,                                    // 0x010
+        None,                                    // 0x011
+        None,                                    // 0x012
+        None,                                    // 0x013
+        None,                                    // 0x020
+        None,                                    // 0x021
+        None,                                    // 0x022
+        None,                                    // 0x023
+        None,                                    // 0x030
+        None,                                    // 0x031
+        None,                                    // 0x032
+        None,                                    // 0x033
+        None,                                    // 0x040
+        None,                                    // 0x041
+        None,                                    // 0x042
+        None,                                    // 0x043
+        None,                                    // 0x050
+        None,                                    // 0x051
+        None,                                    // 0x052
+        None,                                    // 0x053
+        None,                                    // 0x060
+        None,                                    // 0x061
+        None,                                    // 0x062
+        None,                                    // 0x063
+        None,                                    // 0x070
+        None,                                    // 0x071
+        None,                                    // 0x072
+        None,                                    // 0x073
+        None,                                    // 0x080
+        MOp_M16B_I1B,                            // 0x081 roundps
+        None,                                    // 0x082
+        None,                                    // 0x083
+        None,                                    // 0x090
+        MOp_M16B_I1B,                            // 0x091 roundpd
+        None,                                    // 0x092
+        None,                                    // 0x093
+        None,                                    // 0x0a0
+        MOp_M4B_I1B,                             // 0x0a1 roundss
+        None,                                    // 0x0a2
+        None,                                    // 0x0a3
+        None,                                    // 0x0b0
+        MOp_M8B_I1B,                             // 0x0b1 roundsd
+        None,                                    // 0x0b2
+        None,                                    // 0x0b3
+        None,                                    // 0x0c0
+        MOp_M16B_I1B,                            // 0x0c1 blendps
+        None,                                    // 0x0c2
+        None,                                    // 0x0c3
+        None,                                    // 0x0d0
+        MOp_M16B_I1B,                            // 0x0d1 blendpd
+        None,                                    // 0x0d2
+        None,                                    // 0x0d3
+        None,                                    // 0x0e0
+        MOp_M16B_I1B,                            // 0x0e1 pblendw
+        None,                                    // 0x0e2
+        None,                                    // 0x0e3
+        MOp_M8B_I1B,                             // 0x0f0 palignr
+        MOp_M16B_I1B,                            // 0x0f1 palignr
+        None,                                    // 0x0f2
+        None,                                    // 0x0f3
+        None,                                    // 0x100
+        None,                                    // 0x101
+        None,                                    // 0x102
+        None,                                    // 0x103
+        None,                                    // 0x110
+        None,                                    // 0x111
+        None,                                    // 0x112
+        None,                                    // 0x113
+        None,                                    // 0x120
+        None,                                    // 0x121
+        None,                                    // 0x122
+        None,                                    // 0x123
+        None,                                    // 0x130
+        None,                                    // 0x131
+        None,                                    // 0x132
+        None,                                    // 0x133
+        None,                                    // 0x140
+        M1st_M1B_I1B,                            // 0x141 pextrb
+        None,                                    // 0x142
+        None,                                    // 0x143
+        None,                                    // 0x150
+        M1st_M2B_I1B,                            // 0x151 pextrw
+        None,                                    // 0x152
+        None,                                    // 0x153
+        None,                                    // 0x160
+        M1st_I1B_W_M8B_or_M4B,                   // 0x161 pextrd,pextrq
+        None,                                    // 0x162
+        None,                                    // 0x163
+        None,                                    // 0x170
+        M1st_M4B_I1B,                            // 0x171 extractps
+        None,                                    // 0x172
+        None,                                    // 0x173
+        None,                                    // 0x180
+        None,                                    // 0x181
+        None,                                    // 0x182
+        None,                                    // 0x183
+        None,                                    // 0x190
+        None,                                    // 0x191
+        None,                                    // 0x192
+        None,                                    // 0x193
+        None,                                    // 0x1a0
+        None,                                    // 0x1a1
+        None,                                    // 0x1a2
+        None,                                    // 0x1a3
+        None,                                    // 0x1b0
+        None,                                    // 0x1b1
+        None,                                    // 0x1b2
+        None,                                    // 0x1b3
+        None,                                    // 0x1c0
+        None,                                    // 0x1c1
+        None,                                    // 0x1c2
+        None,                                    // 0x1c3
+        None,                                    // 0x1d0
+        None,                                    // 0x1d1
+        None,                                    // 0x1d2
+        None,                                    // 0x1d3
+        None,                                    // 0x1e0
+        None,                                    // 0x1e1
+        None,                                    // 0x1e2
+        None,                                    // 0x1e3
+        None,                                    // 0x1f0
+        None,                                    // 0x1f1
+        None,                                    // 0x1f2
+        None,                                    // 0x1f3
+        None,                                    // 0x200
+        MOp_M1B_I1B,                             // 0x201 pinsrb
+        None,                                    // 0x202
+        None,                                    // 0x203
+        None,                                    // 0x210
+        MOp_M4B_I1B,                             // 0x211 insertps
+        None,                                    // 0x212
+        None,                                    // 0x213
+        None,                                    // 0x220
+        MOp_I1B_W_M8B_or_M4B,                    // 0x221 pinsrd,pinsrq
+        None,                                    // 0x222
+        None,                                    // 0x223
+        None,                                    // 0x230
+        None,                                    // 0x231
+        None,                                    // 0x232
+        None,                                    // 0x233
+        None,                                    // 0x240
+        None,                                    // 0x241
+        None,                                    // 0x242
+        None,                                    // 0x243
+        None,                                    // 0x250
+        None,                                    // 0x251
+        None,                                    // 0x252
+        None,                                    // 0x253
+        None,                                    // 0x260
+        None,                                    // 0x261
+        None,                                    // 0x262
+        None,                                    // 0x263
+        None,                                    // 0x270
+        None,                                    // 0x271
+        None,                                    // 0x272
+        None,                                    // 0x273
+        None,                                    // 0x280
+        None,                                    // 0x281
+        None,                                    // 0x282
+        None,                                    // 0x283
+        None,                                    // 0x290
+        None,                                    // 0x291
+        None,                                    // 0x292
+        None,                                    // 0x293
+        None,                                    // 0x2a0
+        None,                                    // 0x2a1
+        None,                                    // 0x2a2
+        None,                                    // 0x2a3
+        None,                                    // 0x2b0
+        None,                                    // 0x2b1
+        None,                                    // 0x2b2
+        None,                                    // 0x2b3
+        None,                                    // 0x2c0
+        None,                                    // 0x2c1
+        None,                                    // 0x2c2
+        None,                                    // 0x2c3
+        None,                                    // 0x2d0
+        None,                                    // 0x2d1
+        None,                                    // 0x2d2
+        None,                                    // 0x2d3
+        None,                                    // 0x2e0
+        None,                                    // 0x2e1
+        None,                                    // 0x2e2
+        None,                                    // 0x2e3
+        None,                                    // 0x2f0
+        None,                                    // 0x2f1
+        None,                                    // 0x2f2
+        None,                                    // 0x2f3
+        None,                                    // 0x300
+        None,                                    // 0x301
+        None,                                    // 0x302
+        None,                                    // 0x303
+        None,                                    // 0x310
+        None,                                    // 0x311
+        None,                                    // 0x312
+        None,                                    // 0x313
+        None,                                    // 0x320
+        None,                                    // 0x321
+        None,                                    // 0x322
+        None,                                    // 0x323
+        None,                                    // 0x330
+        None,                                    // 0x331
+        None,                                    // 0x332
+        None,                                    // 0x333
+        None,                                    // 0x340
+        None,                                    // 0x341
+        None,                                    // 0x342
+        None,                                    // 0x343
+        None,                                    // 0x350
+        None,                                    // 0x351
+        None,                                    // 0x352
+        None,                                    // 0x353
+        None,                                    // 0x360
+        None,                                    // 0x361
+        None,                                    // 0x362
+        None,                                    // 0x363
+        None,                                    // 0x370
+        None,                                    // 0x371
+        None,                                    // 0x372
+        None,                                    // 0x373
+        None,                                    // 0x380
+        None,                                    // 0x381
+        None,                                    // 0x382
+        None,                                    // 0x383
+        None,                                    // 0x390
+        None,                                    // 0x391
+        None,                                    // 0x392
+        None,                                    // 0x393
+        None,                                    // 0x3a0
+        None,                                    // 0x3a1
+        None,                                    // 0x3a2
+        None,                                    // 0x3a3
+        None,                                    // 0x3b0
+        None,                                    // 0x3b1
+        None,                                    // 0x3b2
+        None,                                    // 0x3b3
+        None,                                    // 0x3c0
+        None,                                    // 0x3c1
+        None,                                    // 0x3c2
+        None,                                    // 0x3c3
+        None,                                    // 0x3d0
+        None,                                    // 0x3d1
+        None,                                    // 0x3d2
+        None,                                    // 0x3d3
+        None,                                    // 0x3e0
+        None,                                    // 0x3e1
+        None,                                    // 0x3e2
+        None,                                    // 0x3e3
+        None,                                    // 0x3f0
+        None,                                    // 0x3f1
+        None,                                    // 0x3f2
+        None,                                    // 0x3f3
+        None,                                    // 0x400
+        MOp_M16B_I1B,                            // 0x401 dpps
+        None,                                    // 0x402
+        None,                                    // 0x403
+        None,                                    // 0x410
+        MOp_M16B_I1B,                            // 0x411 dppd
+        None,                                    // 0x412
+        None,                                    // 0x413
+        None,                                    // 0x420
+        MOp_M16B_I1B,                            // 0x421 mpsadbw
+        None,                                    // 0x422
+        None,                                    // 0x423
+        None,                                    // 0x430
+        None,                                    // 0x431
+        None,                                    // 0x432
+        None,                                    // 0x433
+        None,                                    // 0x440
+        MOp_M16B_I1B,                            // 0x441 pclmulqdq
+        None,                                    // 0x442
+        None,                                    // 0x443
+        None,                                    // 0x450
+        None,                                    // 0x451
+        None,                                    // 0x452
+        None,                                    // 0x453
+        None,                                    // 0x460
+        None,                                    // 0x461
+        None,                                    // 0x462
+        None,                                    // 0x463
+        None,                                    // 0x470
+        None,                                    // 0x471
+        None,                                    // 0x472
+        None,                                    // 0x473
+        None,                                    // 0x480
+        None,                                    // 0x481
+        None,                                    // 0x482
+        None,                                    // 0x483
+        None,                                    // 0x490
+        None,                                    // 0x491
+        None,                                    // 0x492
+        None,                                    // 0x493
+        None,                                    // 0x4a0
+        None,                                    // 0x4a1
+        None,                                    // 0x4a2
+        None,                                    // 0x4a3
+        None,                                    // 0x4b0
+        None,                                    // 0x4b1
+        None,                                    // 0x4b2
+        None,                                    // 0x4b3
+        None,                                    // 0x4c0
+        None,                                    // 0x4c1
+        None,                                    // 0x4c2
+        None,                                    // 0x4c3
+        None,                                    // 0x4d0
+        None,                                    // 0x4d1
+        None,                                    // 0x4d2
+        None,                                    // 0x4d3
+        None,                                    // 0x4e0
+        None,                                    // 0x4e1
+        None,                                    // 0x4e2
+        None,                                    // 0x4e3
+        None,                                    // 0x4f0
+        None,                                    // 0x4f1
+        None,                                    // 0x4f2
+        None,                                    // 0x4f3
+        None,                                    // 0x500
+        None,                                    // 0x501
+        None,                                    // 0x502
+        None,                                    // 0x503
+        None,                                    // 0x510
+        None,                                    // 0x511
+        None,                                    // 0x512
+        None,                                    // 0x513
+        None,                                    // 0x520
+        None,                                    // 0x521
+        None,                                    // 0x522
+        None,                                    // 0x523
+        None,                                    // 0x530
+        None,                                    // 0x531
+        None,                                    // 0x532
+        None,                                    // 0x533
+        None,                                    // 0x540
+        None,                                    // 0x541
+        None,                                    // 0x542
+        None,                                    // 0x543
+        None,                                    // 0x550
+        None,                                    // 0x551
+        None,                                    // 0x552
+        None,                                    // 0x553
+        None,                                    // 0x560
+        None,                                    // 0x561
+        None,                                    // 0x562
+        None,                                    // 0x563
+        None,                                    // 0x570
+        None,                                    // 0x571
+        None,                                    // 0x572
+        None,                                    // 0x573
+        None,                                    // 0x580
+        None,                                    // 0x581
+        None,                                    // 0x582
+        None,                                    // 0x583
+        None,                                    // 0x590
+        None,                                    // 0x591
+        None,                                    // 0x592
+        None,                                    // 0x593
+        None,                                    // 0x5a0
+        None,                                    // 0x5a1
+        None,                                    // 0x5a2
+        None,                                    // 0x5a3
+        None,                                    // 0x5b0
+        None,                                    // 0x5b1
+        None,                                    // 0x5b2
+        None,                                    // 0x5b3
+        None,                                    // 0x5c0
+        None,                                    // 0x5c1
+        None,                                    // 0x5c2
+        None,                                    // 0x5c3
+        None,                                    // 0x5d0
+        None,                                    // 0x5d1
+        None,                                    // 0x5d2
+        None,                                    // 0x5d3
+        None,                                    // 0x5e0
+        None,                                    // 0x5e1
+        None,                                    // 0x5e2
+        None,                                    // 0x5e3
+        None,                                    // 0x5f0
+        None,                                    // 0x5f1
+        None,                                    // 0x5f2
+        None,                                    // 0x5f3
+        None,                                    // 0x600
+        MOp_M16B_I1B,                            // 0x601 pcmpestrm
+        None,                                    // 0x602
+        None,                                    // 0x603
+        None,                                    // 0x610
+        MOp_M16B_I1B,                            // 0x611 pcmpestri
+        None,                                    // 0x612
+        None,                                    // 0x613
+        None,                                    // 0x620
+        MOp_M16B_I1B,                            // 0x621 pcmpistrm
+        None,                                    // 0x622
+        None,                                    // 0x623
+        None,                                    // 0x630
+        MOp_M16B_I1B,                            // 0x631 pcmpistri
+        None,                                    // 0x632
+        None,                                    // 0x633
+        None,                                    // 0x640
+        None,                                    // 0x641
+        None,                                    // 0x642
+        None,                                    // 0x643
+        None,                                    // 0x650
+        None,                                    // 0x651
+        None,                                    // 0x652
+        None,                                    // 0x653
+        None,                                    // 0x660
+        None,                                    // 0x661
+        None,                                    // 0x662
+        None,                                    // 0x663
+        None,                                    // 0x670
+        None,                                    // 0x671
+        None,                                    // 0x672
+        None,                                    // 0x673
+        None,                                    // 0x680
+        None,                                    // 0x681
+        None,                                    // 0x682
+        None,                                    // 0x683
+        None,                                    // 0x690
+        None,                                    // 0x691
+        None,                                    // 0x692
+        None,                                    // 0x693
+        None,                                    // 0x6a0
+        None,                                    // 0x6a1
+        None,                                    // 0x6a2
+        None,                                    // 0x6a3
+        None,                                    // 0x6b0
+        None,                                    // 0x6b1
+        None,                                    // 0x6b2
+        None,                                    // 0x6b3
+        None,                                    // 0x6c0
+        None,                                    // 0x6c1
+        None,                                    // 0x6c2
+        None,                                    // 0x6c3
+        None,                                    // 0x6d0
+        None,                                    // 0x6d1
+        None,                                    // 0x6d2
+        None,                                    // 0x6d3
+        None,                                    // 0x6e0
+        None,                                    // 0x6e1
+        None,                                    // 0x6e2
+        None,                                    // 0x6e3
+        None,                                    // 0x6f0
+        None,                                    // 0x6f1
+        None,                                    // 0x6f2
+        None,                                    // 0x6f3
+        None,                                    // 0x700
+        None,                                    // 0x701
+        None,                                    // 0x702
+        None,                                    // 0x703
+        None,                                    // 0x710
+        None,                                    // 0x711
+        None,                                    // 0x712
+        None,                                    // 0x713
+        None,                                    // 0x720
+        None,                                    // 0x721
+        None,                                    // 0x722
+        None,                                    // 0x723
+        None,                                    // 0x730
+        None,                                    // 0x731
+        None,                                    // 0x732
+        None,                                    // 0x733
+        None,                                    // 0x740
+        None,                                    // 0x741
+        None,                                    // 0x742
+        None,                                    // 0x743
+        None,                                    // 0x750
+        None,                                    // 0x751
+        None,                                    // 0x752
+        None,                                    // 0x753
+        None,                                    // 0x760
+        None,                                    // 0x761
+        None,                                    // 0x762
+        None,                                    // 0x763
+        None,                                    // 0x770
+        None,                                    // 0x771
+        None,                                    // 0x772
+        None,                                    // 0x773
+        None,                                    // 0x780
+        None,                                    // 0x781
+        None,                                    // 0x782
+        None,                                    // 0x783
+        None,                                    // 0x790
+        None,                                    // 0x791
+        None,                                    // 0x792
+        None,                                    // 0x793
+        None,                                    // 0x7a0
+        None,                                    // 0x7a1
+        None,                                    // 0x7a2
+        None,                                    // 0x7a3
+        None,                                    // 0x7b0
+        None,                                    // 0x7b1
+        None,                                    // 0x7b2
+        None,                                    // 0x7b3
+        None,                                    // 0x7c0
+        None,                                    // 0x7c1
+        None,                                    // 0x7c2
+        None,                                    // 0x7c3
+        None,                                    // 0x7d0
+        None,                                    // 0x7d1
+        None,                                    // 0x7d2
+        None,                                    // 0x7d3
+        None,                                    // 0x7e0
+        None,                                    // 0x7e1
+        None,                                    // 0x7e2
+        None,                                    // 0x7e3
+        None,                                    // 0x7f0
+        None,                                    // 0x7f1
+        None,                                    // 0x7f2
+        None,                                    // 0x7f3
+        None,                                    // 0x800
+        None,                                    // 0x801
+        None,                                    // 0x802
+        None,                                    // 0x803
+        None,                                    // 0x810
+        None,                                    // 0x811
+        None,                                    // 0x812
+        None,                                    // 0x813
+        None,                                    // 0x820
+        None,                                    // 0x821
+        None,                                    // 0x822
+        None,                                    // 0x823
+        None,                                    // 0x830
+        None,                                    // 0x831
+        None,                                    // 0x832
+        None,                                    // 0x833
+        None,                                    // 0x840
+        None,                                    // 0x841
+        None,                                    // 0x842
+        None,                                    // 0x843
+        None,                                    // 0x850
+        None,                                    // 0x851
+        None,                                    // 0x852
+        None,                                    // 0x853
+        None,                                    // 0x860
+        None,                                    // 0x861
+        None,                                    // 0x862
+        None,                                    // 0x863
+        None,                                    // 0x870
+        None,                                    // 0x871
+        None,                                    // 0x872
+        None,                                    // 0x873
+        None,                                    // 0x880
+        None,                                    // 0x881
+        None,                                    // 0x882
+        None,                                    // 0x883
+        None,                                    // 0x890
+        None,                                    // 0x891
+        None,                                    // 0x892
+        None,                                    // 0x893
+        None,                                    // 0x8a0
+        None,                                    // 0x8a1
+        None,                                    // 0x8a2
+        None,                                    // 0x8a3
+        None,                                    // 0x8b0
+        None,                                    // 0x8b1
+        None,                                    // 0x8b2
+        None,                                    // 0x8b3
+        None,                                    // 0x8c0
+        None,                                    // 0x8c1
+        None,                                    // 0x8c2
+        None,                                    // 0x8c3
+        None,                                    // 0x8d0
+        None,                                    // 0x8d1
+        None,                                    // 0x8d2
+        None,                                    // 0x8d3
+        None,                                    // 0x8e0
+        None,                                    // 0x8e1
+        None,                                    // 0x8e2
+        None,                                    // 0x8e3
+        None,                                    // 0x8f0
+        None,                                    // 0x8f1
+        None,                                    // 0x8f2
+        None,                                    // 0x8f3
+        None,                                    // 0x900
+        None,                                    // 0x901
+        None,                                    // 0x902
+        None,                                    // 0x903
+        None,                                    // 0x910
+        None,                                    // 0x911
+        None,                                    // 0x912
+        None,                                    // 0x913
+        None,                                    // 0x920
+        None,                                    // 0x921
+        None,                                    // 0x922
+        None,                                    // 0x923
+        None,                                    // 0x930
+        None,                                    // 0x931
+        None,                                    // 0x932
+        None,                                    // 0x933
+        None,                                    // 0x940
+        None,                                    // 0x941
+        None,                                    // 0x942
+        None,                                    // 0x943
+        None,                                    // 0x950
+        None,                                    // 0x951
+        None,                                    // 0x952
+        None,                                    // 0x953
+        None,                                    // 0x960
+        None,                                    // 0x961
+        None,                                    // 0x962
+        None,                                    // 0x963
+        None,                                    // 0x970
+        None,                                    // 0x971
+        None,                                    // 0x972
+        None,                                    // 0x973
+        None,                                    // 0x980
+        None,                                    // 0x981
+        None,                                    // 0x982
+        None,                                    // 0x983
+        None,                                    // 0x990
+        None,                                    // 0x991
+        None,                                    // 0x992
+        None,                                    // 0x993
+        None,                                    // 0x9a0
+        None,                                    // 0x9a1
+        None,                                    // 0x9a2
+        None,                                    // 0x9a3
+        None,                                    // 0x9b0
+        None,                                    // 0x9b1
+        None,                                    // 0x9b2
+        None,                                    // 0x9b3
+        None,                                    // 0x9c0
+        None,                                    // 0x9c1
+        None,                                    // 0x9c2
+        None,                                    // 0x9c3
+        None,                                    // 0x9d0
+        None,                                    // 0x9d1
+        None,                                    // 0x9d2
+        None,                                    // 0x9d3
+        None,                                    // 0x9e0
+        None,                                    // 0x9e1
+        None,                                    // 0x9e2
+        None,                                    // 0x9e3
+        None,                                    // 0x9f0
+        None,                                    // 0x9f1
+        None,                                    // 0x9f2
+        None,                                    // 0x9f3
+        None,                                    // 0xa00
+        None,                                    // 0xa01
+        None,                                    // 0xa02
+        None,                                    // 0xa03
+        None,                                    // 0xa10
+        None,                                    // 0xa11
+        None,                                    // 0xa12
+        None,                                    // 0xa13
+        None,                                    // 0xa20
+        None,                                    // 0xa21
+        None,                                    // 0xa22
+        None,                                    // 0xa23
+        None,                                    // 0xa30
+        None,                                    // 0xa31
+        None,                                    // 0xa32
+        None,                                    // 0xa33
+        None,                                    // 0xa40
+        None,                                    // 0xa41
+        None,                                    // 0xa42
+        None,                                    // 0xa43
+        None,                                    // 0xa50
+        None,                                    // 0xa51
+        None,                                    // 0xa52
+        None,                                    // 0xa53
+        None,                                    // 0xa60
+        None,                                    // 0xa61
+        None,                                    // 0xa62
+        None,                                    // 0xa63
+        None,                                    // 0xa70
+        None,                                    // 0xa71
+        None,                                    // 0xa72
+        None,                                    // 0xa73
+        None,                                    // 0xa80
+        None,                                    // 0xa81
+        None,                                    // 0xa82
+        None,                                    // 0xa83
+        None,                                    // 0xa90
+        None,                                    // 0xa91
+        None,                                    // 0xa92
+        None,                                    // 0xa93
+        None,                                    // 0xaa0
+        None,                                    // 0xaa1
+        None,                                    // 0xaa2
+        None,                                    // 0xaa3
+        None,                                    // 0xab0
+        None,                                    // 0xab1
+        None,                                    // 0xab2
+        None,                                    // 0xab3
+        None,                                    // 0xac0
+        None,                                    // 0xac1
+        None,                                    // 0xac2
+        None,                                    // 0xac3
+        None,                                    // 0xad0
+        None,                                    // 0xad1
+        None,                                    // 0xad2
+        None,                                    // 0xad3
+        None,                                    // 0xae0
+        None,                                    // 0xae1
+        None,                                    // 0xae2
+        None,                                    // 0xae3
+        None,                                    // 0xaf0
+        None,                                    // 0xaf1
+        None,                                    // 0xaf2
+        None,                                    // 0xaf3
+        None,                                    // 0xb00
+        None,                                    // 0xb01
+        None,                                    // 0xb02
+        None,                                    // 0xb03
+        None,                                    // 0xb10
+        None,                                    // 0xb11
+        None,                                    // 0xb12
+        None,                                    // 0xb13
+        None,                                    // 0xb20
+        None,                                    // 0xb21
+        None,                                    // 0xb22
+        None,                                    // 0xb23
+        None,                                    // 0xb30
+        None,                                    // 0xb31
+        None,                                    // 0xb32
+        None,                                    // 0xb33
+        None,                                    // 0xb40
+        None,                                    // 0xb41
+        None,                                    // 0xb42
+        None,                                    // 0xb43
+        None,                                    // 0xb50
+        None,                                    // 0xb51
+        None,                                    // 0xb52
+        None,                                    // 0xb53
+        None,                                    // 0xb60
+        None,                                    // 0xb61
+        None,                                    // 0xb62
+        None,                                    // 0xb63
+        None,                                    // 0xb70
+        None,                                    // 0xb71
+        None,                                    // 0xb72
+        None,                                    // 0xb73
+        None,                                    // 0xb80
+        None,                                    // 0xb81
+        None,                                    // 0xb82
+        None,                                    // 0xb83
+        None,                                    // 0xb90
+        None,                                    // 0xb91
+        None,                                    // 0xb92
+        None,                                    // 0xb93
+        None,                                    // 0xba0
+        None,                                    // 0xba1
+        None,                                    // 0xba2
+        None,                                    // 0xba3
+        None,                                    // 0xbb0
+        None,                                    // 0xbb1
+        None,                                    // 0xbb2
+        None,                                    // 0xbb3
+        None,                                    // 0xbc0
+        None,                                    // 0xbc1
+        None,                                    // 0xbc2
+        None,                                    // 0xbc3
+        None,                                    // 0xbd0
+        None,                                    // 0xbd1
+        None,                                    // 0xbd2
+        None,                                    // 0xbd3
+        None,                                    // 0xbe0
+        None,                                    // 0xbe1
+        None,                                    // 0xbe2
+        None,                                    // 0xbe3
+        None,                                    // 0xbf0
+        None,                                    // 0xbf1
+        None,                                    // 0xbf2
+        None,                                    // 0xbf3
+        None,                                    // 0xc00
+        None,                                    // 0xc01
+        None,                                    // 0xc02
+        None,                                    // 0xc03
+        None,                                    // 0xc10
+        None,                                    // 0xc11
+        None,                                    // 0xc12
+        None,                                    // 0xc13
+        None,                                    // 0xc20
+        None,                                    // 0xc21
+        None,                                    // 0xc22
+        None,                                    // 0xc23
+        None,                                    // 0xc30
+        None,                                    // 0xc31
+        None,                                    // 0xc32
+        None,                                    // 0xc33
+        None,                                    // 0xc40
+        None,                                    // 0xc41
+        None,                                    // 0xc42
+        None,                                    // 0xc43
+        None,                                    // 0xc50
+        None,                                    // 0xc51
+        None,                                    // 0xc52
+        None,                                    // 0xc53
+        None,                                    // 0xc60
+        None,                                    // 0xc61
+        None,                                    // 0xc62
+        None,                                    // 0xc63
+        None,                                    // 0xc70
+        None,                                    // 0xc71
+        None,                                    // 0xc72
+        None,                                    // 0xc73
+        None,                                    // 0xc80
+        None,                                    // 0xc81
+        None,                                    // 0xc82
+        None,                                    // 0xc83
+        None,                                    // 0xc90
+        None,                                    // 0xc91
+        None,                                    // 0xc92
+        None,                                    // 0xc93
+        None,                                    // 0xca0
+        None,                                    // 0xca1
+        None,                                    // 0xca2
+        None,                                    // 0xca3
+        None,                                    // 0xcb0
+        None,                                    // 0xcb1
+        None,                                    // 0xcb2
+        None,                                    // 0xcb3
+        MOp_M16B_I1B,                            // 0xcc0 sha1rnds4
+        None,                                    // 0xcc1
+        None,                                    // 0xcc2
+        None,                                    // 0xcc3
+        None,                                    // 0xcd0
+        None,                                    // 0xcd1
+        None,                                    // 0xcd2
+        None,                                    // 0xcd3
+        None,                                    // 0xce0
+        None,                                    // 0xce1
+        None,                                    // 0xce2
+        None,                                    // 0xce3
+        None,                                    // 0xcf0
+        None,                                    // 0xcf1
+        None,                                    // 0xcf2
+        None,                                    // 0xcf3
+        None,                                    // 0xd00
+        None,                                    // 0xd01
+        None,                                    // 0xd02
+        None,                                    // 0xd03
+        None,                                    // 0xd10
+        None,                                    // 0xd11
+        None,                                    // 0xd12
+        None,                                    // 0xd13
+        None,                                    // 0xd20
+        None,                                    // 0xd21
+        None,                                    // 0xd22
+        None,                                    // 0xd23
+        None,                                    // 0xd30
+        None,                                    // 0xd31
+        None,                                    // 0xd32
+        None,                                    // 0xd33
+        None,                                    // 0xd40
+        None,                                    // 0xd41
+        None,                                    // 0xd42
+        None,                                    // 0xd43
+        None,                                    // 0xd50
+        None,                                    // 0xd51
+        None,                                    // 0xd52
+        None,                                    // 0xd53
+        None,                                    // 0xd60
+        None,                                    // 0xd61
+        None,                                    // 0xd62
+        None,                                    // 0xd63
+        None,                                    // 0xd70
+        None,                                    // 0xd71
+        None,                                    // 0xd72
+        None,                                    // 0xd73
+        None,                                    // 0xd80
+        None,                                    // 0xd81
+        None,                                    // 0xd82
+        None,                                    // 0xd83
+        None,                                    // 0xd90
+        None,                                    // 0xd91
+        None,                                    // 0xd92
+        None,                                    // 0xd93
+        None,                                    // 0xda0
+        None,                                    // 0xda1
+        None,                                    // 0xda2
+        None,                                    // 0xda3
+        None,                                    // 0xdb0
+        None,                                    // 0xdb1
+        None,                                    // 0xdb2
+        None,                                    // 0xdb3
+        None,                                    // 0xdc0
+        None,                                    // 0xdc1
+        None,                                    // 0xdc2
+        None,                                    // 0xdc3
+        None,                                    // 0xdd0
+        None,                                    // 0xdd1
+        None,                                    // 0xdd2
+        None,                                    // 0xdd3
+        None,                                    // 0xde0
+        None,                                    // 0xde1
+        None,                                    // 0xde2
+        None,                                    // 0xde3
+        None,                                    // 0xdf0
+        MOp_M16B_I1B,                            // 0xdf1 aeskeygenassist
+        None,                                    // 0xdf2
+        None,                                    // 0xdf3
+        None,                                    // 0xe00
+        None,                                    // 0xe01
+        None,                                    // 0xe02
+        None,                                    // 0xe03
+        None,                                    // 0xe10
+        None,                                    // 0xe11
+        None,                                    // 0xe12
+        None,                                    // 0xe13
+        None,                                    // 0xe20
+        None,                                    // 0xe21
+        None,                                    // 0xe22
+        None,                                    // 0xe23
+        None,                                    // 0xe30
+        None,                                    // 0xe31
+        None,                                    // 0xe32
+        None,                                    // 0xe33
+        None,                                    // 0xe40
+        None,                                    // 0xe41
+        None,                                    // 0xe42
+        None,                                    // 0xe43
+        None,                                    // 0xe50
+        None,                                    // 0xe51
+        None,                                    // 0xe52
+        None,                                    // 0xe53
+        None,                                    // 0xe60
+        None,                                    // 0xe61
+        None,                                    // 0xe62
+        None,                                    // 0xe63
+        None,                                    // 0xe70
+        None,                                    // 0xe71
+        None,                                    // 0xe72
+        None,                                    // 0xe73
+        None,                                    // 0xe80
+        None,                                    // 0xe81
+        None,                                    // 0xe82
+        None,                                    // 0xe83
+        None,                                    // 0xe90
+        None,                                    // 0xe91
+        None,                                    // 0xe92
+        None,                                    // 0xe93
+        None,                                    // 0xea0
+        None,                                    // 0xea1
+        None,                                    // 0xea2
+        None,                                    // 0xea3
+        None,                                    // 0xeb0
+        None,                                    // 0xeb1
+        None,                                    // 0xeb2
+        None,                                    // 0xeb3
+        None,                                    // 0xec0
+        None,                                    // 0xec1
+        None,                                    // 0xec2
+        None,                                    // 0xec3
+        None,                                    // 0xed0
+        None,                                    // 0xed1
+        None,                                    // 0xed2
+        None,                                    // 0xed3
+        None,                                    // 0xee0
+        None,                                    // 0xee1
+        None,                                    // 0xee2
+        None,                                    // 0xee3
+        None,                                    // 0xef0
+        None,                                    // 0xef1
+        None,                                    // 0xef2
+        None,                                    // 0xef3
+        None,                                    // 0xf00
+        None,                                    // 0xf01
+        None,                                    // 0xf02
+        None,                                    // 0xf03
+        None,                                    // 0xf10
+        None,                                    // 0xf11
+        None,                                    // 0xf12
+        None,                                    // 0xf13
+        None,                                    // 0xf20
+        None,                                    // 0xf21
+        None,                                    // 0xf22
+        None,                                    // 0xf23
+        None,                                    // 0xf30
+        None,                                    // 0xf31
+        None,                                    // 0xf32
+        None,                                    // 0xf33
+        None,                                    // 0xf40
+        None,                                    // 0xf41
+        None,                                    // 0xf42
+        None,                                    // 0xf43
+        None,                                    // 0xf50
+        None,                                    // 0xf51
+        None,                                    // 0xf52
+        None,                                    // 0xf53
+        None,                                    // 0xf60
+        None,                                    // 0xf61
+        None,                                    // 0xf62
+        None,                                    // 0xf63
+        None,                                    // 0xf70
+        None,                                    // 0xf71
+        None,                                    // 0xf72
+        None,                                    // 0xf73
+        None,                                    // 0xf80
+        None,                                    // 0xf81
+        None,                                    // 0xf82
+        None,                                    // 0xf83
+        None,                                    // 0xf90
+        None,                                    // 0xf91
+        None,                                    // 0xf92
+        None,                                    // 0xf93
+        None,                                    // 0xfa0
+        None,                                    // 0xfa1
+        None,                                    // 0xfa2
+        None,                                    // 0xfa3
+        None,                                    // 0xfb0
+        None,                                    // 0xfb1
+        None,                                    // 0xfb2
+        None,                                    // 0xfb3
+        None,                                    // 0xfc0
+        None,                                    // 0xfc1
+        None,                                    // 0xfc2
+        None,                                    // 0xfc3
+        None,                                    // 0xfd0
+        None,                                    // 0xfd1
+        None,                                    // 0xfd2
+        None,                                    // 0xfd3
+        None,                                    // 0xfe0
+        None,                                    // 0xfe1
+        None,                                    // 0xfe2
+        None,                                    // 0xfe3
+        None,                                    // 0xff0
+        None,                                    // 0xff1
+        None,                                    // 0xff2
+        None,                                    // 0xff3
+    };
+
+    static const InstrForm instrFormVex1[1024]
+    {
+        None,                                    // 0x000
+        None,                                    // 0x001
+        None,                                    // 0x002
+        None,                                    // 0x003
+        None,                                    // 0x010
+        None,                                    // 0x011
+        None,                                    // 0x012
+        None,                                    // 0x013
+        None,                                    // 0x020
+        None,                                    // 0x021
+        None,                                    // 0x022
+        None,                                    // 0x023
+        None,                                    // 0x030
+        None,                                    // 0x031
+        None,                                    // 0x032
+        None,                                    // 0x033
+        None,                                    // 0x040
+        None,                                    // 0x041
+        None,                                    // 0x042
+        None,                                    // 0x043
+        None,                                    // 0x050
+        None,                                    // 0x051
+        None,                                    // 0x052
+        None,                                    // 0x053
+        None,                                    // 0x060
+        None,                                    // 0x061
+        None,                                    // 0x062
+        None,                                    // 0x063
+        None,                                    // 0x070
+        None,                                    // 0x071
+        None,                                    // 0x072
+        None,                                    // 0x073
+        None,                                    // 0x080
+        None,                                    // 0x081
+        None,                                    // 0x082
+        None,                                    // 0x083
+        None,                                    // 0x090
+        None,                                    // 0x091
+        None,                                    // 0x092
+        None,                                    // 0x093
+        None,                                    // 0x0a0
+        None,                                    // 0x0a1
+        None,                                    // 0x0a2
+        None,                                    // 0x0a3
+        None,                                    // 0x0b0
+        None,                                    // 0x0b1
+        None,                                    // 0x0b2
+        None,                                    // 0x0b3
+        None,                                    // 0x0c0
+        None,                                    // 0x0c1
+        None,                                    // 0x0c2
+        None,                                    // 0x0c3
+        None,                                    // 0x0d0
+        None,                                    // 0x0d1
+        None,                                    // 0x0d2
+        None,                                    // 0x0d3
+        None,                                    // 0x0e0
+        None,                                    // 0x0e1
+        None,                                    // 0x0e2
+        None,                                    // 0x0e3
+        None,                                    // 0x0f0
+        None,                                    // 0x0f1
+        None,                                    // 0x0f2
+        None,                                    // 0x0f3
+        MOp_L_M32B_or_M16B,                      // 0x100 vmovups
+        MOp_L_M32B_or_M16B,                      // 0x101 vmovupd
+        MOp_M4B,                                 // 0x102 vmovss
+        MOp_M8B,                                 // 0x103 vmovsd
+        M1st_L_M32B_or_M16B,                     // 0x110 vmovups
+        M1st_L_M32B_or_M16B,                     // 0x111 vmovupd
+        M1st_M4B,                                // 0x112 vmovss
+        M1st_M8B,                                // 0x113 vmovsd
+        MOp_M8B,                                 // 0x120 vmovlps
+        MOp_M8B,                                 // 0x121 vmovlpd
+        MOp_L_M32B_or_M16B,                      // 0x122 vmovsldup
+        MOp_L_M32B_or_M8B,                       // 0x123 vmovddup
+        M1st_M8B,                                // 0x130 vmovlps
+        M1st_M8B,                                // 0x131 vmovlpd
+        M1st_M8B,                                // 0x132 vmovlps
+        M1st_M8B,                                // 0x133 vmovlps
+        MOp_L_M32B_or_M16B,                      // 0x140 vunpcklps
+        MOp_L_M32B_or_M16B,                      // 0x141 vunpcklpd
+        MOp_L_M32B_or_M16B,                      // 0x142 vunpcklps
+        MOp_L_M32B_or_M16B,                      // 0x143 vunpcklps
+        MOp_L_M32B_or_M16B,                      // 0x150 vunpckhps
+        MOp_L_M32B_or_M16B,                      // 0x151 vunpckhpd
+        MOp_L_M32B_or_M16B,                      // 0x152 vunpckhps
+        MOp_L_M32B_or_M16B,                      // 0x153 vunpckhps
+        MOp_M8B,                                 // 0x160 vmovhps
+        MOp_M8B,                                 // 0x161 vmovhpd
+        MOp_L_M32B_or_M16B,                      // 0x162 vmovshdup
+        None,                                    // 0x163
+        M1st_M8B,                                // 0x170 vmovhps
+        M1st_M8B,                                // 0x171 vmovhpd
+        M1st_M8B,                                // 0x172 vmovhps
+        M1st_M8B,                                // 0x173 vmovhps
+        None,                                    // 0x180
+        None,                                    // 0x181
+        None,                                    // 0x182
+        None,                                    // 0x183
+        None,                                    // 0x190
+        None,                                    // 0x191
+        None,                                    // 0x192
+        None,                                    // 0x193
+        None,                                    // 0x1a0
+        None,                                    // 0x1a1
+        None,                                    // 0x1a2
+        None,                                    // 0x1a3
+        None,                                    // 0x1b0
+        None,                                    // 0x1b1
+        None,                                    // 0x1b2
+        None,                                    // 0x1b3
+        None,                                    // 0x1c0
+        None,                                    // 0x1c1
+        None,                                    // 0x1c2
+        None,                                    // 0x1c3
+        None,                                    // 0x1d0
+        None,                                    // 0x1d1
+        None,                                    // 0x1d2
+        None,                                    // 0x1d3
+        None,                                    // 0x1e0
+        None,                                    // 0x1e1
+        None,                                    // 0x1e2
+        None,                                    // 0x1e3
+        None,                                    // 0x1f0
+        None,                                    // 0x1f1
+        None,                                    // 0x1f2
+        None,                                    // 0x1f3
+        None,                                    // 0x200
+        None,                                    // 0x201
+        None,                                    // 0x202
+        None,                                    // 0x203
+        None,                                    // 0x210
+        None,                                    // 0x211
+        None,                                    // 0x212
+        None,                                    // 0x213
+        None,                                    // 0x220
+        None,                                    // 0x221
+        None,                                    // 0x222
+        None,                                    // 0x223
+        None,                                    // 0x230
+        None,                                    // 0x231
+        None,                                    // 0x232
+        None,                                    // 0x233
+        None,                                    // 0x240
+        None,                                    // 0x241
+        None,                                    // 0x242
+        None,                                    // 0x243
+        None,                                    // 0x250
+        None,                                    // 0x251
+        None,                                    // 0x252
+        None,                                    // 0x253
+        None,                                    // 0x260
+        None,                                    // 0x261
+        None,                                    // 0x262
+        None,                                    // 0x263
+        None,                                    // 0x270
+        None,                                    // 0x271
+        None,                                    // 0x272
+        None,                                    // 0x273
+        MOp_L_M32B_or_M16B,                      // 0x280 vmovaps
+        MOp_L_M32B_or_M16B,                      // 0x281 vmovapd
+        MOp_L_M32B_or_M16B,                      // 0x282 vmovaps
+        MOp_L_M32B_or_M16B,                      // 0x283 vmovaps
+        M1st_L_M32B_or_M16B,                     // 0x290 vmovaps
+        M1st_L_M32B_or_M16B,                     // 0x291 vmovapd
+        M1st_L_M32B_or_M16B,                     // 0x292 vmovaps
+        M1st_L_M32B_or_M16B,                     // 0x293 vmovaps
+        None,                                    // 0x2a0
+        None,                                    // 0x2a1
+        MOp_W_M8B_or_M4B,                        // 0x2a2 vcvtsi2ss
+        MOp_W_M8B_or_M4B,                        // 0x2a3 vcvtsi2sd
+        M1st_L_M32B_or_M16B,                     // 0x2b0 vmovntps
+        M1st_L_M32B_or_M16B,                     // 0x2b1 vmovntpd
+        M1st_L_M32B_or_M16B,                     // 0x2b2 vmovntps
+        M1st_L_M32B_or_M16B,                     // 0x2b3 vmovntps
+        None,                                    // 0x2c0
+        None,                                    // 0x2c1
+        MOp_M4B,                                 // 0x2c2 vcvttss2si
+        MOp_M8B,                                 // 0x2c3 vcvttsd2si
+        None,                                    // 0x2d0
+        None,                                    // 0x2d1
+        MOp_M4B,                                 // 0x2d2 vcvtss2si
+        MOp_M8B,                                 // 0x2d3 vcvtsd2si
+        MOp_M4B,                                 // 0x2e0 vucomiss
+        MOp_M8B,                                 // 0x2e1 vucomisd
+        None,                                    // 0x2e2
+        None,                                    // 0x2e3
+        MOp_M4B,                                 // 0x2f0 vcomiss
+        MOp_M8B,                                 // 0x2f1 vcomisd
+        None,                                    // 0x2f2
+        None,                                    // 0x2f3
+        None,                                    // 0x300
+        None,                                    // 0x301
+        None,                                    // 0x302
+        None,                                    // 0x303
+        None,                                    // 0x310
+        None,                                    // 0x311
+        None,                                    // 0x312
+        None,                                    // 0x313
+        None,                                    // 0x320
+        None,                                    // 0x321
+        None,                                    // 0x322
+        None,                                    // 0x323
+        None,                                    // 0x330
+        None,                                    // 0x331
+        None,                                    // 0x332
+        None,                                    // 0x333
+        None,                                    // 0x340
+        None,                                    // 0x341
+        None,                                    // 0x342
+        None,                                    // 0x343
+        None,                                    // 0x350
+        None,                                    // 0x351
+        None,                                    // 0x352
+        None,                                    // 0x353
+        None,                                    // 0x360
+        None,                                    // 0x361
+        None,                                    // 0x362
+        None,                                    // 0x363
+        None,                                    // 0x370
+        None,                                    // 0x371
+        None,                                    // 0x372
+        None,                                    // 0x373
+        None,                                    // 0x380
+        None,                                    // 0x381
+        None,                                    // 0x382
+        None,                                    // 0x383
+        None,                                    // 0x390
+        None,                                    // 0x391
+        None,                                    // 0x392
+        None,                                    // 0x393
+        None,                                    // 0x3a0
+        None,                                    // 0x3a1
+        None,                                    // 0x3a2
+        None,                                    // 0x3a3
+        None,                                    // 0x3b0
+        None,                                    // 0x3b1
+        None,                                    // 0x3b2
+        None,                                    // 0x3b3
+        None,                                    // 0x3c0
+        None,                                    // 0x3c1
+        None,                                    // 0x3c2
+        None,                                    // 0x3c3
+        None,                                    // 0x3d0
+        None,                                    // 0x3d1
+        None,                                    // 0x3d2
+        None,                                    // 0x3d3
+        None,                                    // 0x3e0
+        None,                                    // 0x3e1
+        None,                                    // 0x3e2
+        None,                                    // 0x3e3
+        None,                                    // 0x3f0
+        None,                                    // 0x3f1
+        None,                                    // 0x3f2
+        None,                                    // 0x3f3
+        None,                                    // 0x400
+        None,                                    // 0x401
+        None,                                    // 0x402
+        None,                                    // 0x403
+        None,                                    // 0x410
+        None,                                    // 0x411
+        None,                                    // 0x412
+        None,                                    // 0x413
+        None,                                    // 0x420
+        None,                                    // 0x421
+        None,                                    // 0x422
+        None,                                    // 0x423
+        None,                                    // 0x430
+        None,                                    // 0x431
+        None,                                    // 0x432
+        None,                                    // 0x433
+        None,                                    // 0x440
+        None,                                    // 0x441
+        None,                                    // 0x442
+        None,                                    // 0x443
+        None,                                    // 0x450
+        None,                                    // 0x451
+        None,                                    // 0x452
+        None,                                    // 0x453
+        None,                                    // 0x460
+        None,                                    // 0x461
+        None,                                    // 0x462
+        None,                                    // 0x463
+        None,                                    // 0x470
+        None,                                    // 0x471
+        None,                                    // 0x472
+        None,                                    // 0x473
+        None,                                    // 0x480
+        None,                                    // 0x481
+        None,                                    // 0x482
+        None,                                    // 0x483
+        None,                                    // 0x490
+        None,                                    // 0x491
+        None,                                    // 0x492
+        None,                                    // 0x493
+        None,                                    // 0x4a0
+        None,                                    // 0x4a1
+        None,                                    // 0x4a2
+        None,                                    // 0x4a3
+        None,                                    // 0x4b0
+        None,                                    // 0x4b1
+        None,                                    // 0x4b2
+        None,                                    // 0x4b3
+        None,                                    // 0x4c0
+        None,                                    // 0x4c1
+        None,                                    // 0x4c2
+        None,                                    // 0x4c3
+        None,                                    // 0x4d0
+        None,                                    // 0x4d1
+        None,                                    // 0x4d2
+        None,                                    // 0x4d3
+        None,                                    // 0x4e0
+        None,                                    // 0x4e1
+        None,                                    // 0x4e2
+        None,                                    // 0x4e3
+        None,                                    // 0x4f0
+        None,                                    // 0x4f1
+        None,                                    // 0x4f2
+        None,                                    // 0x4f3
+        None,                                    // 0x500
+        None,                                    // 0x501
+        None,                                    // 0x502
+        None,                                    // 0x503
+        MOp_L_M32B_or_M16B,                      // 0x510 vsqrtps
+        MOp_L_M32B_or_M16B,                      // 0x511 vsqrtpd
+        MOp_M4B,                                 // 0x512 vsqrtss
+        MOp_M8B,                                 // 0x513 vsqrtsd
+        MOp_L_M32B_or_M16B,                      // 0x520 vrsqrtps
+        None,                                    // 0x521
+        MOp_M4B,                                 // 0x522 vrsqrtss
+        None,                                    // 0x523
+        MOp_L_M32B_or_M16B,                      // 0x530 vrcpps
+        None,                                    // 0x531
+        MOp_M4B,                                 // 0x532 vrcpss
+        None,                                    // 0x533
+        MOp_L_M32B_or_M16B,                      // 0x540 vandps
+        MOp_L_M32B_or_M16B,                      // 0x541 vandpd
+        MOp_L_M32B_or_M16B,                      // 0x542 vandps
+        MOp_L_M32B_or_M16B,                      // 0x543 vandps
+        MOp_L_M32B_or_M16B,                      // 0x550 vandnps
+        MOp_L_M32B_or_M16B,                      // 0x551 vandnpd
+        MOp_L_M32B_or_M16B,                      // 0x552 vandnps
+        MOp_L_M32B_or_M16B,                      // 0x553 vandnps
+        MOp_L_M32B_or_M16B,                      // 0x560 vorps
+        MOp_L_M32B_or_M16B,                      // 0x561 vorpd
+        MOp_L_M32B_or_M16B,                      // 0x562 vorps
+        MOp_L_M32B_or_M16B,                      // 0x563 vorps
+        MOp_L_M32B_or_M16B,                      // 0x570 vxorps
+        MOp_L_M32B_or_M16B,                      // 0x571 vxorpd
+        MOp_L_M32B_or_M16B,                      // 0x572 vxorps
+        MOp_L_M32B_or_M16B,                      // 0x573 vxorps
+        MOp_L_M32B_or_M16B,                      // 0x580 vaddps
+        MOp_L_M32B_or_M16B,                      // 0x581 vaddpd
+        MOp_M4B,                                 // 0x582 vaddss
+        MOp_M8B,                                 // 0x583 vaddsd
+        MOp_L_M32B_or_M16B,                      // 0x590 vmulps
+        MOp_L_M32B_or_M16B,                      // 0x591 vmulpd
+        MOp_M4B,                                 // 0x592 vmulss
+        MOp_M8B,                                 // 0x593 vmulsd
+        MOp_L_M16B_or_M8B,                       // 0x5a0 vcvtps2pd
+        MOp_L_M32B_or_M16B,                      // 0x5a1 vcvtpd2ps
+        MOp_M4B,                                 // 0x5a2 vcvtss2sd
+        MOp_M8B,                                 // 0x5a3 vcvtsd2ss
+        MOp_L_M32B_or_M16B,                      // 0x5b0 vcvtdq2ps
+        MOp_L_M32B_or_M16B,                      // 0x5b1 vcvtps2dq
+        MOp_L_M32B_or_M16B,                      // 0x5b2 vcvttps2dq
+        None,                                    // 0x5b3
+        MOp_L_M32B_or_M16B,                      // 0x5c0 vsubps
+        MOp_L_M32B_or_M16B,                      // 0x5c1 vsubpd
+        MOp_M4B,                                 // 0x5c2 vsubss
+        MOp_M8B,                                 // 0x5c3 vsubsd
+        MOp_L_M32B_or_M16B,                      // 0x5d0 vminps
+        MOp_L_M32B_or_M16B,                      // 0x5d1 vminpd
+        MOp_M4B,                                 // 0x5d2 vminss
+        MOp_M8B,                                 // 0x5d3 vminsd
+        MOp_L_M32B_or_M16B,                      // 0x5e0 vdivps
+        MOp_L_M32B_or_M16B,                      // 0x5e1 vdivpd
+        MOp_M4B,                                 // 0x5e2 vdivss
+        MOp_M8B,                                 // 0x5e3 vdivsd
+        MOp_L_M32B_or_M16B,                      // 0x5f0 vmaxps
+        MOp_L_M32B_or_M16B,                      // 0x5f1 vmaxpd
+        MOp_M4B,                                 // 0x5f2 vmaxss
+        MOp_M8B,                                 // 0x5f3 vmaxsd
+        None,                                    // 0x600
+        MOp_L_M32B_or_M16B,                      // 0x601 vpunpcklbw
+        None,                                    // 0x602
+        None,                                    // 0x603
+        None,                                    // 0x610
+        MOp_L_M32B_or_M16B,                      // 0x611 vpunpcklwd
+        None,                                    // 0x612
+        None,                                    // 0x613
+        None,                                    // 0x620
+        MOp_L_M32B_or_M16B,                      // 0x621 vpunpckldq
+        None,                                    // 0x622
+        None,                                    // 0x623
+        None,                                    // 0x630
+        MOp_L_M32B_or_M16B,                      // 0x631 vpacksswb
+        None,                                    // 0x632
+        None,                                    // 0x633
+        None,                                    // 0x640
+        MOp_L_M32B_or_M16B,                      // 0x641 vpcmpgtb
+        None,                                    // 0x642
+        None,                                    // 0x643
+        None,                                    // 0x650
+        MOp_L_M32B_or_M16B,                      // 0x651 vpcmpgtw
+        None,                                    // 0x652
+        None,                                    // 0x653
+        None,                                    // 0x660
+        MOp_L_M32B_or_M16B,                      // 0x661 vpcmpgtd
+        None,                                    // 0x662
+        None,                                    // 0x663
+        None,                                    // 0x670
+        MOp_L_M32B_or_M16B,                      // 0x671 vpackuswb
+        None,                                    // 0x672
+        None,                                    // 0x673
+        None,                                    // 0x680
+        MOp_L_M32B_or_M16B,                      // 0x681 vpunpckhbw
+        None,                                    // 0x682
+        None,                                    // 0x683
+        None,                                    // 0x690
+        MOp_L_M32B_or_M16B,                      // 0x691 vpunpckhwd
+        None,                                    // 0x692
+        None,                                    // 0x693
+        None,                                    // 0x6a0
+        MOp_L_M32B_or_M16B,                      // 0x6a1 vpunpckhdq
+        None,                                    // 0x6a2
+        None,                                    // 0x6a3
+        None,                                    // 0x6b0
+        MOp_L_M32B_or_M16B,                      // 0x6b1 vpackssdw
+        None,                                    // 0x6b2
+        None,                                    // 0x6b3
+        None,                                    // 0x6c0
+        MOp_L_M32B_or_M16B,                      // 0x6c1 vpunpcklqdq
+        None,                                    // 0x6c2
+        None,                                    // 0x6c3
+        None,                                    // 0x6d0
+        MOp_L_M32B_or_M16B,                      // 0x6d1 vpunpckhqdq
+        None,                                    // 0x6d2
+        None,                                    // 0x6d3
+        None,                                    // 0x6e0
+        MOp_W_M8B_or_M4B,                        // 0x6e1 vmovd,vmovq
+        None,                                    // 0x6e2
+        None,                                    // 0x6e3
+        None,                                    // 0x6f0
+        MOp_L_M32B_or_M16B,                      // 0x6f1 vmovdqa
+        MOp_L_M32B_or_M16B,                      // 0x6f2 vmovdqu
+        None,                                    // 0x6f3
+        None,                                    // 0x700
+        MOp_I1B_L_M32B_or_M16B,                  // 0x701 vpshufd
+        MOp_I1B_L_M32B_or_M16B,                  // 0x702 vpshufhw
+        MOp_I1B_L_M32B_or_M16B,                  // 0x703 vpshuflw
+        None,                                    // 0x710
+        None,                                    // 0x711
+        None,                                    // 0x712
+        None,                                    // 0x713
+        None,                                    // 0x720
+        None,                                    // 0x721
+        None,                                    // 0x722
+        None,                                    // 0x723
+        None,                                    // 0x730
+        None,                                    // 0x731
+        None,                                    // 0x732
+        None,                                    // 0x733
+        None,                                    // 0x740
+        MOp_L_M32B_or_M16B,                      // 0x741 vpcmpeqb
+        None,                                    // 0x742
+        None,                                    // 0x743
+        None,                                    // 0x750
+        MOp_L_M32B_or_M16B,                      // 0x751 vpcmpeqw
+        None,                                    // 0x752
+        None,                                    // 0x753
+        None,                                    // 0x760
+        MOp_L_M32B_or_M16B,                      // 0x761 vpcmpeqd
+        None,                                    // 0x762
+        None,                                    // 0x763
+        None,                                    // 0x770 vzeroall,vzeroupper
+        None,                                    // 0x771
+        None,                                    // 0x772
+        None,                                    // 0x773
+        None,                                    // 0x780
+        None,                                    // 0x781
+        None,                                    // 0x782
+        None,                                    // 0x783
+        None,                                    // 0x790
+        None,                                    // 0x791
+        None,                                    // 0x792
+        None,                                    // 0x793
+        None,                                    // 0x7a0
+        None,                                    // 0x7a1
+        None,                                    // 0x7a2
+        None,                                    // 0x7a3
+        None,                                    // 0x7b0
+        None,                                    // 0x7b1
+        None,                                    // 0x7b2
+        None,                                    // 0x7b3
+        None,                                    // 0x7c0
+        MOp_L_M32B_or_M16B,                      // 0x7c1 vhaddpd
+        None,                                    // 0x7c2
+        MOp_L_M32B_or_M16B,                      // 0x7c3 vhaddps
+        None,                                    // 0x7d0
+        MOp_L_M32B_or_M16B,                      // 0x7d1 vhsubpd
+        None,                                    // 0x7d2
+        MOp_L_M32B_or_M16B,                      // 0x7d3 vhsubps
+        None,                                    // 0x7e0
+        M1st_W_M8B_or_M4B,                       // 0x7e1 vmovd,vmovq
+        MOp_M8B,                                 // 0x7e2 vmovq
+        None,                                    // 0x7e3
+        None,                                    // 0x7f0
+        M1st_L_M32B_or_M16B,                     // 0x7f1 vmovdqa
+        M1st_L_M32B_or_M16B,                     // 0x7f2 vmovdqu
+        None,                                    // 0x7f3
+        None,                                    // 0x800
+        None,                                    // 0x801
+        None,                                    // 0x802
+        None,                                    // 0x803
+        None,                                    // 0x810
+        None,                                    // 0x811
+        None,                                    // 0x812
+        None,                                    // 0x813
+        None,                                    // 0x820
+        None,                                    // 0x821
+        None,                                    // 0x822
+        None,                                    // 0x823
+        None,                                    // 0x830
+        None,                                    // 0x831
+        None,                                    // 0x832
+        None,                                    // 0x833
+        None,                                    // 0x840
+        None,                                    // 0x841
+        None,                                    // 0x842
+        None,                                    // 0x843
+        None,                                    // 0x850
+        None,                                    // 0x851
+        None,                                    // 0x852
+        None,                                    // 0x853
+        None,                                    // 0x860
+        None,                                    // 0x861
+        None,                                    // 0x862
+        None,                                    // 0x863
+        None,                                    // 0x870
+        None,                                    // 0x871
+        None,                                    // 0x872
+        None,                                    // 0x873
+        None,                                    // 0x880
+        None,                                    // 0x881
+        None,                                    // 0x882
+        None,                                    // 0x883
+        None,                                    // 0x890
+        None,                                    // 0x891
+        None,                                    // 0x892
+        None,                                    // 0x893
+        None,                                    // 0x8a0
+        None,                                    // 0x8a1
+        None,                                    // 0x8a2
+        None,                                    // 0x8a3
+        None,                                    // 0x8b0
+        None,                                    // 0x8b1
+        None,                                    // 0x8b2
+        None,                                    // 0x8b3
+        None,                                    // 0x8c0
+        None,                                    // 0x8c1
+        None,                                    // 0x8c2
+        None,                                    // 0x8c3
+        None,                                    // 0x8d0
+        None,                                    // 0x8d1
+        None,                                    // 0x8d2
+        None,                                    // 0x8d3
+        None,                                    // 0x8e0
+        None,                                    // 0x8e1
+        None,                                    // 0x8e2
+        None,                                    // 0x8e3
+        None,                                    // 0x8f0
+        None,                                    // 0x8f1
+        None,                                    // 0x8f2
+        None,                                    // 0x8f3
+        MOp_W_M8B_or_M2B,                        // 0x900 kmovq,kmovw
+        MOp_W_M4B_or_M1B,                        // 0x901 kmovb,kmovd
+        None,                                    // 0x902
+        None,                                    // 0x903
+        M1st_W_M8B_or_M2B,                       // 0x910 kmovq,kmovw
+        M1st_W_M4B_or_M1B,                       // 0x911 kmovb,kmovd
+        None,                                    // 0x912
+        None,                                    // 0x913
+        None,                                    // 0x920
+        None,                                    // 0x921
+        None,                                    // 0x922
+        None,                                    // 0x923
+        None,                                    // 0x930
+        None,                                    // 0x931
+        None,                                    // 0x932
+        None,                                    // 0x933
+        None,                                    // 0x940
+        None,                                    // 0x941
+        None,                                    // 0x942
+        None,                                    // 0x943
+        None,                                    // 0x950
+        None,                                    // 0x951
+        None,                                    // 0x952
+        None,                                    // 0x953
+        None,                                    // 0x960
+        None,                                    // 0x961
+        None,                                    // 0x962
+        None,                                    // 0x963
+        None,                                    // 0x970
+        None,                                    // 0x971
+        None,                                    // 0x972
+        None,                                    // 0x973
+        None,                                    // 0x980
+        None,                                    // 0x981
+        None,                                    // 0x982
+        None,                                    // 0x983
+        None,                                    // 0x990
+        None,                                    // 0x991
+        None,                                    // 0x992
+        None,                                    // 0x993
+        None,                                    // 0x9a0
+        None,                                    // 0x9a1
+        None,                                    // 0x9a2
+        None,                                    // 0x9a3
+        None,                                    // 0x9b0
+        None,                                    // 0x9b1
+        None,                                    // 0x9b2
+        None,                                    // 0x9b3
+        None,                                    // 0x9c0
+        None,                                    // 0x9c1
+        None,                                    // 0x9c2
+        None,                                    // 0x9c3
+        None,                                    // 0x9d0
+        None,                                    // 0x9d1
+        None,                                    // 0x9d2
+        None,                                    // 0x9d3
+        None,                                    // 0x9e0
+        None,                                    // 0x9e1
+        None,                                    // 0x9e2
+        None,                                    // 0x9e3
+        None,                                    // 0x9f0
+        None,                                    // 0x9f1
+        None,                                    // 0x9f2
+        None,                                    // 0x9f3
+        None,                                    // 0xa00
+        None,                                    // 0xa01
+        None,                                    // 0xa02
+        None,                                    // 0xa03
+        None,                                    // 0xa10
+        None,                                    // 0xa11
+        None,                                    // 0xa12
+        None,                                    // 0xa13
+        None,                                    // 0xa20
+        None,                                    // 0xa21
+        None,                                    // 0xa22
+        None,                                    // 0xa23
+        None,                                    // 0xa30
+        None,                                    // 0xa31
+        None,                                    // 0xa32
+        None,                                    // 0xa33
+        None,                                    // 0xa40
+        None,                                    // 0xa41
+        None,                                    // 0xa42
+        None,                                    // 0xa43
+        None,                                    // 0xa50
+        None,                                    // 0xa51
+        None,                                    // 0xa52
+        None,                                    // 0xa53
+        None,                                    // 0xa60
+        None,                                    // 0xa61
+        None,                                    // 0xa62
+        None,                                    // 0xa63
+        None,                                    // 0xa70
+        None,                                    // 0xa71
+        None,                                    // 0xa72
+        None,                                    // 0xa73
+        None,                                    // 0xa80
+        None,                                    // 0xa81
+        None,                                    // 0xa82
+        None,                                    // 0xa83
+        None,                                    // 0xa90
+        None,                                    // 0xa91
+        None,                                    // 0xa92
+        None,                                    // 0xa93
+        None,                                    // 0xaa0
+        None,                                    // 0xaa1
+        None,                                    // 0xaa2
+        None,                                    // 0xaa3
+        None,                                    // 0xab0
+        None,                                    // 0xab1
+        None,                                    // 0xab2
+        None,                                    // 0xab3
+        None,                                    // 0xac0
+        None,                                    // 0xac1
+        None,                                    // 0xac2
+        None,                                    // 0xac3
+        None,                                    // 0xad0
+        None,                                    // 0xad1
+        None,                                    // 0xad2
+        None,                                    // 0xad3
+        MOnly_M4B,                               // 0xae0 vldmxcsr,vstmxcsr
+        MOnly_M4B,                               // 0xae1 vldmxcsr,vstmxcsr
+        MOnly_M4B,                               // 0xae2 vldmxcsr,vstmxcsr
+        MOnly_M4B,                               // 0xae3 vldmxcsr,vstmxcsr
+        None,                                    // 0xaf0
+        None,                                    // 0xaf1
+        None,                                    // 0xaf2
+        None,                                    // 0xaf3
+        None,                                    // 0xb00
+        None,                                    // 0xb01
+        None,                                    // 0xb02
+        None,                                    // 0xb03
+        None,                                    // 0xb10
+        None,                                    // 0xb11
+        None,                                    // 0xb12
+        None,                                    // 0xb13
+        None,                                    // 0xb20
+        None,                                    // 0xb21
+        None,                                    // 0xb22
+        None,                                    // 0xb23
+        None,                                    // 0xb30
+        None,                                    // 0xb31
+        None,                                    // 0xb32
+        None,                                    // 0xb33
+        None,                                    // 0xb40
+        None,                                    // 0xb41
+        None,                                    // 0xb42
+        None,                                    // 0xb43
+        None,                                    // 0xb50
+        None,                                    // 0xb51
+        None,                                    // 0xb52
+        None,                                    // 0xb53
+        None,                                    // 0xb60
+        None,                                    // 0xb61
+        None,                                    // 0xb62
+        None,                                    // 0xb63
+        None,                                    // 0xb70
+        None,                                    // 0xb71
+        None,                                    // 0xb72
+        None,                                    // 0xb73
+        None,                                    // 0xb80
+        None,                                    // 0xb81
+        None,                                    // 0xb82
+        None,                                    // 0xb83
+        None,                                    // 0xb90
+        None,                                    // 0xb91
+        None,                                    // 0xb92
+        None,                                    // 0xb93
+        None,                                    // 0xba0
+        None,                                    // 0xba1
+        None,                                    // 0xba2
+        None,                                    // 0xba3
+        None,                                    // 0xbb0
+        None,                                    // 0xbb1
+        None,                                    // 0xbb2
+        None,                                    // 0xbb3
+        None,                                    // 0xbc0
+        None,                                    // 0xbc1
+        None,                                    // 0xbc2
+        None,                                    // 0xbc3
+        None,                                    // 0xbd0
+        None,                                    // 0xbd1
+        None,                                    // 0xbd2
+        None,                                    // 0xbd3
+        None,                                    // 0xbe0
+        None,                                    // 0xbe1
+        None,                                    // 0xbe2
+        None,                                    // 0xbe3
+        None,                                    // 0xbf0
+        None,                                    // 0xbf1
+        None,                                    // 0xbf2
+        None,                                    // 0xbf3
+        None,                                    // 0xc00
+        None,                                    // 0xc01
+        None,                                    // 0xc02
+        None,                                    // 0xc03
+        None,                                    // 0xc10
+        None,                                    // 0xc11
+        None,                                    // 0xc12
+        None,                                    // 0xc13
+        MOp_I1B_L_M32B_or_M16B,                  // 0xc20 vcmpps
+        MOp_I1B_L_M32B_or_M16B,                  // 0xc21 vcmppd
+        MOp_M4B_I1B,                             // 0xc22 vcmpss
+        MOp_M8B_I1B,                             // 0xc23 vcmpsd
+        None,                                    // 0xc30
+        None,                                    // 0xc31
+        None,                                    // 0xc32
+        None,                                    // 0xc33
+        None,                                    // 0xc40
+        MOp_M2B_I1B,                             // 0xc41 vpinsrw
+        None,                                    // 0xc42
+        None,                                    // 0xc43
+        None,                                    // 0xc50
+        None,                                    // 0xc51
+        None,                                    // 0xc52
+        None,                                    // 0xc53
+        MOp_I1B_L_M32B_or_M16B,                  // 0xc60 vshufps
+        MOp_I1B_L_M32B_or_M16B,                  // 0xc61 vshufpd
+        MOp_I1B_L_M32B_or_M16B,                  // 0xc62 vshufps
+        MOp_I1B_L_M32B_or_M16B,                  // 0xc63 vshufps
+        None,                                    // 0xc70
+        None,                                    // 0xc71
+        None,                                    // 0xc72
+        None,                                    // 0xc73
+        None,                                    // 0xc80
+        None,                                    // 0xc81
+        None,                                    // 0xc82
+        None,                                    // 0xc83
+        None,                                    // 0xc90
+        None,                                    // 0xc91
+        None,                                    // 0xc92
+        None,                                    // 0xc93
+        None,                                    // 0xca0
+        None,                                    // 0xca1
+        None,                                    // 0xca2
+        None,                                    // 0xca3
+        None,                                    // 0xcb0
+        None,                                    // 0xcb1
+        None,                                    // 0xcb2
+        None,                                    // 0xcb3
+        None,                                    // 0xcc0
+        None,                                    // 0xcc1
+        None,                                    // 0xcc2
+        None,                                    // 0xcc3
+        None,                                    // 0xcd0
+        None,                                    // 0xcd1
+        None,                                    // 0xcd2
+        None,                                    // 0xcd3
+        None,                                    // 0xce0
+        None,                                    // 0xce1
+        None,                                    // 0xce2
+        None,                                    // 0xce3
+        None,                                    // 0xcf0
+        None,                                    // 0xcf1
+        None,                                    // 0xcf2
+        None,                                    // 0xcf3
+        None,                                    // 0xd00
+        MOp_L_M32B_or_M16B,                      // 0xd01 vaddsubpd
+        None,                                    // 0xd02
+        MOp_L_M32B_or_M16B,                      // 0xd03 vaddsubps
+        None,                                    // 0xd10
+        MOp_M16B,                                // 0xd11 vpsrlw
+        None,                                    // 0xd12
+        None,                                    // 0xd13
+        None,                                    // 0xd20
+        MOp_M16B,                                // 0xd21 vpsrld
+        None,                                    // 0xd22
+        None,                                    // 0xd23
+        None,                                    // 0xd30
+        MOp_M16B,                                // 0xd31 vpsrlq
+        None,                                    // 0xd32
+        None,                                    // 0xd33
+        None,                                    // 0xd40
+        MOp_L_M32B_or_M16B,                      // 0xd41 vpaddq
+        None,                                    // 0xd42
+        None,                                    // 0xd43
+        None,                                    // 0xd50
+        MOp_L_M32B_or_M16B,                      // 0xd51 vpmullw
+        None,                                    // 0xd52
+        None,                                    // 0xd53
+        None,                                    // 0xd60
+        M1st_M8B,                                // 0xd61 vmovq
+        None,                                    // 0xd62
+        None,                                    // 0xd63
+        None,                                    // 0xd70
+        None,                                    // 0xd71
+        None,                                    // 0xd72
+        None,                                    // 0xd73
+        None,                                    // 0xd80
+        MOp_L_M32B_or_M16B,                      // 0xd81 vpsubusb
+        None,                                    // 0xd82
+        None,                                    // 0xd83
+        None,                                    // 0xd90
+        MOp_L_M32B_or_M16B,                      // 0xd91 vpsubusw
+        None,                                    // 0xd92
+        None,                                    // 0xd93
+        None,                                    // 0xda0
+        MOp_L_M32B_or_M16B,                      // 0xda1 vpminub
+        None,                                    // 0xda2
+        None,                                    // 0xda3
+        None,                                    // 0xdb0
+        MOp_L_M32B_or_M16B,                      // 0xdb1 vpand
+        None,                                    // 0xdb2
+        None,                                    // 0xdb3
+        None,                                    // 0xdc0
+        MOp_L_M32B_or_M16B,                      // 0xdc1 vpaddusb
+        None,                                    // 0xdc2
+        None,                                    // 0xdc3
+        None,                                    // 0xdd0
+        MOp_L_M32B_or_M16B,                      // 0xdd1 vpaddusw
+        None,                                    // 0xdd2
+        None,                                    // 0xdd3
+        None,                                    // 0xde0
+        MOp_L_M32B_or_M16B,                      // 0xde1 vpmaxub
+        None,                                    // 0xde2
+        None,                                    // 0xde3
+        None,                                    // 0xdf0
+        MOp_L_M32B_or_M16B,                      // 0xdf1 vpandn
+        None,                                    // 0xdf2
+        None,                                    // 0xdf3
+        None,                                    // 0xe00
+        MOp_L_M32B_or_M16B,                      // 0xe01 vpavgb
+        None,                                    // 0xe02
+        None,                                    // 0xe03
+        None,                                    // 0xe10
+        MOp_M16B,                                // 0xe11 vpsraw
+        None,                                    // 0xe12
+        None,                                    // 0xe13
+        None,                                    // 0xe20
+        MOp_M16B,                                // 0xe21 vpsrad
+        None,                                    // 0xe22
+        None,                                    // 0xe23
+        None,                                    // 0xe30
+        MOp_L_M32B_or_M16B,                      // 0xe31 vpavgw
+        None,                                    // 0xe32
+        None,                                    // 0xe33
+        None,                                    // 0xe40
+        MOp_L_M32B_or_M16B,                      // 0xe41 vpmulhuw
+        None,                                    // 0xe42
+        None,                                    // 0xe43
+        None,                                    // 0xe50
+        MOp_L_M32B_or_M16B,                      // 0xe51 vpmulhw
+        None,                                    // 0xe52
+        None,                                    // 0xe53
+        None,                                    // 0xe60
+        MOp_L_M32B_or_M16B,                      // 0xe61 vcvttpd2dq
+        MOp_L_M16B_or_M8B,                       // 0xe62 vcvtdq2pd
+        MOp_L_M32B_or_M16B,                      // 0xe63 vcvtpd2dq
+        None,                                    // 0xe70
+        M1st_L_M32B_or_M16B,                     // 0xe71 vmovntdq
+        None,                                    // 0xe72
+        None,                                    // 0xe73
+        None,                                    // 0xe80
+        MOp_L_M32B_or_M16B,                      // 0xe81 vpsubsb
+        None,                                    // 0xe82
+        None,                                    // 0xe83
+        None,                                    // 0xe90
+        MOp_L_M32B_or_M16B,                      // 0xe91 vpsubsw
+        None,                                    // 0xe92
+        None,                                    // 0xe93
+        None,                                    // 0xea0
+        MOp_L_M32B_or_M16B,                      // 0xea1 vpminsw
+        None,                                    // 0xea2
+        None,                                    // 0xea3
+        None,                                    // 0xeb0
+        MOp_L_M32B_or_M16B,                      // 0xeb1 vpor
+        None,                                    // 0xeb2
+        None,                                    // 0xeb3
+        None,                                    // 0xec0
+        MOp_L_M32B_or_M16B,                      // 0xec1 vpaddsb
+        None,                                    // 0xec2
+        None,                                    // 0xec3
+        None,                                    // 0xed0
+        MOp_L_M32B_or_M16B,                      // 0xed1 vpaddsw
+        None,                                    // 0xed2
+        None,                                    // 0xed3
+        None,                                    // 0xee0
+        MOp_L_M32B_or_M16B,                      // 0xee1 vpmaxsw
+        None,                                    // 0xee2
+        None,                                    // 0xee3
+        None,                                    // 0xef0
+        MOp_L_M32B_or_M16B,                      // 0xef1 vpxor
+        None,                                    // 0xef2
+        None,                                    // 0xef3
+        None,                                    // 0xf00
+        None,                                    // 0xf01
+        None,                                    // 0xf02
+        MOp_L_M32B_or_M16B,                      // 0xf03 vlddqu
+        None,                                    // 0xf10
+        MOp_M16B,                                // 0xf11 vpsllw
+        None,                                    // 0xf12
+        None,                                    // 0xf13
+        None,                                    // 0xf20
+        MOp_M16B,                                // 0xf21 vpslld
+        None,                                    // 0xf22
+        None,                                    // 0xf23
+        None,                                    // 0xf30
+        MOp_M16B,                                // 0xf31 vpsllq
+        None,                                    // 0xf32
+        None,                                    // 0xf33
+        None,                                    // 0xf40
+        MOp_L_M32B_or_M16B,                      // 0xf41 vpmuludq
+        None,                                    // 0xf42
+        None,                                    // 0xf43
+        None,                                    // 0xf50
+        MOp_L_M32B_or_M16B,                      // 0xf51 vpmaddwd
+        None,                                    // 0xf52
+        None,                                    // 0xf53
+        None,                                    // 0xf60
+        MOp_L_M32B_or_M16B,                      // 0xf61 vpsadbw
+        None,                                    // 0xf62
+        None,                                    // 0xf63
+        None,                                    // 0xf70
+        None,                                    // 0xf71
+        None,                                    // 0xf72
+        None,                                    // 0xf73
+        None,                                    // 0xf80
+        MOp_L_M32B_or_M16B,                      // 0xf81 vpsubb
+        None,                                    // 0xf82
+        None,                                    // 0xf83
+        None,                                    // 0xf90
+        MOp_L_M32B_or_M16B,                      // 0xf91 vpsubw
+        None,                                    // 0xf92
+        None,                                    // 0xf93
+        None,                                    // 0xfa0
+        MOp_L_M32B_or_M16B,                      // 0xfa1 vpsubd
+        None,                                    // 0xfa2
+        None,                                    // 0xfa3
+        None,                                    // 0xfb0
+        MOp_L_M32B_or_M16B,                      // 0xfb1 vpsubq
+        None,                                    // 0xfb2
+        None,                                    // 0xfb3
+        None,                                    // 0xfc0
+        MOp_L_M32B_or_M16B,                      // 0xfc1 vpaddb
+        None,                                    // 0xfc2
+        None,                                    // 0xfc3
+        None,                                    // 0xfd0
+        MOp_L_M32B_or_M16B,                      // 0xfd1 vpaddw
+        None,                                    // 0xfd2
+        None,                                    // 0xfd3
+        None,                                    // 0xfe0
+        MOp_L_M32B_or_M16B,                      // 0xfe1 vpaddd
+        None,                                    // 0xfe2
+        None,                                    // 0xfe3
+        None,                                    // 0xff0
+        None,                                    // 0xff1
+        None,                                    // 0xff2
+        None,                                    // 0xff3
+    };
+
+    static const InstrForm instrFormVex2[1024]
+    {
+        None,                                    // 0x000
+        MOp_L_M32B_or_M16B,                      // 0x001 vpshufb
+        None,                                    // 0x002
+        None,                                    // 0x003
+        None,                                    // 0x010
+        MOp_L_M32B_or_M16B,                      // 0x011 vphaddw
+        None,                                    // 0x012
+        None,                                    // 0x013
+        None,                                    // 0x020
+        MOp_L_M32B_or_M16B,                      // 0x021 vphaddd
+        None,                                    // 0x022
+        None,                                    // 0x023
+        None,                                    // 0x030
+        MOp_L_M32B_or_M16B,                      // 0x031 vphaddsw
+        None,                                    // 0x032
+        None,                                    // 0x033
+        None,                                    // 0x040
+        MOp_L_M32B_or_M16B,                      // 0x041 vpmaddubsw
+        None,                                    // 0x042
+        None,                                    // 0x043
+        None,                                    // 0x050
+        MOp_L_M32B_or_M16B,                      // 0x051 vphsubw
+        None,                                    // 0x052
+        None,                                    // 0x053
+        None,                                    // 0x060
+        MOp_L_M32B_or_M16B,                      // 0x061 vphsubd
+        None,                                    // 0x062
+        None,                                    // 0x063
+        None,                                    // 0x070
+        MOp_L_M32B_or_M16B,                      // 0x071 vphsubsw
+        None,                                    // 0x072
+        None,                                    // 0x073
+        None,                                    // 0x080
+        MOp_L_M32B_or_M16B,                      // 0x081 vpsignb
+        None,                                    // 0x082
+        None,                                    // 0x083
+        None,                                    // 0x090
+        MOp_L_M32B_or_M16B,                      // 0x091 vpsignw
+        None,                                    // 0x092
+        None,                                    // 0x093
+        None,                                    // 0x0a0
+        MOp_L_M32B_or_M16B,                      // 0x0a1 vpsignd
+        None,                                    // 0x0a2
+        None,                                    // 0x0a3
+        None,                                    // 0x0b0
+        MOp_L_M32B_or_M16B,                      // 0x0b1 vpmulhrsw
+        None,                                    // 0x0b2
+        None,                                    // 0x0b3
+        None,                                    // 0x0c0
+        MOp_L_M32B_or_M16B,                      // 0x0c1 vpermilps
+        None,                                    // 0x0c2
+        None,                                    // 0x0c3
+        None,                                    // 0x0d0
+        MOp_L_M32B_or_M16B,                      // 0x0d1 vpermilpd
+        None,                                    // 0x0d2
+        None,                                    // 0x0d3
+        None,                                    // 0x0e0
+        MOp_L_M32B_or_M16B,                      // 0x0e1 vtestps
+        None,                                    // 0x0e2
+        None,                                    // 0x0e3
+        None,                                    // 0x0f0
+        MOp_L_M32B_or_M16B,                      // 0x0f1 vtestpd
+        None,                                    // 0x0f2
+        None,                                    // 0x0f3
+        None,                                    // 0x100
+        None,                                    // 0x101
+        None,                                    // 0x102
+        None,                                    // 0x103
+        None,                                    // 0x110
+        None,                                    // 0x111
+        None,                                    // 0x112
+        None,                                    // 0x113
+        None,                                    // 0x120
+        None,                                    // 0x121
+        None,                                    // 0x122
+        None,                                    // 0x123
+        None,                                    // 0x130
+        MOp_L_M16B_or_M8B,                       // 0x131 vcvtph2ps
+        None,                                    // 0x132
+        None,                                    // 0x133
+        None,                                    // 0x140
+        None,                                    // 0x141
+        None,                                    // 0x142
+        None,                                    // 0x143
+        None,                                    // 0x150
+        None,                                    // 0x151
+        None,                                    // 0x152
+        None,                                    // 0x153
+        None,                                    // 0x160
+        MOp_M32B,                                // 0x161 vpermps
+        None,                                    // 0x162
+        None,                                    // 0x163
+        None,                                    // 0x170
+        MOp_L_M32B_or_M16B,                      // 0x171 vptest
+        None,                                    // 0x172
+        None,                                    // 0x173
+        None,                                    // 0x180
+        MOp_M4B,                                 // 0x181 vbroadcastss
+        None,                                    // 0x182
+        None,                                    // 0x183
+        None,                                    // 0x190
+        MOp_M8B,                                 // 0x191 vbroadcastsd
+        None,                                    // 0x192
+        None,                                    // 0x193
+        None,                                    // 0x1a0
+        MOp_M16B,                                // 0x1a1 vbroadcastf128
+        None,                                    // 0x1a2
+        None,                                    // 0x1a3
+        None,                                    // 0x1b0
+        None,                                    // 0x1b1
+        None,                                    // 0x1b2
+        None,                                    // 0x1b3
+        None,                                    // 0x1c0
+        MOp_L_M32B_or_M16B,                      // 0x1c1 vpabsb
+        None,                                    // 0x1c2
+        None,                                    // 0x1c3
+        None,                                    // 0x1d0
+        MOp_L_M32B_or_M16B,                      // 0x1d1 vpabsw
+        None,                                    // 0x1d2
+        None,                                    // 0x1d3
+        None,                                    // 0x1e0
+        MOp_L_M32B_or_M16B,                      // 0x1e1 vpabsd
+        None,                                    // 0x1e2
+        None,                                    // 0x1e3
+        None,                                    // 0x1f0
+        None,                                    // 0x1f1
+        None,                                    // 0x1f2
+        None,                                    // 0x1f3
+        None,                                    // 0x200
+        MOp_L_M16B_or_M8B,                       // 0x201 vpmovsxbw
+        None,                                    // 0x202
+        None,                                    // 0x203
+        None,                                    // 0x210
+        MOp_L_M8B_or_M4B,                        // 0x211 vpmovsxbd
+        None,                                    // 0x212
+        None,                                    // 0x213
+        None,                                    // 0x220
+        MOp_L_M4B_or_M2B,                        // 0x221 vpmovsxbq
+        None,                                    // 0x222
+        None,                                    // 0x223
+        None,                                    // 0x230
+        MOp_L_M16B_or_M8B,                       // 0x231 vpmovsxwd
+        None,                                    // 0x232
+        None,                                    // 0x233
+        None,                                    // 0x240
+        MOp_L_M8B_or_M4B,                        // 0x241 vpmovsxwq
+        None,                                    // 0x242
+        None,                                    // 0x243
+        None,                                    // 0x250
+        MOp_L_M16B_or_M8B,                       // 0x251 vpmovsxdq
+        None,                                    // 0x252
+        None,                                    // 0x253
+        None,                                    // 0x260
+        None,                                    // 0x261
+        None,                                    // 0x262
+        None,                                    // 0x263
+        None,                                    // 0x270
+        None,                                    // 0x271
+        None,                                    // 0x272
+        None,                                    // 0x273
+        None,                                    // 0x280
+        MOp_L_M32B_or_M16B,                      // 0x281 vpmuldq
+        None,                                    // 0x282
+        None,                                    // 0x283
+        None,                                    // 0x290
+        MOp_L_M32B_or_M16B,                      // 0x291 vpcmpeqq
+        None,                                    // 0x292
+        None,                                    // 0x293
+        None,                                    // 0x2a0
+        MOp_L_M32B_or_M16B,                      // 0x2a1 vmovntdqa
+        None,                                    // 0x2a2
+        None,                                    // 0x2a3
+        None,                                    // 0x2b0
+        MOp_L_M32B_or_M16B,                      // 0x2b1 vpackusdw
+        None,                                    // 0x2b2
+        None,                                    // 0x2b3
+        None,                                    // 0x2c0
+        MOp_L_M32B_or_M16B,                      // 0x2c1 vmaskmovps
+        None,                                    // 0x2c2
+        None,                                    // 0x2c3
+        None,                                    // 0x2d0
+        MOp_L_M32B_or_M16B,                      // 0x2d1 vmaskmovpd
+        None,                                    // 0x2d2
+        None,                                    // 0x2d3
+        None,                                    // 0x2e0
+        M1st_L_M32B_or_M16B,                     // 0x2e1 vmaskmovps
+        None,                                    // 0x2e2
+        None,                                    // 0x2e3
+        None,                                    // 0x2f0
+        M1st_L_M32B_or_M16B,                     // 0x2f1 vmaskmovpd
+        None,                                    // 0x2f2
+        None,                                    // 0x2f3
+        None,                                    // 0x300
+        MOp_L_M16B_or_M8B,                       // 0x301 vpmovzxbw
+        None,                                    // 0x302
+        None,                                    // 0x303
+        None,                                    // 0x310
+        MOp_L_M8B_or_M4B,                        // 0x311 vpmovzxbd
+        None,                                    // 0x312
+        None,                                    // 0x313
+        None,                                    // 0x320
+        MOp_L_M4B_or_M2B,                        // 0x321 vpmovzxbq
+        None,                                    // 0x322
+        None,                                    // 0x323
+        None,                                    // 0x330
+        MOp_L_M16B_or_M8B,                       // 0x331 vpmovzxwd
+        None,                                    // 0x332
+        None,                                    // 0x333
+        None,                                    // 0x340
+        MOp_L_M8B_or_M4B,                        // 0x341 vpmovzxwq
+        None,                                    // 0x342
+        None,                                    // 0x343
+        None,                                    // 0x350
+        MOp_L_M16B_or_M8B,                       // 0x351 vpmovzxdq
+        None,                                    // 0x352
+        None,                                    // 0x353
+        None,                                    // 0x360
+        MOp_M32B,                                // 0x361 vpermd
+        None,                                    // 0x362
+        None,                                    // 0x363
+        None,                                    // 0x370
+        MOp_L_M32B_or_M16B,                      // 0x371 vpcmpgtq
+        None,                                    // 0x372
+        None,                                    // 0x373
+        None,                                    // 0x380
+        MOp_L_M32B_or_M16B,                      // 0x381 vpminsb
+        None,                                    // 0x382
+        None,                                    // 0x383
+        None,                                    // 0x390
+        MOp_L_M32B_or_M16B,                      // 0x391 vpminsd
+        None,                                    // 0x392
+        None,                                    // 0x393
+        None,                                    // 0x3a0
+        MOp_L_M32B_or_M16B,                      // 0x3a1 vpminuw
+        None,                                    // 0x3a2
+        None,                                    // 0x3a3
+        None,                                    // 0x3b0
+        MOp_L_M32B_or_M16B,                      // 0x3b1 vpminud
+        None,                                    // 0x3b2
+        None,                                    // 0x3b3
+        None,                                    // 0x3c0
+        MOp_L_M32B_or_M16B,                      // 0x3c1 vpmaxsb
+        None,                                    // 0x3c2
+        None,                                    // 0x3c3
+        None,                                    // 0x3d0
+        MOp_L_M32B_or_M16B,                      // 0x3d1 vpmaxsd
+        None,                                    // 0x3d2
+        None,                                    // 0x3d3
+        None,                                    // 0x3e0
+        MOp_L_M32B_or_M16B,                      // 0x3e1 vpmaxuw
+        None,                                    // 0x3e2
+        None,                                    // 0x3e3
+        None,                                    // 0x3f0
+        MOp_L_M32B_or_M16B,                      // 0x3f1 vpmaxud
+        None,                                    // 0x3f2
+        None,                                    // 0x3f3
+        None,                                    // 0x400
+        MOp_L_M32B_or_M16B,                      // 0x401 vpmulld
+        None,                                    // 0x402
+        None,                                    // 0x403
+        None,                                    // 0x410
+        MOp_M16B,                                // 0x411 vphminposuw
+        None,                                    // 0x412
+        None,                                    // 0x413
+        None,                                    // 0x420
+        None,                                    // 0x421
+        None,                                    // 0x422
+        None,                                    // 0x423
+        None,                                    // 0x430
+        None,                                    // 0x431
+        None,                                    // 0x432
+        None,                                    // 0x433
+        None,                                    // 0x440
+        None,                                    // 0x441
+        None,                                    // 0x442
+        None,                                    // 0x443
+        None,                                    // 0x450
+        MOp_L_M32B_or_M16B,                      // 0x451 vpsrlvd,vpsrlvq
+        None,                                    // 0x452
+        None,                                    // 0x453
+        None,                                    // 0x460
+        MOp_L_M32B_or_M16B,                      // 0x461 vpsravd
+        None,                                    // 0x462
+        None,                                    // 0x463
+        None,                                    // 0x470
+        MOp_L_M32B_or_M16B,                      // 0x471 vpsllvd,vpsllvq
+        None,                                    // 0x472
+        None,                                    // 0x473
+        None,                                    // 0x480
+        None,                                    // 0x481
+        None,                                    // 0x482
+        None,                                    // 0x483
+        None,                                    // 0x490
+        None,                                    // 0x491
+        None,                                    // 0x492
+        None,                                    // 0x493
+        None,                                    // 0x4a0
+        None,                                    // 0x4a1
+        None,                                    // 0x4a2
+        None,                                    // 0x4a3
+        None,                                    // 0x4b0
+        None,                                    // 0x4b1
+        None,                                    // 0x4b2
+        None,                                    // 0x4b3
+        None,                                    // 0x4c0
+        None,                                    // 0x4c1
+        None,                                    // 0x4c2
+        None,                                    // 0x4c3
+        None,                                    // 0x4d0
+        None,                                    // 0x4d1
+        None,                                    // 0x4d2
+        None,                                    // 0x4d3
+        None,                                    // 0x4e0
+        None,                                    // 0x4e1
+        None,                                    // 0x4e2
+        None,                                    // 0x4e3
+        None,                                    // 0x4f0
+        None,                                    // 0x4f1
+        None,                                    // 0x4f2
+        None,                                    // 0x4f3
+        None,                                    // 0x500
+        None,                                    // 0x501
+        None,                                    // 0x502
+        None,                                    // 0x503
+        None,                                    // 0x510
+        None,                                    // 0x511
+        None,                                    // 0x512
+        None,                                    // 0x513
+        None,                                    // 0x520
+        None,                                    // 0x521
+        None,                                    // 0x522
+        None,                                    // 0x523
+        None,                                    // 0x530
+        None,                                    // 0x531
+        None,                                    // 0x532
+        None,                                    // 0x533
+        None,                                    // 0x540
+        None,                                    // 0x541
+        None,                                    // 0x542
+        None,                                    // 0x543
+        None,                                    // 0x550
+        None,                                    // 0x551
+        None,                                    // 0x552
+        None,                                    // 0x553
+        None,                                    // 0x560
+        None,                                    // 0x561
+        None,                                    // 0x562
+        None,                                    // 0x563
+        None,                                    // 0x570
+        None,                                    // 0x571
+        None,                                    // 0x572
+        None,                                    // 0x573
+        None,                                    // 0x580
+        MOp_M4B,                                 // 0x581 vpbroadcastd
+        None,                                    // 0x582
+        None,                                    // 0x583
+        None,                                    // 0x590
+        MOp_M8B,                                 // 0x591 vpbroadcastq
+        None,                                    // 0x592
+        None,                                    // 0x593
+        None,                                    // 0x5a0
+        MOp_M16B,                                // 0x5a1 vbroadcasti128
+        None,                                    // 0x5a2
+        None,                                    // 0x5a3
+        None,                                    // 0x5b0
+        None,                                    // 0x5b1
+        None,                                    // 0x5b2
+        None,                                    // 0x5b3
+        None,                                    // 0x5c0
+        None,                                    // 0x5c1
+        None,                                    // 0x5c2
+        None,                                    // 0x5c3
+        None,                                    // 0x5d0
+        None,                                    // 0x5d1
+        None,                                    // 0x5d2
+        None,                                    // 0x5d3
+        None,                                    // 0x5e0
+        None,                                    // 0x5e1
+        None,                                    // 0x5e2
+        None,                                    // 0x5e3
+        None,                                    // 0x5f0
+        None,                                    // 0x5f1
+        None,                                    // 0x5f2
+        None,                                    // 0x5f3
+        None,                                    // 0x600
+        None,                                    // 0x601
+        None,                                    // 0x602
+        None,                                    // 0x603
+        None,                                    // 0x610
+        None,                                    // 0x611
+        None,                                    // 0x612
+        None,                                    // 0x613
+        None,                                    // 0x620
+        None,                                    // 0x621
+        None,                                    // 0x622
+        None,                                    // 0x623
+        None,                                    // 0x630
+        None,                                    // 0x631
+        None,                                    // 0x632
+        None,                                    // 0x633
+        None,                                    // 0x640
+        None,                                    // 0x641
+        None,                                    // 0x642
+        None,                                    // 0x643
+        None,                                    // 0x650
+        None,                                    // 0x651
+        None,                                    // 0x652
+        None,                                    // 0x653
+        None,                                    // 0x660
+        None,                                    // 0x661
+        None,                                    // 0x662
+        None,                                    // 0x663
+        None,                                    // 0x670
+        None,                                    // 0x671
+        None,                                    // 0x672
+        None,                                    // 0x673
+        None,                                    // 0x680
+        None,                                    // 0x681
+        None,                                    // 0x682
+        None,                                    // 0x683
+        None,                                    // 0x690
+        None,                                    // 0x691
+        None,                                    // 0x692
+        None,                                    // 0x693
+        None,                                    // 0x6a0
+        None,                                    // 0x6a1
+        None,                                    // 0x6a2
+        None,                                    // 0x6a3
+        None,                                    // 0x6b0
+        None,                                    // 0x6b1
+        None,                                    // 0x6b2
+        None,                                    // 0x6b3
+        None,                                    // 0x6c0
+        None,                                    // 0x6c1
+        None,                                    // 0x6c2
+        None,                                    // 0x6c3
+        None,                                    // 0x6d0
+        None,                                    // 0x6d1
+        None,                                    // 0x6d2
+        None,                                    // 0x6d3
+        None,                                    // 0x6e0
+        None,                                    // 0x6e1
+        None,                                    // 0x6e2
+        None,                                    // 0x6e3
+        None,                                    // 0x6f0
+        None,                                    // 0x6f1
+        None,                                    // 0x6f2
+        None,                                    // 0x6f3
+        None,                                    // 0x700
+        None,                                    // 0x701
+        None,                                    // 0x702
+        None,                                    // 0x703
+        None,                                    // 0x710
+        None,                                    // 0x711
+        None,                                    // 0x712
+        None,                                    // 0x713
+        None,                                    // 0x720
+        None,                                    // 0x721
+        None,                                    // 0x722
+        None,                                    // 0x723
+        None,                                    // 0x730
+        None,                                    // 0x731
+        None,                                    // 0x732
+        None,                                    // 0x733
+        None,                                    // 0x740
+        None,                                    // 0x741
+        None,                                    // 0x742
+        None,                                    // 0x743
+        None,                                    // 0x750
+        None,                                    // 0x751
+        None,                                    // 0x752
+        None,                                    // 0x753
+        None,                                    // 0x760
+        None,                                    // 0x761
+        None,                                    // 0x762
+        None,                                    // 0x763
+        None,                                    // 0x770
+        None,                                    // 0x771
+        None,                                    // 0x772
+        None,                                    // 0x773
+        None,                                    // 0x780
+        MOp_M1B,                                 // 0x781 vpbroadcastb
+        None,                                    // 0x782
+        None,                                    // 0x783
+        None,                                    // 0x790
+        MOp_M2B,                                 // 0x791 vpbroadcastw
+        None,                                    // 0x792
+        None,                                    // 0x793
+        None,                                    // 0x7a0
+        None,                                    // 0x7a1
+        None,                                    // 0x7a2
+        None,                                    // 0x7a3
+        None,                                    // 0x7b0
+        None,                                    // 0x7b1
+        None,                                    // 0x7b2
+        None,                                    // 0x7b3
+        None,                                    // 0x7c0
+        None,                                    // 0x7c1
+        None,                                    // 0x7c2
+        None,                                    // 0x7c3
+        None,                                    // 0x7d0
+        None,                                    // 0x7d1
+        None,                                    // 0x7d2
+        None,                                    // 0x7d3
+        None,                                    // 0x7e0
+        None,                                    // 0x7e1
+        None,                                    // 0x7e2
+        None,                                    // 0x7e3
+        None,                                    // 0x7f0
+        None,                                    // 0x7f1
+        None,                                    // 0x7f2
+        None,                                    // 0x7f3
+        None,                                    // 0x800
+        None,                                    // 0x801
+        None,                                    // 0x802
+        None,                                    // 0x803
+        None,                                    // 0x810
+        None,                                    // 0x811
+        None,                                    // 0x812
+        None,                                    // 0x813
+        None,                                    // 0x820
+        None,                                    // 0x821
+        None,                                    // 0x822
+        None,                                    // 0x823
+        None,                                    // 0x830
+        None,                                    // 0x831
+        None,                                    // 0x832
+        None,                                    // 0x833
+        None,                                    // 0x840
+        None,                                    // 0x841
+        None,                                    // 0x842
+        None,                                    // 0x843
+        None,                                    // 0x850
+        None,                                    // 0x851
+        None,                                    // 0x852
+        None,                                    // 0x853
+        None,                                    // 0x860
+        None,                                    // 0x861
+        None,                                    // 0x862
+        None,                                    // 0x863
+        None,                                    // 0x870
+        None,                                    // 0x871
+        None,                                    // 0x872
+        None,                                    // 0x873
+        None,                                    // 0x880
+        None,                                    // 0x881
+        None,                                    // 0x882
+        None,                                    // 0x883
+        None,                                    // 0x890
+        None,                                    // 0x891
+        None,                                    // 0x892
+        None,                                    // 0x893
+        None,                                    // 0x8a0
+        None,                                    // 0x8a1
+        None,                                    // 0x8a2
+        None,                                    // 0x8a3
+        None,                                    // 0x8b0
+        None,                                    // 0x8b1
+        None,                                    // 0x8b2
+        None,                                    // 0x8b3
+        None,                                    // 0x8c0
+        MOp_L_M32B_or_M16B,                      // 0x8c1 vpmaskmovd,vpmaskmovq
+        None,                                    // 0x8c2
+        None,                                    // 0x8c3
+        None,                                    // 0x8d0
+        None,                                    // 0x8d1
+        None,                                    // 0x8d2
+        None,                                    // 0x8d3
+        None,                                    // 0x8e0
+        M1st_L_M32B_or_M16B,                     // 0x8e1 vpmaskmovd,vpmaskmovq
+        None,                                    // 0x8e2
+        None,                                    // 0x8e3
+        None,                                    // 0x8f0
+        None,                                    // 0x8f1
+        None,                                    // 0x8f2
+        None,                                    // 0x8f3
+        None,                                    // 0x900
+        MOp_W_M8B_or_M4B,                        // 0x901 vpgatherdd,vpgatherdq
+        None,                                    // 0x902
+        None,                                    // 0x903
+        None,                                    // 0x910
+        MOp_W_M8B_or_M4B,                        // 0x911 vpgatherqd,vpgatherqq
+        None,                                    // 0x912
+        None,                                    // 0x913
+        None,                                    // 0x920
+        MOp_W_M8B_or_M4B,                        // 0x921 vgatherdpd,vgatherdps
+        None,                                    // 0x922
+        None,                                    // 0x923
+        None,                                    // 0x930
+        MOp_W_M8B_or_M4B,                        // 0x931 vgatherqpd,vgatherqps
+        None,                                    // 0x932
+        None,                                    // 0x933
+        None,                                    // 0x940
+        None,                                    // 0x941
+        None,                                    // 0x942
+        None,                                    // 0x943
+        None,                                    // 0x950
+        None,                                    // 0x951
+        None,                                    // 0x952
+        None,                                    // 0x953
+        None,                                    // 0x960
+        MOp_L_M32B_or_M16B,                      // 0x961 vfmaddsub132pd,vfmaddsub132ps
+        None,                                    // 0x962
+        None,                                    // 0x963
+        None,                                    // 0x970
+        MOp_L_M32B_or_M16B,                      // 0x971 vfmsubadd132pd,vfmsubadd132ps
+        None,                                    // 0x972
+        None,                                    // 0x973
+        None,                                    // 0x980
+        MOp_L_M32B_or_M16B,                      // 0x981 vfmadd132pd,vfmadd132ps
+        None,                                    // 0x982
+        None,                                    // 0x983
+        None,                                    // 0x990
+        MOp_W_M8B_or_M4B,                        // 0x991 vfmadd132sd,vfmadd132ss
+        None,                                    // 0x992
+        None,                                    // 0x993
+        None,                                    // 0x9a0
+        MOp_L_M32B_or_M16B,                      // 0x9a1 vfmsub132pd,vfmsub132ps
+        None,                                    // 0x9a2
+        None,                                    // 0x9a3
+        None,                                    // 0x9b0
+        MOp_W_M8B_or_M4B,                        // 0x9b1 vfmsub132sd,vfmsub132ss
+        None,                                    // 0x9b2
+        None,                                    // 0x9b3
+        None,                                    // 0x9c0
+        MOp_L_M32B_or_M16B,                      // 0x9c1 vfnmadd132pd,vfnmadd132ps
+        None,                                    // 0x9c2
+        None,                                    // 0x9c3
+        None,                                    // 0x9d0
+        MOp_W_M8B_or_M4B,                        // 0x9d1 vfnmadd132sd,vfnmadd132ss
+        None,                                    // 0x9d2
+        None,                                    // 0x9d3
+        None,                                    // 0x9e0
+        MOp_L_M32B_or_M16B,                      // 0x9e1 vfnmsub132pd,vfnmsub132ps
+        None,                                    // 0x9e2
+        None,                                    // 0x9e3
+        None,                                    // 0x9f0
+        MOp_W_M8B_or_M4B,                        // 0x9f1 vfnmsub132sd,vfnmsub132ss
+        None,                                    // 0x9f2
+        None,                                    // 0x9f3
+        None,                                    // 0xa00
+        None,                                    // 0xa01
+        None,                                    // 0xa02
+        None,                                    // 0xa03
+        None,                                    // 0xa10
+        None,                                    // 0xa11
+        None,                                    // 0xa12
+        None,                                    // 0xa13
+        None,                                    // 0xa20
+        None,                                    // 0xa21
+        None,                                    // 0xa22
+        None,                                    // 0xa23
+        None,                                    // 0xa30
+        None,                                    // 0xa31
+        None,                                    // 0xa32
+        None,                                    // 0xa33
+        None,                                    // 0xa40
+        None,                                    // 0xa41
+        None,                                    // 0xa42
+        None,                                    // 0xa43
+        None,                                    // 0xa50
+        None,                                    // 0xa51
+        None,                                    // 0xa52
+        None,                                    // 0xa53
+        None,                                    // 0xa60
+        MOp_L_M32B_or_M16B,                      // 0xa61 vfmaddsub213pd,vfmaddsub213ps
+        None,                                    // 0xa62
+        None,                                    // 0xa63
+        None,                                    // 0xa70
+        MOp_L_M32B_or_M16B,                      // 0xa71 vfmsubadd213pd,vfmsubadd213ps
+        None,                                    // 0xa72
+        None,                                    // 0xa73
+        None,                                    // 0xa80
+        MOp_L_M32B_or_M16B,                      // 0xa81 vfmadd213pd,vfmadd213ps
+        None,                                    // 0xa82
+        None,                                    // 0xa83
+        None,                                    // 0xa90
+        MOp_W_M8B_or_M4B,                        // 0xa91 vfmadd213sd,vfmadd213ss
+        None,                                    // 0xa92
+        None,                                    // 0xa93
+        None,                                    // 0xaa0
+        MOp_L_M32B_or_M16B,                      // 0xaa1 vfmsub213pd,vfmsub213ps
+        None,                                    // 0xaa2
+        None,                                    // 0xaa3
+        None,                                    // 0xab0
+        MOp_W_M8B_or_M4B,                        // 0xab1 vfmsub213sd,vfmsub213ss
+        None,                                    // 0xab2
+        None,                                    // 0xab3
+        None,                                    // 0xac0
+        MOp_L_M32B_or_M16B,                      // 0xac1 vfnmadd213pd,vfnmadd213ps
+        None,                                    // 0xac2
+        None,                                    // 0xac3
+        None,                                    // 0xad0
+        MOp_W_M8B_or_M4B,                        // 0xad1 vfnmadd213sd,vfnmadd213ss
+        None,                                    // 0xad2
+        None,                                    // 0xad3
+        None,                                    // 0xae0
+        MOp_L_M32B_or_M16B,                      // 0xae1 vfnmsub213pd,vfnmsub213ps
+        None,                                    // 0xae2
+        None,                                    // 0xae3
+        None,                                    // 0xaf0
+        MOp_W_M8B_or_M4B,                        // 0xaf1 vfnmsub213sd,vfnmsub213ss
+        None,                                    // 0xaf2
+        None,                                    // 0xaf3
+        None,                                    // 0xb00
+        None,                                    // 0xb01
+        None,                                    // 0xb02
+        None,                                    // 0xb03
+        None,                                    // 0xb10
+        None,                                    // 0xb11
+        None,                                    // 0xb12
+        None,                                    // 0xb13
+        None,                                    // 0xb20
+        None,                                    // 0xb21
+        None,                                    // 0xb22
+        None,                                    // 0xb23
+        None,                                    // 0xb30
+        None,                                    // 0xb31
+        None,                                    // 0xb32
+        None,                                    // 0xb33
+        None,                                    // 0xb40
+        None,                                    // 0xb41
+        None,                                    // 0xb42
+        None,                                    // 0xb43
+        None,                                    // 0xb50
+        None,                                    // 0xb51
+        None,                                    // 0xb52
+        None,                                    // 0xb53
+        None,                                    // 0xb60
+        MOp_L_M32B_or_M16B,                      // 0xb61 vfmaddsub231pd,vfmaddsub231ps
+        None,                                    // 0xb62
+        None,                                    // 0xb63
+        None,                                    // 0xb70
+        MOp_L_M32B_or_M16B,                      // 0xb71 vfmsubadd231pd,vfmsubadd231ps
+        None,                                    // 0xb72
+        None,                                    // 0xb73
+        None,                                    // 0xb80
+        MOp_L_M32B_or_M16B,                      // 0xb81 vfmadd231pd,vfmadd231ps
+        None,                                    // 0xb82
+        None,                                    // 0xb83
+        None,                                    // 0xb90
+        MOp_W_M8B_or_M4B,                        // 0xb91 vfmadd231sd,vfmadd231ss
+        None,                                    // 0xb92
+        None,                                    // 0xb93
+        None,                                    // 0xba0
+        MOp_L_M32B_or_M16B,                      // 0xba1 vfmsub231pd,vfmsub231ps
+        None,                                    // 0xba2
+        None,                                    // 0xba3
+        None,                                    // 0xbb0
+        MOp_W_M8B_or_M4B,                        // 0xbb1 vfmsub231sd,vfmsub231ss
+        None,                                    // 0xbb2
+        None,                                    // 0xbb3
+        None,                                    // 0xbc0
+        MOp_L_M32B_or_M16B,                      // 0xbc1 vfnmadd231pd,vfnmadd231ps
+        None,                                    // 0xbc2
+        None,                                    // 0xbc3
+        None,                                    // 0xbd0
+        MOp_W_M8B_or_M4B,                        // 0xbd1 vfnmadd231sd,vfnmadd231ss
+        None,                                    // 0xbd2
+        None,                                    // 0xbd3
+        None,                                    // 0xbe0
+        MOp_L_M32B_or_M16B,                      // 0xbe1 vfnmsub231pd,vfnmsub231ps
+        None,                                    // 0xbe2
+        None,                                    // 0xbe3
+        None,                                    // 0xbf0
+        MOp_W_M8B_or_M4B,                        // 0xbf1 vfnmsub231sd,vfnmsub231ss
+        None,                                    // 0xbf2
+        None,                                    // 0xbf3
+        None,                                    // 0xc00
+        None,                                    // 0xc01
+        None,                                    // 0xc02
+        None,                                    // 0xc03
+        None,                                    // 0xc10
+        None,                                    // 0xc11
+        None,                                    // 0xc12
+        None,                                    // 0xc13
+        None,                                    // 0xc20
+        None,                                    // 0xc21
+        None,                                    // 0xc22
+        None,                                    // 0xc23
+        None,                                    // 0xc30
+        None,                                    // 0xc31
+        None,                                    // 0xc32
+        None,                                    // 0xc33
+        None,                                    // 0xc40
+        None,                                    // 0xc41
+        None,                                    // 0xc42
+        None,                                    // 0xc43
+        None,                                    // 0xc50
+        None,                                    // 0xc51
+        None,                                    // 0xc52
+        None,                                    // 0xc53
+        None,                                    // 0xc60
+        None,                                    // 0xc61
+        None,                                    // 0xc62
+        None,                                    // 0xc63
+        None,                                    // 0xc70
+        None,                                    // 0xc71
+        None,                                    // 0xc72
+        None,                                    // 0xc73
+        None,                                    // 0xc80
+        None,                                    // 0xc81
+        None,                                    // 0xc82
+        None,                                    // 0xc83
+        None,                                    // 0xc90
+        None,                                    // 0xc91
+        None,                                    // 0xc92
+        None,                                    // 0xc93
+        None,                                    // 0xca0
+        None,                                    // 0xca1
+        None,                                    // 0xca2
+        None,                                    // 0xca3
+        None,                                    // 0xcb0
+        None,                                    // 0xcb1
+        None,                                    // 0xcb2
+        None,                                    // 0xcb3
+        None,                                    // 0xcc0
+        None,                                    // 0xcc1
+        None,                                    // 0xcc2
+        None,                                    // 0xcc3
+        None,                                    // 0xcd0
+        None,                                    // 0xcd1
+        None,                                    // 0xcd2
+        None,                                    // 0xcd3
+        None,                                    // 0xce0
+        None,                                    // 0xce1
+        None,                                    // 0xce2
+        None,                                    // 0xce3
+        None,                                    // 0xcf0
+        None,                                    // 0xcf1
+        None,                                    // 0xcf2
+        None,                                    // 0xcf3
+        None,                                    // 0xd00
+        None,                                    // 0xd01
+        None,                                    // 0xd02
+        None,                                    // 0xd03
+        None,                                    // 0xd10
+        None,                                    // 0xd11
+        None,                                    // 0xd12
+        None,                                    // 0xd13
+        None,                                    // 0xd20
+        None,                                    // 0xd21
+        None,                                    // 0xd22
+        None,                                    // 0xd23
+        None,                                    // 0xd30
+        None,                                    // 0xd31
+        None,                                    // 0xd32
+        None,                                    // 0xd33
+        None,                                    // 0xd40
+        None,                                    // 0xd41
+        None,                                    // 0xd42
+        None,                                    // 0xd43
+        None,                                    // 0xd50
+        None,                                    // 0xd51
+        None,                                    // 0xd52
+        None,                                    // 0xd53
+        None,                                    // 0xd60
+        None,                                    // 0xd61
+        None,                                    // 0xd62
+        None,                                    // 0xd63
+        None,                                    // 0xd70
+        None,                                    // 0xd71
+        None,                                    // 0xd72
+        None,                                    // 0xd73
+        None,                                    // 0xd80
+        None,                                    // 0xd81
+        None,                                    // 0xd82
+        None,                                    // 0xd83
+        None,                                    // 0xd90
+        None,                                    // 0xd91
+        None,                                    // 0xd92
+        None,                                    // 0xd93
+        None,                                    // 0xda0
+        None,                                    // 0xda1
+        None,                                    // 0xda2
+        None,                                    // 0xda3
+        None,                                    // 0xdb0
+        MOp_M16B,                                // 0xdb1 vaesimc
+        None,                                    // 0xdb2
+        None,                                    // 0xdb3
+        None,                                    // 0xdc0
+        MOp_M16B,                                // 0xdc1 vaesenc
+        None,                                    // 0xdc2
+        None,                                    // 0xdc3
+        None,                                    // 0xdd0
+        MOp_M16B,                                // 0xdd1 vaesenclast
+        None,                                    // 0xdd2
+        None,                                    // 0xdd3
+        None,                                    // 0xde0
+        MOp_M16B,                                // 0xde1 vaesdec
+        None,                                    // 0xde2
+        None,                                    // 0xde3
+        None,                                    // 0xdf0
+        MOp_M16B,                                // 0xdf1 vaesdeclast
+        None,                                    // 0xdf2
+        None,                                    // 0xdf3
+        None,                                    // 0xe00
+        None,                                    // 0xe01
+        None,                                    // 0xe02
+        None,                                    // 0xe03
+        None,                                    // 0xe10
+        None,                                    // 0xe11
+        None,                                    // 0xe12
+        None,                                    // 0xe13
+        None,                                    // 0xe20
+        None,                                    // 0xe21
+        None,                                    // 0xe22
+        None,                                    // 0xe23
+        None,                                    // 0xe30
+        None,                                    // 0xe31
+        None,                                    // 0xe32
+        None,                                    // 0xe33
+        None,                                    // 0xe40
+        None,                                    // 0xe41
+        None,                                    // 0xe42
+        None,                                    // 0xe43
+        None,                                    // 0xe50
+        None,                                    // 0xe51
+        None,                                    // 0xe52
+        None,                                    // 0xe53
+        None,                                    // 0xe60
+        None,                                    // 0xe61
+        None,                                    // 0xe62
+        None,                                    // 0xe63
+        None,                                    // 0xe70
+        None,                                    // 0xe71
+        None,                                    // 0xe72
+        None,                                    // 0xe73
+        None,                                    // 0xe80
+        None,                                    // 0xe81
+        None,                                    // 0xe82
+        None,                                    // 0xe83
+        None,                                    // 0xe90
+        None,                                    // 0xe91
+        None,                                    // 0xe92
+        None,                                    // 0xe93
+        None,                                    // 0xea0
+        None,                                    // 0xea1
+        None,                                    // 0xea2
+        None,                                    // 0xea3
+        None,                                    // 0xeb0
+        None,                                    // 0xeb1
+        None,                                    // 0xeb2
+        None,                                    // 0xeb3
+        None,                                    // 0xec0
+        None,                                    // 0xec1
+        None,                                    // 0xec2
+        None,                                    // 0xec3
+        None,                                    // 0xed0
+        None,                                    // 0xed1
+        None,                                    // 0xed2
+        None,                                    // 0xed3
+        None,                                    // 0xee0
+        None,                                    // 0xee1
+        None,                                    // 0xee2
+        None,                                    // 0xee3
+        None,                                    // 0xef0
+        None,                                    // 0xef1
+        None,                                    // 0xef2
+        None,                                    // 0xef3
+        None,                                    // 0xf00
+        None,                                    // 0xf01
+        None,                                    // 0xf02
+        None,                                    // 0xf03
+        None,                                    // 0xf10
+        None,                                    // 0xf11
+        None,                                    // 0xf12
+        None,                                    // 0xf13
+        MOp_W_M8B_or_M4B,                        // 0xf20 andn
+        None,                                    // 0xf21
+        None,                                    // 0xf22
+        None,                                    // 0xf23
+        MOp_W_M8B_or_M4B,                        // 0xf30 blsi,blsmsk,blsr
+        None,                                    // 0xf31
+        None,                                    // 0xf32
+        None,                                    // 0xf33
+        None,                                    // 0xf40
+        None,                                    // 0xf41
+        None,                                    // 0xf42
+        None,                                    // 0xf43
+        MOp_W_M8B_or_M4B,                        // 0xf50 bzhi
+        None,                                    // 0xf51
+        MOp_W_M8B_or_M4B,                        // 0xf52 pext
+        MOp_W_M8B_or_M4B,                        // 0xf53 pdep
+        None,                                    // 0xf60
+        None,                                    // 0xf61
+        None,                                    // 0xf62
+        MOp_W_M8B_or_M4B,                        // 0xf63 mulx
+        MOp_W_M8B_or_M4B,                        // 0xf70 bextr
+        MOp_W_M8B_or_M4B,                        // 0xf71 shlx
+        MOp_W_M8B_or_M4B,                        // 0xf72 sarx
+        MOp_W_M8B_or_M4B,                        // 0xf73 shrx
+        None,                                    // 0xf80
+        None,                                    // 0xf81
+        None,                                    // 0xf82
+        None,                                    // 0xf83
+        None,                                    // 0xf90
+        None,                                    // 0xf91
+        None,                                    // 0xf92
+        None,                                    // 0xf93
+        None,                                    // 0xfa0
+        None,                                    // 0xfa1
+        None,                                    // 0xfa2
+        None,                                    // 0xfa3
+        None,                                    // 0xfb0
+        None,                                    // 0xfb1
+        None,                                    // 0xfb2
+        None,                                    // 0xfb3
+        None,                                    // 0xfc0
+        None,                                    // 0xfc1
+        None,                                    // 0xfc2
+        None,                                    // 0xfc3
+        None,                                    // 0xfd0
+        None,                                    // 0xfd1
+        None,                                    // 0xfd2
+        None,                                    // 0xfd3
+        None,                                    // 0xfe0
+        None,                                    // 0xfe1
+        None,                                    // 0xfe2
+        None,                                    // 0xfe3
+        None,                                    // 0xff0
+        None,                                    // 0xff1
+        None,                                    // 0xff2
+        None,                                    // 0xff3
+    };
+
+    static const InstrForm instrFormVex3[1024]
+    {
+        None,                                    // 0x000
+        MOp_M32B_I1B,                            // 0x001 vpermq
+        None,                                    // 0x002
+        None,                                    // 0x003
+        None,                                    // 0x010
+        MOp_M32B_I1B,                            // 0x011 vpermpd
+        None,                                    // 0x012
+        None,                                    // 0x013
+        None,                                    // 0x020
+        MOp_I1B_L_M32B_or_M16B,                  // 0x021 vpblendd
+        None,                                    // 0x022
+        None,                                    // 0x023
+        None,                                    // 0x030
+        None,                                    // 0x031
+        None,                                    // 0x032
+        None,                                    // 0x033
+        None,                                    // 0x040
+        MOp_I1B_L_M32B_or_M16B,                  // 0x041 vpermilps
+        None,                                    // 0x042
+        None,                                    // 0x043
+        None,                                    // 0x050
+        MOp_I1B_L_M32B_or_M16B,                  // 0x051 vpermilpd
+        None,                                    // 0x052
+        None,                                    // 0x053
+        None,                                    // 0x060
+        MOp_M32B_I1B,                            // 0x061 vperm2f128
+        None,                                    // 0x062
+        None,                                    // 0x063
+        None,                                    // 0x070
+        None,                                    // 0x071
+        None,                                    // 0x072
+        None,                                    // 0x073
+        None,                                    // 0x080
+        MOp_I1B_L_M32B_or_M16B,                  // 0x081 vroundps
+        None,                                    // 0x082
+        None,                                    // 0x083
+        None,                                    // 0x090
+        MOp_I1B_L_M32B_or_M16B,                  // 0x091 vroundpd
+        None,                                    // 0x092
+        None,                                    // 0x093
+        None,                                    // 0x0a0
+        MOp_M4B_I1B,                             // 0x0a1 vroundss
+        None,                                    // 0x0a2
+        None,                                    // 0x0a3
+        None,                                    // 0x0b0
+        MOp_M8B_I1B,                             // 0x0b1 vroundsd
+        None,                                    // 0x0b2
+        None,                                    // 0x0b3
+        None,                                    // 0x0c0
+        MOp_I1B_L_M32B_or_M16B,                  // 0x0c1 vblendps
+        None,                                    // 0x0c2
+        None,                                    // 0x0c3
+        None,                                    // 0x0d0
+        MOp_I1B_L_M32B_or_M16B,                  // 0x0d1 vblendpd
+        None,                                    // 0x0d2
+        None,                                    // 0x0d3
+        None,                                    // 0x0e0
+        MOp_I1B_L_M32B_or_M16B,                  // 0x0e1 vpblendw
+        None,                                    // 0x0e2
+        None,                                    // 0x0e3
+        None,                                    // 0x0f0
+        MOp_I1B_L_M32B_or_M16B,                  // 0x0f1 vpalignr
+        None,                                    // 0x0f2
+        None,                                    // 0x0f3
+        None,                                    // 0x100
+        None,                                    // 0x101
+        None,                                    // 0x102
+        None,                                    // 0x103
+        None,                                    // 0x110
+        None,                                    // 0x111
+        None,                                    // 0x112
+        None,                                    // 0x113
+        None,                                    // 0x120
+        None,                                    // 0x121
+        None,                                    // 0x122
+        None,                                    // 0x123
+        None,                                    // 0x130
+        None,                                    // 0x131
+        None,                                    // 0x132
+        None,                                    // 0x133
+        None,                                    // 0x140
+        M1st_M1B_I1B,                            // 0x141 vpextrb
+        None,                                    // 0x142
+        None,                                    // 0x143
+        None,                                    // 0x150
+        M1st_M2B_I1B,                            // 0x151 vpextrw
+        None,                                    // 0x152
+        None,                                    // 0x153
+        None,                                    // 0x160
+        M1st_I1B_W_M8B_or_M4B,                   // 0x161 vpextrd,vpextrq
+        None,                                    // 0x162
+        None,                                    // 0x163
+        None,                                    // 0x170
+        M1st_M4B_I1B,                            // 0x171 vextractps
+        None,                                    // 0x172
+        None,                                    // 0x173
+        None,                                    // 0x180
+        MOp_M16B_I1B,                            // 0x181 vinsertf128
+        None,                                    // 0x182
+        None,                                    // 0x183
+        None,                                    // 0x190
+        M1st_M16B_I1B,                           // 0x191 vextractf128
+        None,                                    // 0x192
+        None,                                    // 0x193
+        None,                                    // 0x1a0
+        None,                                    // 0x1a1
+        None,                                    // 0x1a2
+        None,                                    // 0x1a3
+        None,                                    // 0x1b0
+        None,                                    // 0x1b1
+        None,                                    // 0x1b2
+        None,                                    // 0x1b3
+        None,                                    // 0x1c0
+        None,                                    // 0x1c1
+        None,                                    // 0x1c2
+        None,                                    // 0x1c3
+        None,                                    // 0x1d0
+        M1st_I1B_L_M16B_or_M8B,                  // 0x1d1 vcvtps2ph
+        None,                                    // 0x1d2
+        None,                                    // 0x1d3
+        None,                                    // 0x1e0
+        None,                                    // 0x1e1
+        None,                                    // 0x1e2
+        None,                                    // 0x1e3
+        None,                                    // 0x1f0
+        None,                                    // 0x1f1
+        None,                                    // 0x1f2
+        None,                                    // 0x1f3
+        None,                                    // 0x200
+        MOp_M1B_I1B,                             // 0x201 vpinsrb
+        None,                                    // 0x202
+        None,                                    // 0x203
+        None,                                    // 0x210
+        MOp_M4B_I1B,                             // 0x211 vinsertps
+        None,                                    // 0x212
+        None,                                    // 0x213
+        None,                                    // 0x220
+        MOp_I1B_W_M8B_or_M4B,                    // 0x221 vpinsrd,vpinsrq
+        None,                                    // 0x222
+        None,                                    // 0x223
+        None,                                    // 0x230
+        None,                                    // 0x231
+        None,                                    // 0x232
+        None,                                    // 0x233
+        None,                                    // 0x240
+        None,                                    // 0x241
+        None,                                    // 0x242
+        None,                                    // 0x243
+        None,                                    // 0x250
+        None,                                    // 0x251
+        None,                                    // 0x252
+        None,                                    // 0x253
+        None,                                    // 0x260
+        None,                                    // 0x261
+        None,                                    // 0x262
+        None,                                    // 0x263
+        None,                                    // 0x270
+        None,                                    // 0x271
+        None,                                    // 0x272
+        None,                                    // 0x273
+        None,                                    // 0x280
+        None,                                    // 0x281
+        None,                                    // 0x282
+        None,                                    // 0x283
+        None,                                    // 0x290
+        None,                                    // 0x291
+        None,                                    // 0x292
+        None,                                    // 0x293
+        None,                                    // 0x2a0
+        None,                                    // 0x2a1
+        None,                                    // 0x2a2
+        None,                                    // 0x2a3
+        None,                                    // 0x2b0
+        None,                                    // 0x2b1
+        None,                                    // 0x2b2
+        None,                                    // 0x2b3
+        None,                                    // 0x2c0
+        None,                                    // 0x2c1
+        None,                                    // 0x2c2
+        None,                                    // 0x2c3
+        None,                                    // 0x2d0
+        None,                                    // 0x2d1
+        None,                                    // 0x2d2
+        None,                                    // 0x2d3
+        None,                                    // 0x2e0
+        None,                                    // 0x2e1
+        None,                                    // 0x2e2
+        None,                                    // 0x2e3
+        None,                                    // 0x2f0
+        None,                                    // 0x2f1
+        None,                                    // 0x2f2
+        None,                                    // 0x2f3
+        None,                                    // 0x300
+        None,                                    // 0x301
+        None,                                    // 0x302
+        None,                                    // 0x303
+        None,                                    // 0x310
+        None,                                    // 0x311
+        None,                                    // 0x312
+        None,                                    // 0x313
+        None,                                    // 0x320
+        None,                                    // 0x321
+        None,                                    // 0x322
+        None,                                    // 0x323
+        None,                                    // 0x330
+        None,                                    // 0x331
+        None,                                    // 0x332
+        None,                                    // 0x333
+        None,                                    // 0x340
+        None,                                    // 0x341
+        None,                                    // 0x342
+        None,                                    // 0x343
+        None,                                    // 0x350
+        None,                                    // 0x351
+        None,                                    // 0x352
+        None,                                    // 0x353
+        None,                                    // 0x360
+        None,                                    // 0x361
+        None,                                    // 0x362
+        None,                                    // 0x363
+        None,                                    // 0x370
+        None,                                    // 0x371
+        None,                                    // 0x372
+        None,                                    // 0x373
+        None,                                    // 0x380
+        MOp_M16B_I1B,                            // 0x381 vinserti128
+        None,                                    // 0x382
+        None,                                    // 0x383
+        None,                                    // 0x390
+        M1st_M16B_I1B,                           // 0x391 vextracti128
+        None,                                    // 0x392
+        None,                                    // 0x393
+        None,                                    // 0x3a0
+        None,                                    // 0x3a1
+        None,                                    // 0x3a2
+        None,                                    // 0x3a3
+        None,                                    // 0x3b0
+        None,                                    // 0x3b1
+        None,                                    // 0x3b2
+        None,                                    // 0x3b3
+        None,                                    // 0x3c0
+        None,                                    // 0x3c1
+        None,                                    // 0x3c2
+        None,                                    // 0x3c3
+        None,                                    // 0x3d0
+        None,                                    // 0x3d1
+        None,                                    // 0x3d2
+        None,                                    // 0x3d3
+        None,                                    // 0x3e0
+        None,                                    // 0x3e1
+        None,                                    // 0x3e2
+        None,                                    // 0x3e3
+        None,                                    // 0x3f0
+        None,                                    // 0x3f1
+        None,                                    // 0x3f2
+        None,                                    // 0x3f3
+        None,                                    // 0x400
+        MOp_I1B_L_M32B_or_M16B,                  // 0x401 vdpps
+        None,                                    // 0x402
+        None,                                    // 0x403
+        None,                                    // 0x410
+        MOp_M16B_I1B,                            // 0x411 vdppd
+        None,                                    // 0x412
+        None,                                    // 0x413
+        None,                                    // 0x420
+        MOp_I1B_L_M32B_or_M16B,                  // 0x421 vmpsadbw
+        None,                                    // 0x422
+        None,                                    // 0x423
+        None,                                    // 0x430
+        None,                                    // 0x431
+        None,                                    // 0x432
+        None,                                    // 0x433
+        None,                                    // 0x440
+        MOp_M16B_I1B,                            // 0x441 vpclmulqdq
+        None,                                    // 0x442
+        None,                                    // 0x443
+        None,                                    // 0x450
+        None,                                    // 0x451
+        None,                                    // 0x452
+        None,                                    // 0x453
+        None,                                    // 0x460
+        MOp_M32B_I1B,                            // 0x461 vperm2i128
+        None,                                    // 0x462
+        None,                                    // 0x463
+        None,                                    // 0x470
+        None,                                    // 0x471
+        None,                                    // 0x472
+        None,                                    // 0x473
+        None,                                    // 0x480
+        MOp_I1B_L_M32B_or_M16B,                  // 0x481 vpermil2ps
+        None,                                    // 0x482
+        None,                                    // 0x483
+        None,                                    // 0x490
+        MOp_I1B_L_M32B_or_M16B,                  // 0x491 vpermil2pd
+        None,                                    // 0x492
+        None,                                    // 0x493
+        None,                                    // 0x4a0
+        None,                                    // 0x4a1
+        None,                                    // 0x4a2
+        None,                                    // 0x4a3
+        None,                                    // 0x4b0
+        None,                                    // 0x4b1
+        None,                                    // 0x4b2
+        None,                                    // 0x4b3
+        None,                                    // 0x4c0
+        None,                                    // 0x4c1
+        None,                                    // 0x4c2
+        None,                                    // 0x4c3
+        None,                                    // 0x4d0
+        None,                                    // 0x4d1
+        None,                                    // 0x4d2
+        None,                                    // 0x4d3
+        None,                                    // 0x4e0
+        None,                                    // 0x4e1
+        None,                                    // 0x4e2
+        None,                                    // 0x4e3
+        None,                                    // 0x4f0
+        None,                                    // 0x4f1
+        None,                                    // 0x4f2
+        None,                                    // 0x4f3
+        None,                                    // 0x500
+        None,                                    // 0x501
+        None,                                    // 0x502
+        None,                                    // 0x503
+        None,                                    // 0x510
+        None,                                    // 0x511
+        None,                                    // 0x512
+        None,                                    // 0x513
+        None,                                    // 0x520
+        None,                                    // 0x521
+        None,                                    // 0x522
+        None,                                    // 0x523
+        None,                                    // 0x530
+        None,                                    // 0x531
+        None,                                    // 0x532
+        None,                                    // 0x533
+        None,                                    // 0x540
+        None,                                    // 0x541
+        None,                                    // 0x542
+        None,                                    // 0x543
+        None,                                    // 0x550
+        None,                                    // 0x551
+        None,                                    // 0x552
+        None,                                    // 0x553
+        None,                                    // 0x560
+        None,                                    // 0x561
+        None,                                    // 0x562
+        None,                                    // 0x563
+        None,                                    // 0x570
+        None,                                    // 0x571
+        None,                                    // 0x572
+        None,                                    // 0x573
+        None,                                    // 0x580
+        None,                                    // 0x581
+        None,                                    // 0x582
+        None,                                    // 0x583
+        None,                                    // 0x590
+        None,                                    // 0x591
+        None,                                    // 0x592
+        None,                                    // 0x593
+        None,                                    // 0x5a0
+        None,                                    // 0x5a1
+        None,                                    // 0x5a2
+        None,                                    // 0x5a3
+        None,                                    // 0x5b0
+        None,                                    // 0x5b1
+        None,                                    // 0x5b2
+        None,                                    // 0x5b3
+        None,                                    // 0x5c0
+        None,                                    // 0x5c1
+        None,                                    // 0x5c2
+        None,                                    // 0x5c3
+        None,                                    // 0x5d0
+        None,                                    // 0x5d1
+        None,                                    // 0x5d2
+        None,                                    // 0x5d3
+        None,                                    // 0x5e0
+        None,                                    // 0x5e1
+        None,                                    // 0x5e2
+        None,                                    // 0x5e3
+        None,                                    // 0x5f0
+        None,                                    // 0x5f1
+        None,                                    // 0x5f2
+        None,                                    // 0x5f3
+        None,                                    // 0x600
+        MOp_M16B_I1B,                            // 0x601 vpcmpestrm
+        None,                                    // 0x602
+        None,                                    // 0x603
+        None,                                    // 0x610
+        MOp_M16B_I1B,                            // 0x611 vpcmpestri
+        None,                                    // 0x612
+        None,                                    // 0x613
+        None,                                    // 0x620
+        MOp_M16B_I1B,                            // 0x621 vpcmpistrm
+        None,                                    // 0x622
+        None,                                    // 0x623
+        None,                                    // 0x630
+        MOp_M16B_I1B,                            // 0x631 vpcmpistri
+        None,                                    // 0x632
+        None,                                    // 0x633
+        None,                                    // 0x640
+        None,                                    // 0x641
+        None,                                    // 0x642
+        None,                                    // 0x643
+        None,                                    // 0x650
+        None,                                    // 0x651
+        None,                                    // 0x652
+        None,                                    // 0x653
+        None,                                    // 0x660
+        None,                                    // 0x661
+        None,                                    // 0x662
+        None,                                    // 0x663
+        None,                                    // 0x670
+        None,                                    // 0x671
+        None,                                    // 0x672
+        None,                                    // 0x673
+        None,                                    // 0x680
+        None,                                    // 0x681
+        None,                                    // 0x682
+        None,                                    // 0x683
+        None,                                    // 0x690
+        None,                                    // 0x691
+        None,                                    // 0x692
+        None,                                    // 0x693
+        None,                                    // 0x6a0
+        None,                                    // 0x6a1
+        None,                                    // 0x6a2
+        None,                                    // 0x6a3
+        None,                                    // 0x6b0
+        None,                                    // 0x6b1
+        None,                                    // 0x6b2
+        None,                                    // 0x6b3
+        None,                                    // 0x6c0
+        None,                                    // 0x6c1
+        None,                                    // 0x6c2
+        None,                                    // 0x6c3
+        None,                                    // 0x6d0
+        None,                                    // 0x6d1
+        None,                                    // 0x6d2
+        None,                                    // 0x6d3
+        None,                                    // 0x6e0
+        None,                                    // 0x6e1
+        None,                                    // 0x6e2
+        None,                                    // 0x6e3
+        None,                                    // 0x6f0
+        None,                                    // 0x6f1
+        None,                                    // 0x6f2
+        None,                                    // 0x6f3
+        None,                                    // 0x700
+        None,                                    // 0x701
+        None,                                    // 0x702
+        None,                                    // 0x703
+        None,                                    // 0x710
+        None,                                    // 0x711
+        None,                                    // 0x712
+        None,                                    // 0x713
+        None,                                    // 0x720
+        None,                                    // 0x721
+        None,                                    // 0x722
+        None,                                    // 0x723
+        None,                                    // 0x730
+        None,                                    // 0x731
+        None,                                    // 0x732
+        None,                                    // 0x733
+        None,                                    // 0x740
+        None,                                    // 0x741
+        None,                                    // 0x742
+        None,                                    // 0x743
+        None,                                    // 0x750
+        None,                                    // 0x751
+        None,                                    // 0x752
+        None,                                    // 0x753
+        None,                                    // 0x760
+        None,                                    // 0x761
+        None,                                    // 0x762
+        None,                                    // 0x763
+        None,                                    // 0x770
+        None,                                    // 0x771
+        None,                                    // 0x772
+        None,                                    // 0x773
+        None,                                    // 0x780
+        None,                                    // 0x781
+        None,                                    // 0x782
+        None,                                    // 0x783
+        None,                                    // 0x790
+        None,                                    // 0x791
+        None,                                    // 0x792
+        None,                                    // 0x793
+        None,                                    // 0x7a0
+        None,                                    // 0x7a1
+        None,                                    // 0x7a2
+        None,                                    // 0x7a3
+        None,                                    // 0x7b0
+        None,                                    // 0x7b1
+        None,                                    // 0x7b2
+        None,                                    // 0x7b3
+        None,                                    // 0x7c0
+        None,                                    // 0x7c1
+        None,                                    // 0x7c2
+        None,                                    // 0x7c3
+        None,                                    // 0x7d0
+        None,                                    // 0x7d1
+        None,                                    // 0x7d2
+        None,                                    // 0x7d3
+        None,                                    // 0x7e0
+        None,                                    // 0x7e1
+        None,                                    // 0x7e2
+        None,                                    // 0x7e3
+        None,                                    // 0x7f0
+        None,                                    // 0x7f1
+        None,                                    // 0x7f2
+        None,                                    // 0x7f3
+        None,                                    // 0x800
+        None,                                    // 0x801
+        None,                                    // 0x802
+        None,                                    // 0x803
+        None,                                    // 0x810
+        None,                                    // 0x811
+        None,                                    // 0x812
+        None,                                    // 0x813
+        None,                                    // 0x820
+        None,                                    // 0x821
+        None,                                    // 0x822
+        None,                                    // 0x823
+        None,                                    // 0x830
+        None,                                    // 0x831
+        None,                                    // 0x832
+        None,                                    // 0x833
+        None,                                    // 0x840
+        None,                                    // 0x841
+        None,                                    // 0x842
+        None,                                    // 0x843
+        None,                                    // 0x850
+        None,                                    // 0x851
+        None,                                    // 0x852
+        None,                                    // 0x853
+        None,                                    // 0x860
+        None,                                    // 0x861
+        None,                                    // 0x862
+        None,                                    // 0x863
+        None,                                    // 0x870
+        None,                                    // 0x871
+        None,                                    // 0x872
+        None,                                    // 0x873
+        None,                                    // 0x880
+        None,                                    // 0x881
+        None,                                    // 0x882
+        None,                                    // 0x883
+        None,                                    // 0x890
+        None,                                    // 0x891
+        None,                                    // 0x892
+        None,                                    // 0x893
+        None,                                    // 0x8a0
+        None,                                    // 0x8a1
+        None,                                    // 0x8a2
+        None,                                    // 0x8a3
+        None,                                    // 0x8b0
+        None,                                    // 0x8b1
+        None,                                    // 0x8b2
+        None,                                    // 0x8b3
+        None,                                    // 0x8c0
+        None,                                    // 0x8c1
+        None,                                    // 0x8c2
+        None,                                    // 0x8c3
+        None,                                    // 0x8d0
+        None,                                    // 0x8d1
+        None,                                    // 0x8d2
+        None,                                    // 0x8d3
+        None,                                    // 0x8e0
+        None,                                    // 0x8e1
+        None,                                    // 0x8e2
+        None,                                    // 0x8e3
+        None,                                    // 0x8f0
+        None,                                    // 0x8f1
+        None,                                    // 0x8f2
+        None,                                    // 0x8f3
+        None,                                    // 0x900
+        None,                                    // 0x901
+        None,                                    // 0x902
+        None,                                    // 0x903
+        None,                                    // 0x910
+        None,                                    // 0x911
+        None,                                    // 0x912
+        None,                                    // 0x913
+        None,                                    // 0x920
+        None,                                    // 0x921
+        None,                                    // 0x922
+        None,                                    // 0x923
+        None,                                    // 0x930
+        None,                                    // 0x931
+        None,                                    // 0x932
+        None,                                    // 0x933
+        None,                                    // 0x940
+        None,                                    // 0x941
+        None,                                    // 0x942
+        None,                                    // 0x943
+        None,                                    // 0x950
+        None,                                    // 0x951
+        None,                                    // 0x952
+        None,                                    // 0x953
+        None,                                    // 0x960
+        None,                                    // 0x961
+        None,                                    // 0x962
+        None,                                    // 0x963
+        None,                                    // 0x970
+        None,                                    // 0x971
+        None,                                    // 0x972
+        None,                                    // 0x973
+        None,                                    // 0x980
+        None,                                    // 0x981
+        None,                                    // 0x982
+        None,                                    // 0x983
+        None,                                    // 0x990
+        None,                                    // 0x991
+        None,                                    // 0x992
+        None,                                    // 0x993
+        None,                                    // 0x9a0
+        None,                                    // 0x9a1
+        None,                                    // 0x9a2
+        None,                                    // 0x9a3
+        None,                                    // 0x9b0
+        None,                                    // 0x9b1
+        None,                                    // 0x9b2
+        None,                                    // 0x9b3
+        None,                                    // 0x9c0
+        None,                                    // 0x9c1
+        None,                                    // 0x9c2
+        None,                                    // 0x9c3
+        None,                                    // 0x9d0
+        None,                                    // 0x9d1
+        None,                                    // 0x9d2
+        None,                                    // 0x9d3
+        None,                                    // 0x9e0
+        None,                                    // 0x9e1
+        None,                                    // 0x9e2
+        None,                                    // 0x9e3
+        None,                                    // 0x9f0
+        None,                                    // 0x9f1
+        None,                                    // 0x9f2
+        None,                                    // 0x9f3
+        None,                                    // 0xa00
+        None,                                    // 0xa01
+        None,                                    // 0xa02
+        None,                                    // 0xa03
+        None,                                    // 0xa10
+        None,                                    // 0xa11
+        None,                                    // 0xa12
+        None,                                    // 0xa13
+        None,                                    // 0xa20
+        None,                                    // 0xa21
+        None,                                    // 0xa22
+        None,                                    // 0xa23
+        None,                                    // 0xa30
+        None,                                    // 0xa31
+        None,                                    // 0xa32
+        None,                                    // 0xa33
+        None,                                    // 0xa40
+        None,                                    // 0xa41
+        None,                                    // 0xa42
+        None,                                    // 0xa43
+        None,                                    // 0xa50
+        None,                                    // 0xa51
+        None,                                    // 0xa52
+        None,                                    // 0xa53
+        None,                                    // 0xa60
+        None,                                    // 0xa61
+        None,                                    // 0xa62
+        None,                                    // 0xa63
+        None,                                    // 0xa70
+        None,                                    // 0xa71
+        None,                                    // 0xa72
+        None,                                    // 0xa73
+        None,                                    // 0xa80
+        None,                                    // 0xa81
+        None,                                    // 0xa82
+        None,                                    // 0xa83
+        None,                                    // 0xa90
+        None,                                    // 0xa91
+        None,                                    // 0xa92
+        None,                                    // 0xa93
+        None,                                    // 0xaa0
+        None,                                    // 0xaa1
+        None,                                    // 0xaa2
+        None,                                    // 0xaa3
+        None,                                    // 0xab0
+        None,                                    // 0xab1
+        None,                                    // 0xab2
+        None,                                    // 0xab3
+        None,                                    // 0xac0
+        None,                                    // 0xac1
+        None,                                    // 0xac2
+        None,                                    // 0xac3
+        None,                                    // 0xad0
+        None,                                    // 0xad1
+        None,                                    // 0xad2
+        None,                                    // 0xad3
+        None,                                    // 0xae0
+        None,                                    // 0xae1
+        None,                                    // 0xae2
+        None,                                    // 0xae3
+        None,                                    // 0xaf0
+        None,                                    // 0xaf1
+        None,                                    // 0xaf2
+        None,                                    // 0xaf3
+        None,                                    // 0xb00
+        None,                                    // 0xb01
+        None,                                    // 0xb02
+        None,                                    // 0xb03
+        None,                                    // 0xb10
+        None,                                    // 0xb11
+        None,                                    // 0xb12
+        None,                                    // 0xb13
+        None,                                    // 0xb20
+        None,                                    // 0xb21
+        None,                                    // 0xb22
+        None,                                    // 0xb23
+        None,                                    // 0xb30
+        None,                                    // 0xb31
+        None,                                    // 0xb32
+        None,                                    // 0xb33
+        None,                                    // 0xb40
+        None,                                    // 0xb41
+        None,                                    // 0xb42
+        None,                                    // 0xb43
+        None,                                    // 0xb50
+        None,                                    // 0xb51
+        None,                                    // 0xb52
+        None,                                    // 0xb53
+        None,                                    // 0xb60
+        None,                                    // 0xb61
+        None,                                    // 0xb62
+        None,                                    // 0xb63
+        None,                                    // 0xb70
+        None,                                    // 0xb71
+        None,                                    // 0xb72
+        None,                                    // 0xb73
+        None,                                    // 0xb80
+        None,                                    // 0xb81
+        None,                                    // 0xb82
+        None,                                    // 0xb83
+        None,                                    // 0xb90
+        None,                                    // 0xb91
+        None,                                    // 0xb92
+        None,                                    // 0xb93
+        None,                                    // 0xba0
+        None,                                    // 0xba1
+        None,                                    // 0xba2
+        None,                                    // 0xba3
+        None,                                    // 0xbb0
+        None,                                    // 0xbb1
+        None,                                    // 0xbb2
+        None,                                    // 0xbb3
+        None,                                    // 0xbc0
+        None,                                    // 0xbc1
+        None,                                    // 0xbc2
+        None,                                    // 0xbc3
+        None,                                    // 0xbd0
+        None,                                    // 0xbd1
+        None,                                    // 0xbd2
+        None,                                    // 0xbd3
+        None,                                    // 0xbe0
+        None,                                    // 0xbe1
+        None,                                    // 0xbe2
+        None,                                    // 0xbe3
+        None,                                    // 0xbf0
+        None,                                    // 0xbf1
+        None,                                    // 0xbf2
+        None,                                    // 0xbf3
+        None,                                    // 0xc00
+        None,                                    // 0xc01
+        None,                                    // 0xc02
+        None,                                    // 0xc03
+        None,                                    // 0xc10
+        None,                                    // 0xc11
+        None,                                    // 0xc12
+        None,                                    // 0xc13
+        None,                                    // 0xc20
+        None,                                    // 0xc21
+        None,                                    // 0xc22
+        None,                                    // 0xc23
+        None,                                    // 0xc30
+        None,                                    // 0xc31
+        None,                                    // 0xc32
+        None,                                    // 0xc33
+        None,                                    // 0xc40
+        None,                                    // 0xc41
+        None,                                    // 0xc42
+        None,                                    // 0xc43
+        None,                                    // 0xc50
+        None,                                    // 0xc51
+        None,                                    // 0xc52
+        None,                                    // 0xc53
+        None,                                    // 0xc60
+        None,                                    // 0xc61
+        None,                                    // 0xc62
+        None,                                    // 0xc63
+        None,                                    // 0xc70
+        None,                                    // 0xc71
+        None,                                    // 0xc72
+        None,                                    // 0xc73
+        None,                                    // 0xc80
+        None,                                    // 0xc81
+        None,                                    // 0xc82
+        None,                                    // 0xc83
+        None,                                    // 0xc90
+        None,                                    // 0xc91
+        None,                                    // 0xc92
+        None,                                    // 0xc93
+        None,                                    // 0xca0
+        None,                                    // 0xca1
+        None,                                    // 0xca2
+        None,                                    // 0xca3
+        None,                                    // 0xcb0
+        None,                                    // 0xcb1
+        None,                                    // 0xcb2
+        None,                                    // 0xcb3
+        None,                                    // 0xcc0
+        None,                                    // 0xcc1
+        None,                                    // 0xcc2
+        None,                                    // 0xcc3
+        None,                                    // 0xcd0
+        None,                                    // 0xcd1
+        None,                                    // 0xcd2
+        None,                                    // 0xcd3
+        None,                                    // 0xce0
+        None,                                    // 0xce1
+        None,                                    // 0xce2
+        None,                                    // 0xce3
+        None,                                    // 0xcf0
+        None,                                    // 0xcf1
+        None,                                    // 0xcf2
+        None,                                    // 0xcf3
+        None,                                    // 0xd00
+        None,                                    // 0xd01
+        None,                                    // 0xd02
+        None,                                    // 0xd03
+        None,                                    // 0xd10
+        None,                                    // 0xd11
+        None,                                    // 0xd12
+        None,                                    // 0xd13
+        None,                                    // 0xd20
+        None,                                    // 0xd21
+        None,                                    // 0xd22
+        None,                                    // 0xd23
+        None,                                    // 0xd30
+        None,                                    // 0xd31
+        None,                                    // 0xd32
+        None,                                    // 0xd33
+        None,                                    // 0xd40
+        None,                                    // 0xd41
+        None,                                    // 0xd42
+        None,                                    // 0xd43
+        None,                                    // 0xd50
+        None,                                    // 0xd51
+        None,                                    // 0xd52
+        None,                                    // 0xd53
+        None,                                    // 0xd60
+        None,                                    // 0xd61
+        None,                                    // 0xd62
+        None,                                    // 0xd63
+        None,                                    // 0xd70
+        None,                                    // 0xd71
+        None,                                    // 0xd72
+        None,                                    // 0xd73
+        None,                                    // 0xd80
+        None,                                    // 0xd81
+        None,                                    // 0xd82
+        None,                                    // 0xd83
+        None,                                    // 0xd90
+        None,                                    // 0xd91
+        None,                                    // 0xd92
+        None,                                    // 0xd93
+        None,                                    // 0xda0
+        None,                                    // 0xda1
+        None,                                    // 0xda2
+        None,                                    // 0xda3
+        None,                                    // 0xdb0
+        None,                                    // 0xdb1
+        None,                                    // 0xdb2
+        None,                                    // 0xdb3
+        None,                                    // 0xdc0
+        None,                                    // 0xdc1
+        None,                                    // 0xdc2
+        None,                                    // 0xdc3
+        None,                                    // 0xdd0
+        None,                                    // 0xdd1
+        None,                                    // 0xdd2
+        None,                                    // 0xdd3
+        None,                                    // 0xde0
+        None,                                    // 0xde1
+        None,                                    // 0xde2
+        None,                                    // 0xde3
+        None,                                    // 0xdf0
+        MOp_M16B_I1B,                            // 0xdf1 vaeskeygenassist
+        None,                                    // 0xdf2
+        None,                                    // 0xdf3
+        None,                                    // 0xe00
+        None,                                    // 0xe01
+        None,                                    // 0xe02
+        None,                                    // 0xe03
+        None,                                    // 0xe10
+        None,                                    // 0xe11
+        None,                                    // 0xe12
+        None,                                    // 0xe13
+        None,                                    // 0xe20
+        None,                                    // 0xe21
+        None,                                    // 0xe22
+        None,                                    // 0xe23
+        None,                                    // 0xe30
+        None,                                    // 0xe31
+        None,                                    // 0xe32
+        None,                                    // 0xe33
+        None,                                    // 0xe40
+        None,                                    // 0xe41
+        None,                                    // 0xe42
+        None,                                    // 0xe43
+        None,                                    // 0xe50
+        None,                                    // 0xe51
+        None,                                    // 0xe52
+        None,                                    // 0xe53
+        None,                                    // 0xe60
+        None,                                    // 0xe61
+        None,                                    // 0xe62
+        None,                                    // 0xe63
+        None,                                    // 0xe70
+        None,                                    // 0xe71
+        None,                                    // 0xe72
+        None,                                    // 0xe73
+        None,                                    // 0xe80
+        None,                                    // 0xe81
+        None,                                    // 0xe82
+        None,                                    // 0xe83
+        None,                                    // 0xe90
+        None,                                    // 0xe91
+        None,                                    // 0xe92
+        None,                                    // 0xe93
+        None,                                    // 0xea0
+        None,                                    // 0xea1
+        None,                                    // 0xea2
+        None,                                    // 0xea3
+        None,                                    // 0xeb0
+        None,                                    // 0xeb1
+        None,                                    // 0xeb2
+        None,                                    // 0xeb3
+        None,                                    // 0xec0
+        None,                                    // 0xec1
+        None,                                    // 0xec2
+        None,                                    // 0xec3
+        None,                                    // 0xed0
+        None,                                    // 0xed1
+        None,                                    // 0xed2
+        None,                                    // 0xed3
+        None,                                    // 0xee0
+        None,                                    // 0xee1
+        None,                                    // 0xee2
+        None,                                    // 0xee3
+        None,                                    // 0xef0
+        None,                                    // 0xef1
+        None,                                    // 0xef2
+        None,                                    // 0xef3
+        None,                                    // 0xf00
+        None,                                    // 0xf01
+        None,                                    // 0xf02
+        MOp_I1B_W_M8B_or_M4B,                    // 0xf03 rorx
+        None,                                    // 0xf10
+        None,                                    // 0xf11
+        None,                                    // 0xf12
+        None,                                    // 0xf13
+        None,                                    // 0xf20
+        None,                                    // 0xf21
+        None,                                    // 0xf22
+        None,                                    // 0xf23
+        None,                                    // 0xf30
+        None,                                    // 0xf31
+        None,                                    // 0xf32
+        None,                                    // 0xf33
+        None,                                    // 0xf40
+        None,                                    // 0xf41
+        None,                                    // 0xf42
+        None,                                    // 0xf43
+        None,                                    // 0xf50
+        None,                                    // 0xf51
+        None,                                    // 0xf52
+        None,                                    // 0xf53
+        None,                                    // 0xf60
+        None,                                    // 0xf61
+        None,                                    // 0xf62
+        None,                                    // 0xf63
+        None,                                    // 0xf70
+        None,                                    // 0xf71
+        None,                                    // 0xf72
+        None,                                    // 0xf73
+        None,                                    // 0xf80
+        None,                                    // 0xf81
+        None,                                    // 0xf82
+        None,                                    // 0xf83
+        None,                                    // 0xf90
+        None,                                    // 0xf91
+        None,                                    // 0xf92
+        None,                                    // 0xf93
+        None,                                    // 0xfa0
+        None,                                    // 0xfa1
+        None,                                    // 0xfa2
+        None,                                    // 0xfa3
+        None,                                    // 0xfb0
+        None,                                    // 0xfb1
+        None,                                    // 0xfb2
+        None,                                    // 0xfb3
+        None,                                    // 0xfc0
+        None,                                    // 0xfc1
+        None,                                    // 0xfc2
+        None,                                    // 0xfc3
+        None,                                    // 0xfd0
+        None,                                    // 0xfd1
+        None,                                    // 0xfd2
+        None,                                    // 0xfd3
+        None,                                    // 0xfe0
+        None,                                    // 0xfe1
+        None,                                    // 0xfe2
+        None,                                    // 0xfe3
+        None,                                    // 0xff0
+        None,                                    // 0xff1
+        None,                                    // 0xff2
+        None,                                    // 0xff3
+    };
+
+    static const InstrForm instrFormXOP8[1024]
+    {
+        None,                                    // 0x000
+        None,                                    // 0x001
+        None,                                    // 0x002
+        None,                                    // 0x003
+        None,                                    // 0x010
+        None,                                    // 0x011
+        None,                                    // 0x012
+        None,                                    // 0x013
+        None,                                    // 0x020
+        None,                                    // 0x021
+        None,                                    // 0x022
+        None,                                    // 0x023
+        None,                                    // 0x030
+        None,                                    // 0x031
+        None,                                    // 0x032
+        None,                                    // 0x033
+        None,                                    // 0x040
+        None,                                    // 0x041
+        None,                                    // 0x042
+        None,                                    // 0x043
+        None,                                    // 0x050
+        None,                                    // 0x051
+        None,                                    // 0x052
+        None,                                    // 0x053
+        None,                                    // 0x060
+        None,                                    // 0x061
+        None,                                    // 0x062
+        None,                                    // 0x063
+        None,                                    // 0x070
+        None,                                    // 0x071
+        None,                                    // 0x072
+        None,                                    // 0x073
+        None,                                    // 0x080
+        None,                                    // 0x081
+        None,                                    // 0x082
+        None,                                    // 0x083
+        None,                                    // 0x090
+        None,                                    // 0x091
+        None,                                    // 0x092
+        None,                                    // 0x093
+        None,                                    // 0x0a0
+        None,                                    // 0x0a1
+        None,                                    // 0x0a2
+        None,                                    // 0x0a3
+        None,                                    // 0x0b0
+        None,                                    // 0x0b1
+        None,                                    // 0x0b2
+        None,                                    // 0x0b3
+        None,                                    // 0x0c0
+        None,                                    // 0x0c1
+        None,                                    // 0x0c2
+        None,                                    // 0x0c3
+        None,                                    // 0x0d0
+        None,                                    // 0x0d1
+        None,                                    // 0x0d2
+        None,                                    // 0x0d3
+        None,                                    // 0x0e0
+        None,                                    // 0x0e1
+        None,                                    // 0x0e2
+        None,                                    // 0x0e3
+        None,                                    // 0x0f0
+        None,                                    // 0x0f1
+        None,                                    // 0x0f2
+        None,                                    // 0x0f3
+        None,                                    // 0x100
+        None,                                    // 0x101
+        None,                                    // 0x102
+        None,                                    // 0x103
+        None,                                    // 0x110
+        None,                                    // 0x111
+        None,                                    // 0x112
+        None,                                    // 0x113
+        None,                                    // 0x120
+        None,                                    // 0x121
+        None,                                    // 0x122
+        None,                                    // 0x123
+        None,                                    // 0x130
+        None,                                    // 0x131
+        None,                                    // 0x132
+        None,                                    // 0x133
+        None,                                    // 0x140
+        None,                                    // 0x141
+        None,                                    // 0x142
+        None,                                    // 0x143
+        None,                                    // 0x150
+        None,                                    // 0x151
+        None,                                    // 0x152
+        None,                                    // 0x153
+        None,                                    // 0x160
+        None,                                    // 0x161
+        None,                                    // 0x162
+        None,                                    // 0x163
+        None,                                    // 0x170
+        None,                                    // 0x171
+        None,                                    // 0x172
+        None,                                    // 0x173
+        None,                                    // 0x180
+        None,                                    // 0x181
+        None,                                    // 0x182
+        None,                                    // 0x183
+        None,                                    // 0x190
+        None,                                    // 0x191
+        None,                                    // 0x192
+        None,                                    // 0x193
+        None,                                    // 0x1a0
+        None,                                    // 0x1a1
+        None,                                    // 0x1a2
+        None,                                    // 0x1a3
+        None,                                    // 0x1b0
+        None,                                    // 0x1b1
+        None,                                    // 0x1b2
+        None,                                    // 0x1b3
+        None,                                    // 0x1c0
+        None,                                    // 0x1c1
+        None,                                    // 0x1c2
+        None,                                    // 0x1c3
+        None,                                    // 0x1d0
+        None,                                    // 0x1d1
+        None,                                    // 0x1d2
+        None,                                    // 0x1d3
+        None,                                    // 0x1e0
+        None,                                    // 0x1e1
+        None,                                    // 0x1e2
+        None,                                    // 0x1e3
+        None,                                    // 0x1f0
+        None,                                    // 0x1f1
+        None,                                    // 0x1f2
+        None,                                    // 0x1f3
+        None,                                    // 0x200
+        None,                                    // 0x201
+        None,                                    // 0x202
+        None,                                    // 0x203
+        None,                                    // 0x210
+        None,                                    // 0x211
+        None,                                    // 0x212
+        None,                                    // 0x213
+        None,                                    // 0x220
+        None,                                    // 0x221
+        None,                                    // 0x222
+        None,                                    // 0x223
+        None,                                    // 0x230
+        None,                                    // 0x231
+        None,                                    // 0x232
+        None,                                    // 0x233
+        None,                                    // 0x240
+        None,                                    // 0x241
+        None,                                    // 0x242
+        None,                                    // 0x243
+        None,                                    // 0x250
+        None,                                    // 0x251
+        None,                                    // 0x252
+        None,                                    // 0x253
+        None,                                    // 0x260
+        None,                                    // 0x261
+        None,                                    // 0x262
+        None,                                    // 0x263
+        None,                                    // 0x270
+        None,                                    // 0x271
+        None,                                    // 0x272
+        None,                                    // 0x273
+        None,                                    // 0x280
+        None,                                    // 0x281
+        None,                                    // 0x282
+        None,                                    // 0x283
+        None,                                    // 0x290
+        None,                                    // 0x291
+        None,                                    // 0x292
+        None,                                    // 0x293
+        None,                                    // 0x2a0
+        None,                                    // 0x2a1
+        None,                                    // 0x2a2
+        None,                                    // 0x2a3
+        None,                                    // 0x2b0
+        None,                                    // 0x2b1
+        None,                                    // 0x2b2
+        None,                                    // 0x2b3
+        None,                                    // 0x2c0
+        None,                                    // 0x2c1
+        None,                                    // 0x2c2
+        None,                                    // 0x2c3
+        None,                                    // 0x2d0
+        None,                                    // 0x2d1
+        None,                                    // 0x2d2
+        None,                                    // 0x2d3
+        None,                                    // 0x2e0
+        None,                                    // 0x2e1
+        None,                                    // 0x2e2
+        None,                                    // 0x2e3
+        None,                                    // 0x2f0
+        None,                                    // 0x2f1
+        None,                                    // 0x2f2
+        None,                                    // 0x2f3
+        None,                                    // 0x300
+        None,                                    // 0x301
+        None,                                    // 0x302
+        None,                                    // 0x303
+        None,                                    // 0x310
+        None,                                    // 0x311
+        None,                                    // 0x312
+        None,                                    // 0x313
+        None,                                    // 0x320
+        None,                                    // 0x321
+        None,                                    // 0x322
+        None,                                    // 0x323
+        None,                                    // 0x330
+        None,                                    // 0x331
+        None,                                    // 0x332
+        None,                                    // 0x333
+        None,                                    // 0x340
+        None,                                    // 0x341
+        None,                                    // 0x342
+        None,                                    // 0x343
+        None,                                    // 0x350
+        None,                                    // 0x351
+        None,                                    // 0x352
+        None,                                    // 0x353
+        None,                                    // 0x360
+        None,                                    // 0x361
+        None,                                    // 0x362
+        None,                                    // 0x363
+        None,                                    // 0x370
+        None,                                    // 0x371
+        None,                                    // 0x372
+        None,                                    // 0x373
+        None,                                    // 0x380
+        None,                                    // 0x381
+        None,                                    // 0x382
+        None,                                    // 0x383
+        None,                                    // 0x390
+        None,                                    // 0x391
+        None,                                    // 0x392
+        None,                                    // 0x393
+        None,                                    // 0x3a0
+        None,                                    // 0x3a1
+        None,                                    // 0x3a2
+        None,                                    // 0x3a3
+        None,                                    // 0x3b0
+        None,                                    // 0x3b1
+        None,                                    // 0x3b2
+        None,                                    // 0x3b3
+        None,                                    // 0x3c0
+        None,                                    // 0x3c1
+        None,                                    // 0x3c2
+        None,                                    // 0x3c3
+        None,                                    // 0x3d0
+        None,                                    // 0x3d1
+        None,                                    // 0x3d2
+        None,                                    // 0x3d3
+        None,                                    // 0x3e0
+        None,                                    // 0x3e1
+        None,                                    // 0x3e2
+        None,                                    // 0x3e3
+        None,                                    // 0x3f0
+        None,                                    // 0x3f1
+        None,                                    // 0x3f2
+        None,                                    // 0x3f3
+        None,                                    // 0x400
+        None,                                    // 0x401
+        None,                                    // 0x402
+        None,                                    // 0x403
+        None,                                    // 0x410
+        None,                                    // 0x411
+        None,                                    // 0x412
+        None,                                    // 0x413
+        None,                                    // 0x420
+        None,                                    // 0x421
+        None,                                    // 0x422
+        None,                                    // 0x423
+        None,                                    // 0x430
+        None,                                    // 0x431
+        None,                                    // 0x432
+        None,                                    // 0x433
+        None,                                    // 0x440
+        None,                                    // 0x441
+        None,                                    // 0x442
+        None,                                    // 0x443
+        None,                                    // 0x450
+        None,                                    // 0x451
+        None,                                    // 0x452
+        None,                                    // 0x453
+        None,                                    // 0x460
+        None,                                    // 0x461
+        None,                                    // 0x462
+        None,                                    // 0x463
+        None,                                    // 0x470
+        None,                                    // 0x471
+        None,                                    // 0x472
+        None,                                    // 0x473
+        None,                                    // 0x480
+        None,                                    // 0x481
+        None,                                    // 0x482
+        None,                                    // 0x483
+        None,                                    // 0x490
+        None,                                    // 0x491
+        None,                                    // 0x492
+        None,                                    // 0x493
+        None,                                    // 0x4a0
+        None,                                    // 0x4a1
+        None,                                    // 0x4a2
+        None,                                    // 0x4a3
+        None,                                    // 0x4b0
+        None,                                    // 0x4b1
+        None,                                    // 0x4b2
+        None,                                    // 0x4b3
+        None,                                    // 0x4c0
+        None,                                    // 0x4c1
+        None,                                    // 0x4c2
+        None,                                    // 0x4c3
+        None,                                    // 0x4d0
+        None,                                    // 0x4d1
+        None,                                    // 0x4d2
+        None,                                    // 0x4d3
+        None,                                    // 0x4e0
+        None,                                    // 0x4e1
+        None,                                    // 0x4e2
+        None,                                    // 0x4e3
+        None,                                    // 0x4f0
+        None,                                    // 0x4f1
+        None,                                    // 0x4f2
+        None,                                    // 0x4f3
+        None,                                    // 0x500
+        None,                                    // 0x501
+        None,                                    // 0x502
+        None,                                    // 0x503
+        None,                                    // 0x510
+        None,                                    // 0x511
+        None,                                    // 0x512
+        None,                                    // 0x513
+        None,                                    // 0x520
+        None,                                    // 0x521
+        None,                                    // 0x522
+        None,                                    // 0x523
+        None,                                    // 0x530
+        None,                                    // 0x531
+        None,                                    // 0x532
+        None,                                    // 0x533
+        None,                                    // 0x540
+        None,                                    // 0x541
+        None,                                    // 0x542
+        None,                                    // 0x543
+        None,                                    // 0x550
+        None,                                    // 0x551
+        None,                                    // 0x552
+        None,                                    // 0x553
+        None,                                    // 0x560
+        None,                                    // 0x561
+        None,                                    // 0x562
+        None,                                    // 0x563
+        None,                                    // 0x570
+        None,                                    // 0x571
+        None,                                    // 0x572
+        None,                                    // 0x573
+        None,                                    // 0x580
+        None,                                    // 0x581
+        None,                                    // 0x582
+        None,                                    // 0x583
+        None,                                    // 0x590
+        None,                                    // 0x591
+        None,                                    // 0x592
+        None,                                    // 0x593
+        None,                                    // 0x5a0
+        None,                                    // 0x5a1
+        None,                                    // 0x5a2
+        None,                                    // 0x5a3
+        None,                                    // 0x5b0
+        None,                                    // 0x5b1
+        None,                                    // 0x5b2
+        None,                                    // 0x5b3
+        None,                                    // 0x5c0
+        None,                                    // 0x5c1
+        None,                                    // 0x5c2
+        None,                                    // 0x5c3
+        None,                                    // 0x5d0
+        None,                                    // 0x5d1
+        None,                                    // 0x5d2
+        None,                                    // 0x5d3
+        None,                                    // 0x5e0
+        None,                                    // 0x5e1
+        None,                                    // 0x5e2
+        None,                                    // 0x5e3
+        None,                                    // 0x5f0
+        None,                                    // 0x5f1
+        None,                                    // 0x5f2
+        None,                                    // 0x5f3
+        None,                                    // 0x600
+        None,                                    // 0x601
+        None,                                    // 0x602
+        None,                                    // 0x603
+        None,                                    // 0x610
+        None,                                    // 0x611
+        None,                                    // 0x612
+        None,                                    // 0x613
+        None,                                    // 0x620
+        None,                                    // 0x621
+        None,                                    // 0x622
+        None,                                    // 0x623
+        None,                                    // 0x630
+        None,                                    // 0x631
+        None,                                    // 0x632
+        None,                                    // 0x633
+        None,                                    // 0x640
+        None,                                    // 0x641
+        None,                                    // 0x642
+        None,                                    // 0x643
+        None,                                    // 0x650
+        None,                                    // 0x651
+        None,                                    // 0x652
+        None,                                    // 0x653
+        None,                                    // 0x660
+        None,                                    // 0x661
+        None,                                    // 0x662
+        None,                                    // 0x663
+        None,                                    // 0x670
+        None,                                    // 0x671
+        None,                                    // 0x672
+        None,                                    // 0x673
+        None,                                    // 0x680
+        None,                                    // 0x681
+        None,                                    // 0x682
+        None,                                    // 0x683
+        None,                                    // 0x690
+        None,                                    // 0x691
+        None,                                    // 0x692
+        None,                                    // 0x693
+        None,                                    // 0x6a0
+        None,                                    // 0x6a1
+        None,                                    // 0x6a2
+        None,                                    // 0x6a3
+        None,                                    // 0x6b0
+        None,                                    // 0x6b1
+        None,                                    // 0x6b2
+        None,                                    // 0x6b3
+        None,                                    // 0x6c0
+        None,                                    // 0x6c1
+        None,                                    // 0x6c2
+        None,                                    // 0x6c3
+        None,                                    // 0x6d0
+        None,                                    // 0x6d1
+        None,                                    // 0x6d2
+        None,                                    // 0x6d3
+        None,                                    // 0x6e0
+        None,                                    // 0x6e1
+        None,                                    // 0x6e2
+        None,                                    // 0x6e3
+        None,                                    // 0x6f0
+        None,                                    // 0x6f1
+        None,                                    // 0x6f2
+        None,                                    // 0x6f3
+        None,                                    // 0x700
+        None,                                    // 0x701
+        None,                                    // 0x702
+        None,                                    // 0x703
+        None,                                    // 0x710
+        None,                                    // 0x711
+        None,                                    // 0x712
+        None,                                    // 0x713
+        None,                                    // 0x720
+        None,                                    // 0x721
+        None,                                    // 0x722
+        None,                                    // 0x723
+        None,                                    // 0x730
+        None,                                    // 0x731
+        None,                                    // 0x732
+        None,                                    // 0x733
+        None,                                    // 0x740
+        None,                                    // 0x741
+        None,                                    // 0x742
+        None,                                    // 0x743
+        None,                                    // 0x750
+        None,                                    // 0x751
+        None,                                    // 0x752
+        None,                                    // 0x753
+        None,                                    // 0x760
+        None,                                    // 0x761
+        None,                                    // 0x762
+        None,                                    // 0x763
+        None,                                    // 0x770
+        None,                                    // 0x771
+        None,                                    // 0x772
+        None,                                    // 0x773
+        None,                                    // 0x780
+        None,                                    // 0x781
+        None,                                    // 0x782
+        None,                                    // 0x783
+        None,                                    // 0x790
+        None,                                    // 0x791
+        None,                                    // 0x792
+        None,                                    // 0x793
+        None,                                    // 0x7a0
+        None,                                    // 0x7a1
+        None,                                    // 0x7a2
+        None,                                    // 0x7a3
+        None,                                    // 0x7b0
+        None,                                    // 0x7b1
+        None,                                    // 0x7b2
+        None,                                    // 0x7b3
+        None,                                    // 0x7c0
+        None,                                    // 0x7c1
+        None,                                    // 0x7c2
+        None,                                    // 0x7c3
+        None,                                    // 0x7d0
+        None,                                    // 0x7d1
+        None,                                    // 0x7d2
+        None,                                    // 0x7d3
+        None,                                    // 0x7e0
+        None,                                    // 0x7e1
+        None,                                    // 0x7e2
+        None,                                    // 0x7e3
+        None,                                    // 0x7f0
+        None,                                    // 0x7f1
+        None,                                    // 0x7f2
+        None,                                    // 0x7f3
+        None,                                    // 0x800
+        None,                                    // 0x801
+        None,                                    // 0x802
+        None,                                    // 0x803
+        None,                                    // 0x810
+        None,                                    // 0x811
+        None,                                    // 0x812
+        None,                                    // 0x813
+        None,                                    // 0x820
+        None,                                    // 0x821
+        None,                                    // 0x822
+        None,                                    // 0x823
+        None,                                    // 0x830
+        None,                                    // 0x831
+        None,                                    // 0x832
+        None,                                    // 0x833
+        None,                                    // 0x840
+        None,                                    // 0x841
+        None,                                    // 0x842
+        None,                                    // 0x843
+        None,                                    // 0x850
+        None,                                    // 0x851
+        None,                                    // 0x852
+        None,                                    // 0x853
+        None,                                    // 0x860
+        None,                                    // 0x861
+        None,                                    // 0x862
+        None,                                    // 0x863
+        None,                                    // 0x870
+        None,                                    // 0x871
+        None,                                    // 0x872
+        None,                                    // 0x873
+        None,                                    // 0x880
+        None,                                    // 0x881
+        None,                                    // 0x882
+        None,                                    // 0x883
+        None,                                    // 0x890
+        None,                                    // 0x891
+        None,                                    // 0x892
+        None,                                    // 0x893
+        None,                                    // 0x8a0
+        None,                                    // 0x8a1
+        None,                                    // 0x8a2
+        None,                                    // 0x8a3
+        None,                                    // 0x8b0
+        None,                                    // 0x8b1
+        None,                                    // 0x8b2
+        None,                                    // 0x8b3
+        None,                                    // 0x8c0
+        None,                                    // 0x8c1
+        None,                                    // 0x8c2
+        None,                                    // 0x8c3
+        None,                                    // 0x8d0
+        None,                                    // 0x8d1
+        None,                                    // 0x8d2
+        None,                                    // 0x8d3
+        None,                                    // 0x8e0
+        None,                                    // 0x8e1
+        None,                                    // 0x8e2
+        None,                                    // 0x8e3
+        None,                                    // 0x8f0
+        None,                                    // 0x8f1
+        None,                                    // 0x8f2
+        None,                                    // 0x8f3
+        None,                                    // 0x900
+        None,                                    // 0x901
+        None,                                    // 0x902
+        None,                                    // 0x903
+        None,                                    // 0x910
+        None,                                    // 0x911
+        None,                                    // 0x912
+        None,                                    // 0x913
+        None,                                    // 0x920
+        None,                                    // 0x921
+        None,                                    // 0x922
+        None,                                    // 0x923
+        None,                                    // 0x930
+        None,                                    // 0x931
+        None,                                    // 0x932
+        None,                                    // 0x933
+        None,                                    // 0x940
+        None,                                    // 0x941
+        None,                                    // 0x942
+        None,                                    // 0x943
+        None,                                    // 0x950
+        None,                                    // 0x951
+        None,                                    // 0x952
+        None,                                    // 0x953
+        None,                                    // 0x960
+        None,                                    // 0x961
+        None,                                    // 0x962
+        None,                                    // 0x963
+        None,                                    // 0x970
+        None,                                    // 0x971
+        None,                                    // 0x972
+        None,                                    // 0x973
+        None,                                    // 0x980
+        None,                                    // 0x981
+        None,                                    // 0x982
+        None,                                    // 0x983
+        None,                                    // 0x990
+        None,                                    // 0x991
+        None,                                    // 0x992
+        None,                                    // 0x993
+        None,                                    // 0x9a0
+        None,                                    // 0x9a1
+        None,                                    // 0x9a2
+        None,                                    // 0x9a3
+        None,                                    // 0x9b0
+        None,                                    // 0x9b1
+        None,                                    // 0x9b2
+        None,                                    // 0x9b3
+        None,                                    // 0x9c0
+        None,                                    // 0x9c1
+        None,                                    // 0x9c2
+        None,                                    // 0x9c3
+        None,                                    // 0x9d0
+        None,                                    // 0x9d1
+        None,                                    // 0x9d2
+        None,                                    // 0x9d3
+        None,                                    // 0x9e0
+        None,                                    // 0x9e1
+        None,                                    // 0x9e2
+        None,                                    // 0x9e3
+        None,                                    // 0x9f0
+        None,                                    // 0x9f1
+        None,                                    // 0x9f2
+        None,                                    // 0x9f3
+        None,                                    // 0xa00
+        None,                                    // 0xa01
+        None,                                    // 0xa02
+        None,                                    // 0xa03
+        None,                                    // 0xa10
+        None,                                    // 0xa11
+        None,                                    // 0xa12
+        None,                                    // 0xa13
+        None,                                    // 0xa20
+        None,                                    // 0xa21
+        None,                                    // 0xa22
+        None,                                    // 0xa23
+        None,                                    // 0xa30
+        None,                                    // 0xa31
+        None,                                    // 0xa32
+        None,                                    // 0xa33
+        None,                                    // 0xa40
+        None,                                    // 0xa41
+        None,                                    // 0xa42
+        None,                                    // 0xa43
+        None,                                    // 0xa50
+        None,                                    // 0xa51
+        None,                                    // 0xa52
+        None,                                    // 0xa53
+        None,                                    // 0xa60
+        None,                                    // 0xa61
+        None,                                    // 0xa62
+        None,                                    // 0xa63
+        None,                                    // 0xa70
+        None,                                    // 0xa71
+        None,                                    // 0xa72
+        None,                                    // 0xa73
+        None,                                    // 0xa80
+        None,                                    // 0xa81
+        None,                                    // 0xa82
+        None,                                    // 0xa83
+        None,                                    // 0xa90
+        None,                                    // 0xa91
+        None,                                    // 0xa92
+        None,                                    // 0xa93
+        None,                                    // 0xaa0
+        None,                                    // 0xaa1
+        None,                                    // 0xaa2
+        None,                                    // 0xaa3
+        None,                                    // 0xab0
+        None,                                    // 0xab1
+        None,                                    // 0xab2
+        None,                                    // 0xab3
+        None,                                    // 0xac0
+        None,                                    // 0xac1
+        None,                                    // 0xac2
+        None,                                    // 0xac3
+        None,                                    // 0xad0
+        None,                                    // 0xad1
+        None,                                    // 0xad2
+        None,                                    // 0xad3
+        None,                                    // 0xae0
+        None,                                    // 0xae1
+        None,                                    // 0xae2
+        None,                                    // 0xae3
+        None,                                    // 0xaf0
+        None,                                    // 0xaf1
+        None,                                    // 0xaf2
+        None,                                    // 0xaf3
+        None,                                    // 0xb00
+        None,                                    // 0xb01
+        None,                                    // 0xb02
+        None,                                    // 0xb03
+        None,                                    // 0xb10
+        None,                                    // 0xb11
+        None,                                    // 0xb12
+        None,                                    // 0xb13
+        None,                                    // 0xb20
+        None,                                    // 0xb21
+        None,                                    // 0xb22
+        None,                                    // 0xb23
+        None,                                    // 0xb30
+        None,                                    // 0xb31
+        None,                                    // 0xb32
+        None,                                    // 0xb33
+        None,                                    // 0xb40
+        None,                                    // 0xb41
+        None,                                    // 0xb42
+        None,                                    // 0xb43
+        None,                                    // 0xb50
+        None,                                    // 0xb51
+        None,                                    // 0xb52
+        None,                                    // 0xb53
+        None,                                    // 0xb60
+        None,                                    // 0xb61
+        None,                                    // 0xb62
+        None,                                    // 0xb63
+        None,                                    // 0xb70
+        None,                                    // 0xb71
+        None,                                    // 0xb72
+        None,                                    // 0xb73
+        None,                                    // 0xb80
+        None,                                    // 0xb81
+        None,                                    // 0xb82
+        None,                                    // 0xb83
+        None,                                    // 0xb90
+        None,                                    // 0xb91
+        None,                                    // 0xb92
+        None,                                    // 0xb93
+        None,                                    // 0xba0
+        None,                                    // 0xba1
+        None,                                    // 0xba2
+        None,                                    // 0xba3
+        None,                                    // 0xbb0
+        None,                                    // 0xbb1
+        None,                                    // 0xbb2
+        None,                                    // 0xbb3
+        None,                                    // 0xbc0
+        None,                                    // 0xbc1
+        None,                                    // 0xbc2
+        None,                                    // 0xbc3
+        None,                                    // 0xbd0
+        None,                                    // 0xbd1
+        None,                                    // 0xbd2
+        None,                                    // 0xbd3
+        None,                                    // 0xbe0
+        None,                                    // 0xbe1
+        None,                                    // 0xbe2
+        None,                                    // 0xbe3
+        None,                                    // 0xbf0
+        None,                                    // 0xbf1
+        None,                                    // 0xbf2
+        None,                                    // 0xbf3
+        I1B_W_None_or_MOp_M16B,                  // 0xc00 vprotb
+        I1B_W_None_or_MOp_M16B,                  // 0xc01 vprotb
+        I1B_W_None_or_MOp_M16B,                  // 0xc02 vprotb
+        I1B_W_None_or_MOp_M16B,                  // 0xc03 vprotb
+        I1B_W_None_or_MOp_M16B,                  // 0xc10 vprotw
+        I1B_W_None_or_MOp_M16B,                  // 0xc11 vprotw
+        I1B_W_None_or_MOp_M16B,                  // 0xc12 vprotw
+        I1B_W_None_or_MOp_M16B,                  // 0xc13 vprotw
+        I1B_W_None_or_MOp_M16B,                  // 0xc20 vprotd
+        I1B_W_None_or_MOp_M16B,                  // 0xc21 vprotd
+        I1B_W_None_or_MOp_M16B,                  // 0xc22 vprotd
+        I1B_W_None_or_MOp_M16B,                  // 0xc23 vprotd
+        I1B_W_None_or_MOp_M16B,                  // 0xc30 vprotq
+        I1B_W_None_or_MOp_M16B,                  // 0xc31 vprotq
+        I1B_W_None_or_MOp_M16B,                  // 0xc32 vprotq
+        I1B_W_None_or_MOp_M16B,                  // 0xc33 vprotq
+        None,                                    // 0xc40
+        None,                                    // 0xc41
+        None,                                    // 0xc42
+        None,                                    // 0xc43
+        None,                                    // 0xc50
+        None,                                    // 0xc51
+        None,                                    // 0xc52
+        None,                                    // 0xc53
+        None,                                    // 0xc60
+        None,                                    // 0xc61
+        None,                                    // 0xc62
+        None,                                    // 0xc63
+        None,                                    // 0xc70
+        None,                                    // 0xc71
+        None,                                    // 0xc72
+        None,                                    // 0xc73
+        None,                                    // 0xc80
+        None,                                    // 0xc81
+        None,                                    // 0xc82
+        None,                                    // 0xc83
+        None,                                    // 0xc90
+        None,                                    // 0xc91
+        None,                                    // 0xc92
+        None,                                    // 0xc93
+        None,                                    // 0xca0
+        None,                                    // 0xca1
+        None,                                    // 0xca2
+        None,                                    // 0xca3
+        None,                                    // 0xcb0
+        None,                                    // 0xcb1
+        None,                                    // 0xcb2
+        None,                                    // 0xcb3
+        MOp_M16B_I1B,                            // 0xcc0 vpcomb
+        MOp_M16B_I1B,                            // 0xcc1 vpcomb
+        MOp_M16B_I1B,                            // 0xcc2 vpcomb
+        MOp_M16B_I1B,                            // 0xcc3 vpcomb
+        MOp_M16B_I1B,                            // 0xcd0 vpcomw
+        MOp_M16B_I1B,                            // 0xcd1 vpcomw
+        MOp_M16B_I1B,                            // 0xcd2 vpcomw
+        MOp_M16B_I1B,                            // 0xcd3 vpcomw
+        MOp_M16B_I1B,                            // 0xce0 vpcomd
+        MOp_M16B_I1B,                            // 0xce1 vpcomd
+        MOp_M16B_I1B,                            // 0xce2 vpcomd
+        MOp_M16B_I1B,                            // 0xce3 vpcomd
+        MOp_M16B_I1B,                            // 0xcf0 vpcomq
+        MOp_M16B_I1B,                            // 0xcf1 vpcomq
+        MOp_M16B_I1B,                            // 0xcf2 vpcomq
+        MOp_M16B_I1B,                            // 0xcf3 vpcomq
+        None,                                    // 0xd00
+        None,                                    // 0xd01
+        None,                                    // 0xd02
+        None,                                    // 0xd03
+        None,                                    // 0xd10
+        None,                                    // 0xd11
+        None,                                    // 0xd12
+        None,                                    // 0xd13
+        None,                                    // 0xd20
+        None,                                    // 0xd21
+        None,                                    // 0xd22
+        None,                                    // 0xd23
+        None,                                    // 0xd30
+        None,                                    // 0xd31
+        None,                                    // 0xd32
+        None,                                    // 0xd33
+        None,                                    // 0xd40
+        None,                                    // 0xd41
+        None,                                    // 0xd42
+        None,                                    // 0xd43
+        None,                                    // 0xd50
+        None,                                    // 0xd51
+        None,                                    // 0xd52
+        None,                                    // 0xd53
+        None,                                    // 0xd60
+        None,                                    // 0xd61
+        None,                                    // 0xd62
+        None,                                    // 0xd63
+        None,                                    // 0xd70
+        None,                                    // 0xd71
+        None,                                    // 0xd72
+        None,                                    // 0xd73
+        None,                                    // 0xd80
+        None,                                    // 0xd81
+        None,                                    // 0xd82
+        None,                                    // 0xd83
+        None,                                    // 0xd90
+        None,                                    // 0xd91
+        None,                                    // 0xd92
+        None,                                    // 0xd93
+        None,                                    // 0xda0
+        None,                                    // 0xda1
+        None,                                    // 0xda2
+        None,                                    // 0xda3
+        None,                                    // 0xdb0
+        None,                                    // 0xdb1
+        None,                                    // 0xdb2
+        None,                                    // 0xdb3
+        None,                                    // 0xdc0
+        None,                                    // 0xdc1
+        None,                                    // 0xdc2
+        None,                                    // 0xdc3
+        None,                                    // 0xdd0
+        None,                                    // 0xdd1
+        None,                                    // 0xdd2
+        None,                                    // 0xdd3
+        None,                                    // 0xde0
+        None,                                    // 0xde1
+        None,                                    // 0xde2
+        None,                                    // 0xde3
+        None,                                    // 0xdf0
+        None,                                    // 0xdf1
+        None,                                    // 0xdf2
+        None,                                    // 0xdf3
+        None,                                    // 0xe00
+        None,                                    // 0xe01
+        None,                                    // 0xe02
+        None,                                    // 0xe03
+        None,                                    // 0xe10
+        None,                                    // 0xe11
+        None,                                    // 0xe12
+        None,                                    // 0xe13
+        None,                                    // 0xe20
+        None,                                    // 0xe21
+        None,                                    // 0xe22
+        None,                                    // 0xe23
+        None,                                    // 0xe30
+        None,                                    // 0xe31
+        None,                                    // 0xe32
+        None,                                    // 0xe33
+        None,                                    // 0xe40
+        None,                                    // 0xe41
+        None,                                    // 0xe42
+        None,                                    // 0xe43
+        None,                                    // 0xe50
+        None,                                    // 0xe51
+        None,                                    // 0xe52
+        None,                                    // 0xe53
+        None,                                    // 0xe60
+        None,                                    // 0xe61
+        None,                                    // 0xe62
+        None,                                    // 0xe63
+        None,                                    // 0xe70
+        None,                                    // 0xe71
+        None,                                    // 0xe72
+        None,                                    // 0xe73
+        None,                                    // 0xe80
+        None,                                    // 0xe81
+        None,                                    // 0xe82
+        None,                                    // 0xe83
+        None,                                    // 0xe90
+        None,                                    // 0xe91
+        None,                                    // 0xe92
+        None,                                    // 0xe93
+        None,                                    // 0xea0
+        None,                                    // 0xea1
+        None,                                    // 0xea2
+        None,                                    // 0xea3
+        None,                                    // 0xeb0
+        None,                                    // 0xeb1
+        None,                                    // 0xeb2
+        None,                                    // 0xeb3
+        MOp_M16B_I1B,                            // 0xec0 vpcomub
+        MOp_M16B_I1B,                            // 0xec1 vpcomub
+        MOp_M16B_I1B,                            // 0xec2 vpcomub
+        MOp_M16B_I1B,                            // 0xec3 vpcomub
+        MOp_M16B_I1B,                            // 0xed0 vpcomuw
+        MOp_M16B_I1B,                            // 0xed1 vpcomuw
+        MOp_M16B_I1B,                            // 0xed2 vpcomuw
+        MOp_M16B_I1B,                            // 0xed3 vpcomuw
+        MOp_M16B_I1B,                            // 0xee0 vpcomud
+        MOp_M16B_I1B,                            // 0xee1 vpcomud
+        MOp_M16B_I1B,                            // 0xee2 vpcomud
+        MOp_M16B_I1B,                            // 0xee3 vpcomud
+        MOp_M16B_I1B,                            // 0xef0 vpcomuq
+        MOp_M16B_I1B,                            // 0xef1 vpcomuq
+        MOp_M16B_I1B,                            // 0xef2 vpcomuq
+        MOp_M16B_I1B,                            // 0xef3 vpcomuq
+        None,                                    // 0xf00
+        None,                                    // 0xf01
+        None,                                    // 0xf02
+        None,                                    // 0xf03
+        None,                                    // 0xf10
+        None,                                    // 0xf11
+        None,                                    // 0xf12
+        None,                                    // 0xf13
+        None,                                    // 0xf20
+        None,                                    // 0xf21
+        None,                                    // 0xf22
+        None,                                    // 0xf23
+        None,                                    // 0xf30
+        None,                                    // 0xf31
+        None,                                    // 0xf32
+        None,                                    // 0xf33
+        None,                                    // 0xf40
+        None,                                    // 0xf41
+        None,                                    // 0xf42
+        None,                                    // 0xf43
+        None,                                    // 0xf50
+        None,                                    // 0xf51
+        None,                                    // 0xf52
+        None,                                    // 0xf53
+        None,                                    // 0xf60
+        None,                                    // 0xf61
+        None,                                    // 0xf62
+        None,                                    // 0xf63
+        None,                                    // 0xf70
+        None,                                    // 0xf71
+        None,                                    // 0xf72
+        None,                                    // 0xf73
+        None,                                    // 0xf80
+        None,                                    // 0xf81
+        None,                                    // 0xf82
+        None,                                    // 0xf83
+        None,                                    // 0xf90
+        None,                                    // 0xf91
+        None,                                    // 0xf92
+        None,                                    // 0xf93
+        None,                                    // 0xfa0
+        None,                                    // 0xfa1
+        None,                                    // 0xfa2
+        None,                                    // 0xfa3
+        None,                                    // 0xfb0
+        None,                                    // 0xfb1
+        None,                                    // 0xfb2
+        None,                                    // 0xfb3
+        None,                                    // 0xfc0
+        None,                                    // 0xfc1
+        None,                                    // 0xfc2
+        None,                                    // 0xfc3
+        None,                                    // 0xfd0
+        None,                                    // 0xfd1
+        None,                                    // 0xfd2
+        None,                                    // 0xfd3
+        None,                                    // 0xfe0
+        None,                                    // 0xfe1
+        None,                                    // 0xfe2
+        None,                                    // 0xfe3
+        None,                                    // 0xff0
+        None,                                    // 0xff1
+        None,                                    // 0xff2
+        None,                                    // 0xff3
+    };
+
+    static const InstrForm instrFormXOP9[1024]
+    {
+        None,                                    // 0x000
+        None,                                    // 0x001
+        None,                                    // 0x002
+        None,                                    // 0x003
+        MOp_W_M8B_or_M4B,                        // 0x010 blcfill,blcic,blcs,blsfill,blsic,t1mskc,tzmsk
+        MOp_W_M8B_or_M4B,                        // 0x011 blcfill,blcic,blcs,blsfill,blsic,t1mskc,tzmsk
+        MOp_W_M8B_or_M4B,                        // 0x012 blcfill,blcic,blcs,blsfill,blsic,t1mskc,tzmsk
+        MOp_W_M8B_or_M4B,                        // 0x013 blcfill,blcic,blcs,blsfill,blsic,t1mskc,tzmsk
+        MOp_W_M8B_or_M4B,                        // 0x020 blci,blcmsk
+        MOp_W_M8B_or_M4B,                        // 0x021 blci,blcmsk
+        MOp_W_M8B_or_M4B,                        // 0x022 blci,blcmsk
+        MOp_W_M8B_or_M4B,                        // 0x023 blci,blcmsk
+        None,                                    // 0x030
+        None,                                    // 0x031
+        None,                                    // 0x032
+        None,                                    // 0x033
+        None,                                    // 0x040
+        None,                                    // 0x041
+        None,                                    // 0x042
+        None,                                    // 0x043
+        None,                                    // 0x050
+        None,                                    // 0x051
+        None,                                    // 0x052
+        None,                                    // 0x053
+        None,                                    // 0x060
+        None,                                    // 0x061
+        None,                                    // 0x062
+        None,                                    // 0x063
+        None,                                    // 0x070
+        None,                                    // 0x071
+        None,                                    // 0x072
+        None,                                    // 0x073
+        None,                                    // 0x080
+        None,                                    // 0x081
+        None,                                    // 0x082
+        None,                                    // 0x083
+        None,                                    // 0x090
+        None,                                    // 0x091
+        None,                                    // 0x092
+        None,                                    // 0x093
+        None,                                    // 0x0a0
+        None,                                    // 0x0a1
+        None,                                    // 0x0a2
+        None,                                    // 0x0a3
+        None,                                    // 0x0b0
+        None,                                    // 0x0b1
+        None,                                    // 0x0b2
+        None,                                    // 0x0b3
+        None,                                    // 0x0c0
+        None,                                    // 0x0c1
+        None,                                    // 0x0c2
+        None,                                    // 0x0c3
+        None,                                    // 0x0d0
+        None,                                    // 0x0d1
+        None,                                    // 0x0d2
+        None,                                    // 0x0d3
+        None,                                    // 0x0e0
+        None,                                    // 0x0e1
+        None,                                    // 0x0e2
+        None,                                    // 0x0e3
+        None,                                    // 0x0f0
+        None,                                    // 0x0f1
+        None,                                    // 0x0f2
+        None,                                    // 0x0f3
+        None,                                    // 0x100
+        None,                                    // 0x101
+        None,                                    // 0x102
+        None,                                    // 0x103
+        None,                                    // 0x110
+        None,                                    // 0x111
+        None,                                    // 0x112
+        None,                                    // 0x113
+        I1B,                                     // 0x120 llwpcb,slwpcb
+        I1B,                                     // 0x121 llwpcb,slwpcb
+        I1B,                                     // 0x122 llwpcb,slwpcb
+        I1B,                                     // 0x123 llwpcb,slwpcb
+        None,                                    // 0x130
+        None,                                    // 0x131
+        None,                                    // 0x132
+        None,                                    // 0x133
+        None,                                    // 0x140
+        None,                                    // 0x141
+        None,                                    // 0x142
+        None,                                    // 0x143
+        None,                                    // 0x150
+        None,                                    // 0x151
+        None,                                    // 0x152
+        None,                                    // 0x153
+        None,                                    // 0x160
+        None,                                    // 0x161
+        None,                                    // 0x162
+        None,                                    // 0x163
+        None,                                    // 0x170
+        None,                                    // 0x171
+        None,                                    // 0x172
+        None,                                    // 0x173
+        None,                                    // 0x180
+        None,                                    // 0x181
+        None,                                    // 0x182
+        None,                                    // 0x183
+        None,                                    // 0x190
+        None,                                    // 0x191
+        None,                                    // 0x192
+        None,                                    // 0x193
+        None,                                    // 0x1a0
+        None,                                    // 0x1a1
+        None,                                    // 0x1a2
+        None,                                    // 0x1a3
+        None,                                    // 0x1b0
+        None,                                    // 0x1b1
+        None,                                    // 0x1b2
+        None,                                    // 0x1b3
+        None,                                    // 0x1c0
+        None,                                    // 0x1c1
+        None,                                    // 0x1c2
+        None,                                    // 0x1c3
+        None,                                    // 0x1d0
+        None,                                    // 0x1d1
+        None,                                    // 0x1d2
+        None,                                    // 0x1d3
+        None,                                    // 0x1e0
+        None,                                    // 0x1e1
+        None,                                    // 0x1e2
+        None,                                    // 0x1e3
+        None,                                    // 0x1f0
+        None,                                    // 0x1f1
+        None,                                    // 0x1f2
+        None,                                    // 0x1f3
+        None,                                    // 0x200
+        None,                                    // 0x201
+        None,                                    // 0x202
+        None,                                    // 0x203
+        None,                                    // 0x210
+        None,                                    // 0x211
+        None,                                    // 0x212
+        None,                                    // 0x213
+        None,                                    // 0x220
+        None,                                    // 0x221
+        None,                                    // 0x222
+        None,                                    // 0x223
+        None,                                    // 0x230
+        None,                                    // 0x231
+        None,                                    // 0x232
+        None,                                    // 0x233
+        None,                                    // 0x240
+        None,                                    // 0x241
+        None,                                    // 0x242
+        None,                                    // 0x243
+        None,                                    // 0x250
+        None,                                    // 0x251
+        None,                                    // 0x252
+        None,                                    // 0x253
+        None,                                    // 0x260
+        None,                                    // 0x261
+        None,                                    // 0x262
+        None,                                    // 0x263
+        None,                                    // 0x270
+        None,                                    // 0x271
+        None,                                    // 0x272
+        None,                                    // 0x273
+        None,                                    // 0x280
+        None,                                    // 0x281
+        None,                                    // 0x282
+        None,                                    // 0x283
+        None,                                    // 0x290
+        None,                                    // 0x291
+        None,                                    // 0x292
+        None,                                    // 0x293
+        None,                                    // 0x2a0
+        None,                                    // 0x2a1
+        None,                                    // 0x2a2
+        None,                                    // 0x2a3
+        None,                                    // 0x2b0
+        None,                                    // 0x2b1
+        None,                                    // 0x2b2
+        None,                                    // 0x2b3
+        None,                                    // 0x2c0
+        None,                                    // 0x2c1
+        None,                                    // 0x2c2
+        None,                                    // 0x2c3
+        None,                                    // 0x2d0
+        None,                                    // 0x2d1
+        None,                                    // 0x2d2
+        None,                                    // 0x2d3
+        None,                                    // 0x2e0
+        None,                                    // 0x2e1
+        None,                                    // 0x2e2
+        None,                                    // 0x2e3
+        None,                                    // 0x2f0
+        None,                                    // 0x2f1
+        None,                                    // 0x2f2
+        None,                                    // 0x2f3
+        None,                                    // 0x300
+        None,                                    // 0x301
+        None,                                    // 0x302
+        None,                                    // 0x303
+        None,                                    // 0x310
+        None,                                    // 0x311
+        None,                                    // 0x312
+        None,                                    // 0x313
+        None,                                    // 0x320
+        None,                                    // 0x321
+        None,                                    // 0x322
+        None,                                    // 0x323
+        None,                                    // 0x330
+        None,                                    // 0x331
+        None,                                    // 0x332
+        None,                                    // 0x333
+        None,                                    // 0x340
+        None,                                    // 0x341
+        None,                                    // 0x342
+        None,                                    // 0x343
+        None,                                    // 0x350
+        None,                                    // 0x351
+        None,                                    // 0x352
+        None,                                    // 0x353
+        None,                                    // 0x360
+        None,                                    // 0x361
+        None,                                    // 0x362
+        None,                                    // 0x363
+        None,                                    // 0x370
+        None,                                    // 0x371
+        None,                                    // 0x372
+        None,                                    // 0x373
+        None,                                    // 0x380
+        None,                                    // 0x381
+        None,                                    // 0x382
+        None,                                    // 0x383
+        None,                                    // 0x390
+        None,                                    // 0x391
+        None,                                    // 0x392
+        None,                                    // 0x393
+        None,                                    // 0x3a0
+        None,                                    // 0x3a1
+        None,                                    // 0x3a2
+        None,                                    // 0x3a3
+        None,                                    // 0x3b0
+        None,                                    // 0x3b1
+        None,                                    // 0x3b2
+        None,                                    // 0x3b3
+        None,                                    // 0x3c0
+        None,                                    // 0x3c1
+        None,                                    // 0x3c2
+        None,                                    // 0x3c3
+        None,                                    // 0x3d0
+        None,                                    // 0x3d1
+        None,                                    // 0x3d2
+        None,                                    // 0x3d3
+        None,                                    // 0x3e0
+        None,                                    // 0x3e1
+        None,                                    // 0x3e2
+        None,                                    // 0x3e3
+        None,                                    // 0x3f0
+        None,                                    // 0x3f1
+        None,                                    // 0x3f2
+        None,                                    // 0x3f3
+        None,                                    // 0x400
+        None,                                    // 0x401
+        None,                                    // 0x402
+        None,                                    // 0x403
+        None,                                    // 0x410
+        None,                                    // 0x411
+        None,                                    // 0x412
+        None,                                    // 0x413
+        None,                                    // 0x420
+        None,                                    // 0x421
+        None,                                    // 0x422
+        None,                                    // 0x423
+        None,                                    // 0x430
+        None,                                    // 0x431
+        None,                                    // 0x432
+        None,                                    // 0x433
+        None,                                    // 0x440
+        None,                                    // 0x441
+        None,                                    // 0x442
+        None,                                    // 0x443
+        None,                                    // 0x450
+        None,                                    // 0x451
+        None,                                    // 0x452
+        None,                                    // 0x453
+        None,                                    // 0x460
+        None,                                    // 0x461
+        None,                                    // 0x462
+        None,                                    // 0x463
+        None,                                    // 0x470
+        None,                                    // 0x471
+        None,                                    // 0x472
+        None,                                    // 0x473
+        None,                                    // 0x480
+        None,                                    // 0x481
+        None,                                    // 0x482
+        None,                                    // 0x483
+        None,                                    // 0x490
+        None,                                    // 0x491
+        None,                                    // 0x492
+        None,                                    // 0x493
+        None,                                    // 0x4a0
+        None,                                    // 0x4a1
+        None,                                    // 0x4a2
+        None,                                    // 0x4a3
+        None,                                    // 0x4b0
+        None,                                    // 0x4b1
+        None,                                    // 0x4b2
+        None,                                    // 0x4b3
+        None,                                    // 0x4c0
+        None,                                    // 0x4c1
+        None,                                    // 0x4c2
+        None,                                    // 0x4c3
+        None,                                    // 0x4d0
+        None,                                    // 0x4d1
+        None,                                    // 0x4d2
+        None,                                    // 0x4d3
+        None,                                    // 0x4e0
+        None,                                    // 0x4e1
+        None,                                    // 0x4e2
+        None,                                    // 0x4e3
+        None,                                    // 0x4f0
+        None,                                    // 0x4f1
+        None,                                    // 0x4f2
+        None,                                    // 0x4f3
+        None,                                    // 0x500
+        None,                                    // 0x501
+        None,                                    // 0x502
+        None,                                    // 0x503
+        None,                                    // 0x510
+        None,                                    // 0x511
+        None,                                    // 0x512
+        None,                                    // 0x513
+        None,                                    // 0x520
+        None,                                    // 0x521
+        None,                                    // 0x522
+        None,                                    // 0x523
+        None,                                    // 0x530
+        None,                                    // 0x531
+        None,                                    // 0x532
+        None,                                    // 0x533
+        None,                                    // 0x540
+        None,                                    // 0x541
+        None,                                    // 0x542
+        None,                                    // 0x543
+        None,                                    // 0x550
+        None,                                    // 0x551
+        None,                                    // 0x552
+        None,                                    // 0x553
+        None,                                    // 0x560
+        None,                                    // 0x561
+        None,                                    // 0x562
+        None,                                    // 0x563
+        None,                                    // 0x570
+        None,                                    // 0x571
+        None,                                    // 0x572
+        None,                                    // 0x573
+        None,                                    // 0x580
+        None,                                    // 0x581
+        None,                                    // 0x582
+        None,                                    // 0x583
+        None,                                    // 0x590
+        None,                                    // 0x591
+        None,                                    // 0x592
+        None,                                    // 0x593
+        None,                                    // 0x5a0
+        None,                                    // 0x5a1
+        None,                                    // 0x5a2
+        None,                                    // 0x5a3
+        None,                                    // 0x5b0
+        None,                                    // 0x5b1
+        None,                                    // 0x5b2
+        None,                                    // 0x5b3
+        None,                                    // 0x5c0
+        None,                                    // 0x5c1
+        None,                                    // 0x5c2
+        None,                                    // 0x5c3
+        None,                                    // 0x5d0
+        None,                                    // 0x5d1
+        None,                                    // 0x5d2
+        None,                                    // 0x5d3
+        None,                                    // 0x5e0
+        None,                                    // 0x5e1
+        None,                                    // 0x5e2
+        None,                                    // 0x5e3
+        None,                                    // 0x5f0
+        None,                                    // 0x5f1
+        None,                                    // 0x5f2
+        None,                                    // 0x5f3
+        None,                                    // 0x600
+        None,                                    // 0x601
+        None,                                    // 0x602
+        None,                                    // 0x603
+        None,                                    // 0x610
+        None,                                    // 0x611
+        None,                                    // 0x612
+        None,                                    // 0x613
+        None,                                    // 0x620
+        None,                                    // 0x621
+        None,                                    // 0x622
+        None,                                    // 0x623
+        None,                                    // 0x630
+        None,                                    // 0x631
+        None,                                    // 0x632
+        None,                                    // 0x633
+        None,                                    // 0x640
+        None,                                    // 0x641
+        None,                                    // 0x642
+        None,                                    // 0x643
+        None,                                    // 0x650
+        None,                                    // 0x651
+        None,                                    // 0x652
+        None,                                    // 0x653
+        None,                                    // 0x660
+        None,                                    // 0x661
+        None,                                    // 0x662
+        None,                                    // 0x663
+        None,                                    // 0x670
+        None,                                    // 0x671
+        None,                                    // 0x672
+        None,                                    // 0x673
+        None,                                    // 0x680
+        None,                                    // 0x681
+        None,                                    // 0x682
+        None,                                    // 0x683
+        None,                                    // 0x690
+        None,                                    // 0x691
+        None,                                    // 0x692
+        None,                                    // 0x693
+        None,                                    // 0x6a0
+        None,                                    // 0x6a1
+        None,                                    // 0x6a2
+        None,                                    // 0x6a3
+        None,                                    // 0x6b0
+        None,                                    // 0x6b1
+        None,                                    // 0x6b2
+        None,                                    // 0x6b3
+        None,                                    // 0x6c0
+        None,                                    // 0x6c1
+        None,                                    // 0x6c2
+        None,                                    // 0x6c3
+        None,                                    // 0x6d0
+        None,                                    // 0x6d1
+        None,                                    // 0x6d2
+        None,                                    // 0x6d3
+        None,                                    // 0x6e0
+        None,                                    // 0x6e1
+        None,                                    // 0x6e2
+        None,                                    // 0x6e3
+        None,                                    // 0x6f0
+        None,                                    // 0x6f1
+        None,                                    // 0x6f2
+        None,                                    // 0x6f3
+        None,                                    // 0x700
+        None,                                    // 0x701
+        None,                                    // 0x702
+        None,                                    // 0x703
+        None,                                    // 0x710
+        None,                                    // 0x711
+        None,                                    // 0x712
+        None,                                    // 0x713
+        None,                                    // 0x720
+        None,                                    // 0x721
+        None,                                    // 0x722
+        None,                                    // 0x723
+        None,                                    // 0x730
+        None,                                    // 0x731
+        None,                                    // 0x732
+        None,                                    // 0x733
+        None,                                    // 0x740
+        None,                                    // 0x741
+        None,                                    // 0x742
+        None,                                    // 0x743
+        None,                                    // 0x750
+        None,                                    // 0x751
+        None,                                    // 0x752
+        None,                                    // 0x753
+        None,                                    // 0x760
+        None,                                    // 0x761
+        None,                                    // 0x762
+        None,                                    // 0x763
+        None,                                    // 0x770
+        None,                                    // 0x771
+        None,                                    // 0x772
+        None,                                    // 0x773
+        None,                                    // 0x780
+        None,                                    // 0x781
+        None,                                    // 0x782
+        None,                                    // 0x783
+        None,                                    // 0x790
+        None,                                    // 0x791
+        None,                                    // 0x792
+        None,                                    // 0x793
+        None,                                    // 0x7a0
+        None,                                    // 0x7a1
+        None,                                    // 0x7a2
+        None,                                    // 0x7a3
+        None,                                    // 0x7b0
+        None,                                    // 0x7b1
+        None,                                    // 0x7b2
+        None,                                    // 0x7b3
+        None,                                    // 0x7c0
+        None,                                    // 0x7c1
+        None,                                    // 0x7c2
+        None,                                    // 0x7c3
+        None,                                    // 0x7d0
+        None,                                    // 0x7d1
+        None,                                    // 0x7d2
+        None,                                    // 0x7d3
+        None,                                    // 0x7e0
+        None,                                    // 0x7e1
+        None,                                    // 0x7e2
+        None,                                    // 0x7e3
+        None,                                    // 0x7f0
+        None,                                    // 0x7f1
+        None,                                    // 0x7f2
+        None,                                    // 0x7f3
+        MOp_L_M32B_or_M16B,                      // 0x800 vfrczps
+        MOp_L_M32B_or_M16B,                      // 0x801 vfrczps
+        MOp_L_M32B_or_M16B,                      // 0x802 vfrczps
+        MOp_L_M32B_or_M16B,                      // 0x803 vfrczps
+        MOp_L_M32B_or_M16B,                      // 0x810 vfrczpd
+        MOp_L_M32B_or_M16B,                      // 0x811 vfrczpd
+        MOp_L_M32B_or_M16B,                      // 0x812 vfrczpd
+        MOp_L_M32B_or_M16B,                      // 0x813 vfrczpd
+        MOp_M4B,                                 // 0x820 vfrczss
+        MOp_M4B,                                 // 0x821 vfrczss
+        MOp_M4B,                                 // 0x822 vfrczss
+        MOp_M4B,                                 // 0x823 vfrczss
+        MOp_M8B,                                 // 0x830 vfrczsd
+        MOp_M8B,                                 // 0x831 vfrczsd
+        MOp_M8B,                                 // 0x832 vfrczsd
+        MOp_M8B,                                 // 0x833 vfrczsd
+        None,                                    // 0x840
+        None,                                    // 0x841
+        None,                                    // 0x842
+        None,                                    // 0x843
+        None,                                    // 0x850
+        None,                                    // 0x851
+        None,                                    // 0x852
+        None,                                    // 0x853
+        None,                                    // 0x860
+        None,                                    // 0x861
+        None,                                    // 0x862
+        None,                                    // 0x863
+        None,                                    // 0x870
+        None,                                    // 0x871
+        None,                                    // 0x872
+        None,                                    // 0x873
+        None,                                    // 0x880
+        None,                                    // 0x881
+        None,                                    // 0x882
+        None,                                    // 0x883
+        None,                                    // 0x890
+        None,                                    // 0x891
+        None,                                    // 0x892
+        None,                                    // 0x893
+        None,                                    // 0x8a0
+        None,                                    // 0x8a1
+        None,                                    // 0x8a2
+        None,                                    // 0x8a3
+        None,                                    // 0x8b0
+        None,                                    // 0x8b1
+        None,                                    // 0x8b2
+        None,                                    // 0x8b3
+        None,                                    // 0x8c0
+        None,                                    // 0x8c1
+        None,                                    // 0x8c2
+        None,                                    // 0x8c3
+        None,                                    // 0x8d0
+        None,                                    // 0x8d1
+        None,                                    // 0x8d2
+        None,                                    // 0x8d3
+        None,                                    // 0x8e0
+        None,                                    // 0x8e1
+        None,                                    // 0x8e2
+        None,                                    // 0x8e3
+        None,                                    // 0x8f0
+        None,                                    // 0x8f1
+        None,                                    // 0x8f2
+        None,                                    // 0x8f3
+        MOp_M16B,                                // 0x900 vprotb
+        MOp_M16B,                                // 0x901 vprotb
+        MOp_M16B,                                // 0x902 vprotb
+        MOp_M16B,                                // 0x903 vprotb
+        MOp_M16B,                                // 0x910 vprotw
+        MOp_M16B,                                // 0x911 vprotw
+        MOp_M16B,                                // 0x912 vprotw
+        MOp_M16B,                                // 0x913 vprotw
+        MOp_M16B,                                // 0x920 vprotd
+        MOp_M16B,                                // 0x921 vprotd
+        MOp_M16B,                                // 0x922 vprotd
+        MOp_M16B,                                // 0x923 vprotd
+        MOp_M16B,                                // 0x930 vprotq
+        MOp_M16B,                                // 0x931 vprotq
+        MOp_M16B,                                // 0x932 vprotq
+        MOp_M16B,                                // 0x933 vprotq
+        MOp_M16B,                                // 0x940 vpshlb
+        MOp_M16B,                                // 0x941 vpshlb
+        MOp_M16B,                                // 0x942 vpshlb
+        MOp_M16B,                                // 0x943 vpshlb
+        MOp_M16B,                                // 0x950 vpshlw
+        MOp_M16B,                                // 0x951 vpshlw
+        MOp_M16B,                                // 0x952 vpshlw
+        MOp_M16B,                                // 0x953 vpshlw
+        MOp_M16B,                                // 0x960 vpshld
+        MOp_M16B,                                // 0x961 vpshld
+        MOp_M16B,                                // 0x962 vpshld
+        MOp_M16B,                                // 0x963 vpshld
+        MOp_M16B,                                // 0x970 vpshlq
+        MOp_M16B,                                // 0x971 vpshlq
+        MOp_M16B,                                // 0x972 vpshlq
+        MOp_M16B,                                // 0x973 vpshlq
+        MOp_M16B,                                // 0x980 vpshab
+        MOp_M16B,                                // 0x981 vpshab
+        MOp_M16B,                                // 0x982 vpshab
+        MOp_M16B,                                // 0x983 vpshab
+        MOp_M16B,                                // 0x990 vpshaw
+        MOp_M16B,                                // 0x991 vpshaw
+        MOp_M16B,                                // 0x992 vpshaw
+        MOp_M16B,                                // 0x993 vpshaw
+        MOp_M16B,                                // 0x9a0 vpshad
+        MOp_M16B,                                // 0x9a1 vpshad
+        MOp_M16B,                                // 0x9a2 vpshad
+        MOp_M16B,                                // 0x9a3 vpshad
+        MOp_M16B,                                // 0x9b0 vpshaq
+        MOp_M16B,                                // 0x9b1 vpshaq
+        MOp_M16B,                                // 0x9b2 vpshaq
+        MOp_M16B,                                // 0x9b3 vpshaq
+        None,                                    // 0x9c0
+        None,                                    // 0x9c1
+        None,                                    // 0x9c2
+        None,                                    // 0x9c3
+        None,                                    // 0x9d0
+        None,                                    // 0x9d1
+        None,                                    // 0x9d2
+        None,                                    // 0x9d3
+        None,                                    // 0x9e0
+        None,                                    // 0x9e1
+        None,                                    // 0x9e2
+        None,                                    // 0x9e3
+        None,                                    // 0x9f0
+        None,                                    // 0x9f1
+        None,                                    // 0x9f2
+        None,                                    // 0x9f3
+        None,                                    // 0xa00
+        None,                                    // 0xa01
+        None,                                    // 0xa02
+        None,                                    // 0xa03
+        None,                                    // 0xa10
+        None,                                    // 0xa11
+        None,                                    // 0xa12
+        None,                                    // 0xa13
+        None,                                    // 0xa20
+        None,                                    // 0xa21
+        None,                                    // 0xa22
+        None,                                    // 0xa23
+        None,                                    // 0xa30
+        None,                                    // 0xa31
+        None,                                    // 0xa32
+        None,                                    // 0xa33
+        None,                                    // 0xa40
+        None,                                    // 0xa41
+        None,                                    // 0xa42
+        None,                                    // 0xa43
+        None,                                    // 0xa50
+        None,                                    // 0xa51
+        None,                                    // 0xa52
+        None,                                    // 0xa53
+        None,                                    // 0xa60
+        None,                                    // 0xa61
+        None,                                    // 0xa62
+        None,                                    // 0xa63
+        None,                                    // 0xa70
+        None,                                    // 0xa71
+        None,                                    // 0xa72
+        None,                                    // 0xa73
+        None,                                    // 0xa80
+        None,                                    // 0xa81
+        None,                                    // 0xa82
+        None,                                    // 0xa83
+        None,                                    // 0xa90
+        None,                                    // 0xa91
+        None,                                    // 0xa92
+        None,                                    // 0xa93
+        None,                                    // 0xaa0
+        None,                                    // 0xaa1
+        None,                                    // 0xaa2
+        None,                                    // 0xaa3
+        None,                                    // 0xab0
+        None,                                    // 0xab1
+        None,                                    // 0xab2
+        None,                                    // 0xab3
+        None,                                    // 0xac0
+        None,                                    // 0xac1
+        None,                                    // 0xac2
+        None,                                    // 0xac3
+        None,                                    // 0xad0
+        None,                                    // 0xad1
+        None,                                    // 0xad2
+        None,                                    // 0xad3
+        None,                                    // 0xae0
+        None,                                    // 0xae1
+        None,                                    // 0xae2
+        None,                                    // 0xae3
+        None,                                    // 0xaf0
+        None,                                    // 0xaf1
+        None,                                    // 0xaf2
+        None,                                    // 0xaf3
+        None,                                    // 0xb00
+        None,                                    // 0xb01
+        None,                                    // 0xb02
+        None,                                    // 0xb03
+        None,                                    // 0xb10
+        None,                                    // 0xb11
+        None,                                    // 0xb12
+        None,                                    // 0xb13
+        None,                                    // 0xb20
+        None,                                    // 0xb21
+        None,                                    // 0xb22
+        None,                                    // 0xb23
+        None,                                    // 0xb30
+        None,                                    // 0xb31
+        None,                                    // 0xb32
+        None,                                    // 0xb33
+        None,                                    // 0xb40
+        None,                                    // 0xb41
+        None,                                    // 0xb42
+        None,                                    // 0xb43
+        None,                                    // 0xb50
+        None,                                    // 0xb51
+        None,                                    // 0xb52
+        None,                                    // 0xb53
+        None,                                    // 0xb60
+        None,                                    // 0xb61
+        None,                                    // 0xb62
+        None,                                    // 0xb63
+        None,                                    // 0xb70
+        None,                                    // 0xb71
+        None,                                    // 0xb72
+        None,                                    // 0xb73
+        None,                                    // 0xb80
+        None,                                    // 0xb81
+        None,                                    // 0xb82
+        None,                                    // 0xb83
+        None,                                    // 0xb90
+        None,                                    // 0xb91
+        None,                                    // 0xb92
+        None,                                    // 0xb93
+        None,                                    // 0xba0
+        None,                                    // 0xba1
+        None,                                    // 0xba2
+        None,                                    // 0xba3
+        None,                                    // 0xbb0
+        None,                                    // 0xbb1
+        None,                                    // 0xbb2
+        None,                                    // 0xbb3
+        None,                                    // 0xbc0
+        None,                                    // 0xbc1
+        None,                                    // 0xbc2
+        None,                                    // 0xbc3
+        None,                                    // 0xbd0
+        None,                                    // 0xbd1
+        None,                                    // 0xbd2
+        None,                                    // 0xbd3
+        None,                                    // 0xbe0
+        None,                                    // 0xbe1
+        None,                                    // 0xbe2
+        None,                                    // 0xbe3
+        None,                                    // 0xbf0
+        None,                                    // 0xbf1
+        None,                                    // 0xbf2
+        None,                                    // 0xbf3
+        None,                                    // 0xc00
+        None,                                    // 0xc01
+        None,                                    // 0xc02
+        None,                                    // 0xc03
+        MOp_M16B,                                // 0xc10 vphaddbw
+        MOp_M16B,                                // 0xc11 vphaddbw
+        MOp_M16B,                                // 0xc12 vphaddbw
+        MOp_M16B,                                // 0xc13 vphaddbw
+        MOp_M16B,                                // 0xc20 vphaddbd
+        MOp_M16B,                                // 0xc21 vphaddbd
+        MOp_M16B,                                // 0xc22 vphaddbd
+        MOp_M16B,                                // 0xc23 vphaddbd
+        MOp_M16B,                                // 0xc30 vphaddbq
+        MOp_M16B,                                // 0xc31 vphaddbq
+        MOp_M16B,                                // 0xc32 vphaddbq
+        MOp_M16B,                                // 0xc33 vphaddbq
+        None,                                    // 0xc40
+        None,                                    // 0xc41
+        None,                                    // 0xc42
+        None,                                    // 0xc43
+        None,                                    // 0xc50
+        None,                                    // 0xc51
+        None,                                    // 0xc52
+        None,                                    // 0xc53
+        MOp_M16B,                                // 0xc60 vphaddwd
+        MOp_M16B,                                // 0xc61 vphaddwd
+        MOp_M16B,                                // 0xc62 vphaddwd
+        MOp_M16B,                                // 0xc63 vphaddwd
+        MOp_M16B,                                // 0xc70 vphaddwq
+        MOp_M16B,                                // 0xc71 vphaddwq
+        MOp_M16B,                                // 0xc72 vphaddwq
+        MOp_M16B,                                // 0xc73 vphaddwq
+        None,                                    // 0xc80
+        None,                                    // 0xc81
+        None,                                    // 0xc82
+        None,                                    // 0xc83
+        None,                                    // 0xc90
+        None,                                    // 0xc91
+        None,                                    // 0xc92
+        None,                                    // 0xc93
+        None,                                    // 0xca0
+        None,                                    // 0xca1
+        None,                                    // 0xca2
+        None,                                    // 0xca3
+        MOp_M16B,                                // 0xcb0 vphadddq
+        MOp_M16B,                                // 0xcb1 vphadddq
+        MOp_M16B,                                // 0xcb2 vphadddq
+        MOp_M16B,                                // 0xcb3 vphadddq
+        None,                                    // 0xcc0
+        None,                                    // 0xcc1
+        None,                                    // 0xcc2
+        None,                                    // 0xcc3
+        None,                                    // 0xcd0
+        None,                                    // 0xcd1
+        None,                                    // 0xcd2
+        None,                                    // 0xcd3
+        None,                                    // 0xce0
+        None,                                    // 0xce1
+        None,                                    // 0xce2
+        None,                                    // 0xce3
+        None,                                    // 0xcf0
+        None,                                    // 0xcf1
+        None,                                    // 0xcf2
+        None,                                    // 0xcf3
+        None,                                    // 0xd00
+        None,                                    // 0xd01
+        None,                                    // 0xd02
+        None,                                    // 0xd03
+        MOp_M16B,                                // 0xd10 vphaddubw
+        MOp_M16B,                                // 0xd11 vphaddubw
+        MOp_M16B,                                // 0xd12 vphaddubw
+        MOp_M16B,                                // 0xd13 vphaddubw
+        MOp_M16B,                                // 0xd20 vphaddubd
+        MOp_M16B,                                // 0xd21 vphaddubd
+        MOp_M16B,                                // 0xd22 vphaddubd
+        MOp_M16B,                                // 0xd23 vphaddubd
+        MOp_M16B,                                // 0xd30 vphaddubq
+        MOp_M16B,                                // 0xd31 vphaddubq
+        MOp_M16B,                                // 0xd32 vphaddubq
+        MOp_M16B,                                // 0xd33 vphaddubq
+        None,                                    // 0xd40
+        None,                                    // 0xd41
+        None,                                    // 0xd42
+        None,                                    // 0xd43
+        None,                                    // 0xd50
+        None,                                    // 0xd51
+        None,                                    // 0xd52
+        None,                                    // 0xd53
+        MOp_M16B,                                // 0xd60 vphadduwd
+        MOp_M16B,                                // 0xd61 vphadduwd
+        MOp_M16B,                                // 0xd62 vphadduwd
+        MOp_M16B,                                // 0xd63 vphadduwd
+        MOp_M16B,                                // 0xd70 vphadduwq
+        MOp_M16B,                                // 0xd71 vphadduwq
+        MOp_M16B,                                // 0xd72 vphadduwq
+        MOp_M16B,                                // 0xd73 vphadduwq
+        None,                                    // 0xd80
+        None,                                    // 0xd81
+        None,                                    // 0xd82
+        None,                                    // 0xd83
+        None,                                    // 0xd90
+        None,                                    // 0xd91
+        None,                                    // 0xd92
+        None,                                    // 0xd93
+        None,                                    // 0xda0
+        None,                                    // 0xda1
+        None,                                    // 0xda2
+        None,                                    // 0xda3
+        MOp_M16B,                                // 0xdb0 vphaddudq
+        MOp_M16B,                                // 0xdb1 vphaddudq
+        MOp_M16B,                                // 0xdb2 vphaddudq
+        MOp_M16B,                                // 0xdb3 vphaddudq
+        None,                                    // 0xdc0
+        None,                                    // 0xdc1
+        None,                                    // 0xdc2
+        None,                                    // 0xdc3
+        None,                                    // 0xdd0
+        None,                                    // 0xdd1
+        None,                                    // 0xdd2
+        None,                                    // 0xdd3
+        None,                                    // 0xde0
+        None,                                    // 0xde1
+        None,                                    // 0xde2
+        None,                                    // 0xde3
+        None,                                    // 0xdf0
+        None,                                    // 0xdf1
+        None,                                    // 0xdf2
+        None,                                    // 0xdf3
+        None,                                    // 0xe00
+        None,                                    // 0xe01
+        None,                                    // 0xe02
+        None,                                    // 0xe03
+        MOp_M16B,                                // 0xe10 vphsubbw
+        MOp_M16B,                                // 0xe11 vphsubbw
+        MOp_M16B,                                // 0xe12 vphsubbw
+        MOp_M16B,                                // 0xe13 vphsubbw
+        MOp_M16B,                                // 0xe20 vphsubwd
+        MOp_M16B,                                // 0xe21 vphsubwd
+        MOp_M16B,                                // 0xe22 vphsubwd
+        MOp_M16B,                                // 0xe23 vphsubwd
+        MOp_M16B,                                // 0xe30 vphsubdq
+        MOp_M16B,                                // 0xe31 vphsubdq
+        MOp_M16B,                                // 0xe32 vphsubdq
+        MOp_M16B,                                // 0xe33 vphsubdq
+        None,                                    // 0xe40
+        None,                                    // 0xe41
+        None,                                    // 0xe42
+        None,                                    // 0xe43
+        None,                                    // 0xe50
+        None,                                    // 0xe51
+        None,                                    // 0xe52
+        None,                                    // 0xe53
+        None,                                    // 0xe60
+        None,                                    // 0xe61
+        None,                                    // 0xe62
+        None,                                    // 0xe63
+        None,                                    // 0xe70
+        None,                                    // 0xe71
+        None,                                    // 0xe72
+        None,                                    // 0xe73
+        None,                                    // 0xe80
+        None,                                    // 0xe81
+        None,                                    // 0xe82
+        None,                                    // 0xe83
+        None,                                    // 0xe90
+        None,                                    // 0xe91
+        None,                                    // 0xe92
+        None,                                    // 0xe93
+        None,                                    // 0xea0
+        None,                                    // 0xea1
+        None,                                    // 0xea2
+        None,                                    // 0xea3
+        None,                                    // 0xeb0
+        None,                                    // 0xeb1
+        None,                                    // 0xeb2
+        None,                                    // 0xeb3
+        None,                                    // 0xec0
+        None,                                    // 0xec1
+        None,                                    // 0xec2
+        None,                                    // 0xec3
+        None,                                    // 0xed0
+        None,                                    // 0xed1
+        None,                                    // 0xed2
+        None,                                    // 0xed3
+        None,                                    // 0xee0
+        None,                                    // 0xee1
+        None,                                    // 0xee2
+        None,                                    // 0xee3
+        None,                                    // 0xef0
+        None,                                    // 0xef1
+        None,                                    // 0xef2
+        None,                                    // 0xef3
+        None,                                    // 0xf00
+        None,                                    // 0xf01
+        None,                                    // 0xf02
+        None,                                    // 0xf03
+        None,                                    // 0xf10
+        None,                                    // 0xf11
+        None,                                    // 0xf12
+        None,                                    // 0xf13
+        None,                                    // 0xf20
+        None,                                    // 0xf21
+        None,                                    // 0xf22
+        None,                                    // 0xf23
+        None,                                    // 0xf30
+        None,                                    // 0xf31
+        None,                                    // 0xf32
+        None,                                    // 0xf33
+        None,                                    // 0xf40
+        None,                                    // 0xf41
+        None,                                    // 0xf42
+        None,                                    // 0xf43
+        None,                                    // 0xf50
+        None,                                    // 0xf51
+        None,                                    // 0xf52
+        None,                                    // 0xf53
+        None,                                    // 0xf60
+        None,                                    // 0xf61
+        None,                                    // 0xf62
+        None,                                    // 0xf63
+        None,                                    // 0xf70
+        None,                                    // 0xf71
+        None,                                    // 0xf72
+        None,                                    // 0xf73
+        None,                                    // 0xf80
+        None,                                    // 0xf81
+        None,                                    // 0xf82
+        None,                                    // 0xf83
+        None,                                    // 0xf90
+        None,                                    // 0xf91
+        None,                                    // 0xf92
+        None,                                    // 0xf93
+        None,                                    // 0xfa0
+        None,                                    // 0xfa1
+        None,                                    // 0xfa2
+        None,                                    // 0xfa3
+        None,                                    // 0xfb0
+        None,                                    // 0xfb1
+        None,                                    // 0xfb2
+        None,                                    // 0xfb3
+        None,                                    // 0xfc0
+        None,                                    // 0xfc1
+        None,                                    // 0xfc2
+        None,                                    // 0xfc3
+        None,                                    // 0xfd0
+        None,                                    // 0xfd1
+        None,                                    // 0xfd2
+        None,                                    // 0xfd3
+        None,                                    // 0xfe0
+        None,                                    // 0xfe1
+        None,                                    // 0xfe2
+        None,                                    // 0xfe3
+        None,                                    // 0xff0
+        None,                                    // 0xff1
+        None,                                    // 0xff2
+        None,                                    // 0xff3
+    };
+
+    static const InstrForm instrFormXOPA[1024]
+    {
+        None,                                    // 0x000
+        None,                                    // 0x001
+        None,                                    // 0x002
+        None,                                    // 0x003
+        None,                                    // 0x010
+        None,                                    // 0x011
+        None,                                    // 0x012
+        None,                                    // 0x013
+        None,                                    // 0x020
+        None,                                    // 0x021
+        None,                                    // 0x022
+        None,                                    // 0x023
+        None,                                    // 0x030
+        None,                                    // 0x031
+        None,                                    // 0x032
+        None,                                    // 0x033
+        None,                                    // 0x040
+        None,                                    // 0x041
+        None,                                    // 0x042
+        None,                                    // 0x043
+        None,                                    // 0x050
+        None,                                    // 0x051
+        None,                                    // 0x052
+        None,                                    // 0x053
+        None,                                    // 0x060
+        None,                                    // 0x061
+        None,                                    // 0x062
+        None,                                    // 0x063
+        None,                                    // 0x070
+        None,                                    // 0x071
+        None,                                    // 0x072
+        None,                                    // 0x073
+        None,                                    // 0x080
+        None,                                    // 0x081
+        None,                                    // 0x082
+        None,                                    // 0x083
+        None,                                    // 0x090
+        None,                                    // 0x091
+        None,                                    // 0x092
+        None,                                    // 0x093
+        None,                                    // 0x0a0
+        None,                                    // 0x0a1
+        None,                                    // 0x0a2
+        None,                                    // 0x0a3
+        None,                                    // 0x0b0
+        None,                                    // 0x0b1
+        None,                                    // 0x0b2
+        None,                                    // 0x0b3
+        None,                                    // 0x0c0
+        None,                                    // 0x0c1
+        None,                                    // 0x0c2
+        None,                                    // 0x0c3
+        None,                                    // 0x0d0
+        None,                                    // 0x0d1
+        None,                                    // 0x0d2
+        None,                                    // 0x0d3
+        None,                                    // 0x0e0
+        None,                                    // 0x0e1
+        None,                                    // 0x0e2
+        None,                                    // 0x0e3
+        None,                                    // 0x0f0
+        None,                                    // 0x0f1
+        None,                                    // 0x0f2
+        None,                                    // 0x0f3
+        MOp_I4B_W_M8B_or_M4B,                    // 0x100 bextr
+        MOp_I4B_W_M8B_or_M4B,                    // 0x101 bextr
+        MOp_I4B_W_M8B_or_M4B,                    // 0x102 bextr
+        MOp_I4B_W_M8B_or_M4B,                    // 0x103 bextr
+        None,                                    // 0x110
+        None,                                    // 0x111
+        None,                                    // 0x112
+        None,                                    // 0x113
+        MOp_M4B_I4B,                             // 0x120 lwpins,lwpval
+        MOp_M4B_I4B,                             // 0x121 lwpins,lwpval
+        MOp_M4B_I4B,                             // 0x122 lwpins,lwpval
+        None,                                    // 0x123
+        None,                                    // 0x130
+        None,                                    // 0x131
+        None,                                    // 0x132
+        None,                                    // 0x133
+        None,                                    // 0x140
+        None,                                    // 0x141
+        None,                                    // 0x142
+        None,                                    // 0x143
+        None,                                    // 0x150
+        None,                                    // 0x151
+        None,                                    // 0x152
+        None,                                    // 0x153
+        None,                                    // 0x160
+        None,                                    // 0x161
+        None,                                    // 0x162
+        None,                                    // 0x163
+        None,                                    // 0x170
+        None,                                    // 0x171
+        None,                                    // 0x172
+        None,                                    // 0x173
+        None,                                    // 0x180
+        None,                                    // 0x181
+        None,                                    // 0x182
+        None,                                    // 0x183
+        None,                                    // 0x190
+        None,                                    // 0x191
+        None,                                    // 0x192
+        None,                                    // 0x193
+        None,                                    // 0x1a0
+        None,                                    // 0x1a1
+        None,                                    // 0x1a2
+        None,                                    // 0x1a3
+        None,                                    // 0x1b0
+        None,                                    // 0x1b1
+        None,                                    // 0x1b2
+        None,                                    // 0x1b3
+        None,                                    // 0x1c0
+        None,                                    // 0x1c1
+        None,                                    // 0x1c2
+        None,                                    // 0x1c3
+        None,                                    // 0x1d0
+        None,                                    // 0x1d1
+        None,                                    // 0x1d2
+        None,                                    // 0x1d3
+        None,                                    // 0x1e0
+        None,                                    // 0x1e1
+        None,                                    // 0x1e2
+        None,                                    // 0x1e3
+        None,                                    // 0x1f0
+        None,                                    // 0x1f1
+        None,                                    // 0x1f2
+        None,                                    // 0x1f3
+        None,                                    // 0x200
+        None,                                    // 0x201
+        None,                                    // 0x202
+        None,                                    // 0x203
+        None,                                    // 0x210
+        None,                                    // 0x211
+        None,                                    // 0x212
+        None,                                    // 0x213
+        None,                                    // 0x220
+        None,                                    // 0x221
+        None,                                    // 0x222
+        None,                                    // 0x223
+        None,                                    // 0x230
+        None,                                    // 0x231
+        None,                                    // 0x232
+        None,                                    // 0x233
+        None,                                    // 0x240
+        None,                                    // 0x241
+        None,                                    // 0x242
+        None,                                    // 0x243
+        None,                                    // 0x250
+        None,                                    // 0x251
+        None,                                    // 0x252
+        None,                                    // 0x253
+        None,                                    // 0x260
+        None,                                    // 0x261
+        None,                                    // 0x262
+        None,                                    // 0x263
+        None,                                    // 0x270
+        None,                                    // 0x271
+        None,                                    // 0x272
+        None,                                    // 0x273
+        None,                                    // 0x280
+        None,                                    // 0x281
+        None,                                    // 0x282
+        None,                                    // 0x283
+        None,                                    // 0x290
+        None,                                    // 0x291
+        None,                                    // 0x292
+        None,                                    // 0x293
+        None,                                    // 0x2a0
+        None,                                    // 0x2a1
+        None,                                    // 0x2a2
+        None,                                    // 0x2a3
+        None,                                    // 0x2b0
+        None,                                    // 0x2b1
+        None,                                    // 0x2b2
+        None,                                    // 0x2b3
+        None,                                    // 0x2c0
+        None,                                    // 0x2c1
+        None,                                    // 0x2c2
+        None,                                    // 0x2c3
+        None,                                    // 0x2d0
+        None,                                    // 0x2d1
+        None,                                    // 0x2d2
+        None,                                    // 0x2d3
+        None,                                    // 0x2e0
+        None,                                    // 0x2e1
+        None,                                    // 0x2e2
+        None,                                    // 0x2e3
+        None,                                    // 0x2f0
+        None,                                    // 0x2f1
+        None,                                    // 0x2f2
+        None,                                    // 0x2f3
+        None,                                    // 0x300
+        None,                                    // 0x301
+        None,                                    // 0x302
+        None,                                    // 0x303
+        None,                                    // 0x310
+        None,                                    // 0x311
+        None,                                    // 0x312
+        None,                                    // 0x313
+        None,                                    // 0x320
+        None,                                    // 0x321
+        None,                                    // 0x322
+        None,                                    // 0x323
+        None,                                    // 0x330
+        None,                                    // 0x331
+        None,                                    // 0x332
+        None,                                    // 0x333
+        None,                                    // 0x340
+        None,                                    // 0x341
+        None,                                    // 0x342
+        None,                                    // 0x343
+        None,                                    // 0x350
+        None,                                    // 0x351
+        None,                                    // 0x352
+        None,                                    // 0x353
+        None,                                    // 0x360
+        None,                                    // 0x361
+        None,                                    // 0x362
+        None,                                    // 0x363
+        None,                                    // 0x370
+        None,                                    // 0x371
+        None,                                    // 0x372
+        None,                                    // 0x373
+        None,                                    // 0x380
+        None,                                    // 0x381
+        None,                                    // 0x382
+        None,                                    // 0x383
+        None,                                    // 0x390
+        None,                                    // 0x391
+        None,                                    // 0x392
+        None,                                    // 0x393
+        None,                                    // 0x3a0
+        None,                                    // 0x3a1
+        None,                                    // 0x3a2
+        None,                                    // 0x3a3
+        None,                                    // 0x3b0
+        None,                                    // 0x3b1
+        None,                                    // 0x3b2
+        None,                                    // 0x3b3
+        None,                                    // 0x3c0
+        None,                                    // 0x3c1
+        None,                                    // 0x3c2
+        None,                                    // 0x3c3
+        None,                                    // 0x3d0
+        None,                                    // 0x3d1
+        None,                                    // 0x3d2
+        None,                                    // 0x3d3
+        None,                                    // 0x3e0
+        None,                                    // 0x3e1
+        None,                                    // 0x3e2
+        None,                                    // 0x3e3
+        None,                                    // 0x3f0
+        None,                                    // 0x3f1
+        None,                                    // 0x3f2
+        None,                                    // 0x3f3
+        None,                                    // 0x400
+        None,                                    // 0x401
+        None,                                    // 0x402
+        None,                                    // 0x403
+        None,                                    // 0x410
+        None,                                    // 0x411
+        None,                                    // 0x412
+        None,                                    // 0x413
+        None,                                    // 0x420
+        None,                                    // 0x421
+        None,                                    // 0x422
+        None,                                    // 0x423
+        None,                                    // 0x430
+        None,                                    // 0x431
+        None,                                    // 0x432
+        None,                                    // 0x433
+        None,                                    // 0x440
+        None,                                    // 0x441
+        None,                                    // 0x442
+        None,                                    // 0x443
+        None,                                    // 0x450
+        None,                                    // 0x451
+        None,                                    // 0x452
+        None,                                    // 0x453
+        None,                                    // 0x460
+        None,                                    // 0x461
+        None,                                    // 0x462
+        None,                                    // 0x463
+        None,                                    // 0x470
+        None,                                    // 0x471
+        None,                                    // 0x472
+        None,                                    // 0x473
+        None,                                    // 0x480
+        None,                                    // 0x481
+        None,                                    // 0x482
+        None,                                    // 0x483
+        None,                                    // 0x490
+        None,                                    // 0x491
+        None,                                    // 0x492
+        None,                                    // 0x493
+        None,                                    // 0x4a0
+        None,                                    // 0x4a1
+        None,                                    // 0x4a2
+        None,                                    // 0x4a3
+        None,                                    // 0x4b0
+        None,                                    // 0x4b1
+        None,                                    // 0x4b2
+        None,                                    // 0x4b3
+        None,                                    // 0x4c0
+        None,                                    // 0x4c1
+        None,                                    // 0x4c2
+        None,                                    // 0x4c3
+        None,                                    // 0x4d0
+        None,                                    // 0x4d1
+        None,                                    // 0x4d2
+        None,                                    // 0x4d3
+        None,                                    // 0x4e0
+        None,                                    // 0x4e1
+        None,                                    // 0x4e2
+        None,                                    // 0x4e3
+        None,                                    // 0x4f0
+        None,                                    // 0x4f1
+        None,                                    // 0x4f2
+        None,                                    // 0x4f3
+        None,                                    // 0x500
+        None,                                    // 0x501
+        None,                                    // 0x502
+        None,                                    // 0x503
+        None,                                    // 0x510
+        None,                                    // 0x511
+        None,                                    // 0x512
+        None,                                    // 0x513
+        None,                                    // 0x520
+        None,                                    // 0x521
+        None,                                    // 0x522
+        None,                                    // 0x523
+        None,                                    // 0x530
+        None,                                    // 0x531
+        None,                                    // 0x532
+        None,                                    // 0x533
+        None,                                    // 0x540
+        None,                                    // 0x541
+        None,                                    // 0x542
+        None,                                    // 0x543
+        None,                                    // 0x550
+        None,                                    // 0x551
+        None,                                    // 0x552
+        None,                                    // 0x553
+        None,                                    // 0x560
+        None,                                    // 0x561
+        None,                                    // 0x562
+        None,                                    // 0x563
+        None,                                    // 0x570
+        None,                                    // 0x571
+        None,                                    // 0x572
+        None,                                    // 0x573
+        None,                                    // 0x580
+        None,                                    // 0x581
+        None,                                    // 0x582
+        None,                                    // 0x583
+        None,                                    // 0x590
+        None,                                    // 0x591
+        None,                                    // 0x592
+        None,                                    // 0x593
+        None,                                    // 0x5a0
+        None,                                    // 0x5a1
+        None,                                    // 0x5a2
+        None,                                    // 0x5a3
+        None,                                    // 0x5b0
+        None,                                    // 0x5b1
+        None,                                    // 0x5b2
+        None,                                    // 0x5b3
+        None,                                    // 0x5c0
+        None,                                    // 0x5c1
+        None,                                    // 0x5c2
+        None,                                    // 0x5c3
+        None,                                    // 0x5d0
+        None,                                    // 0x5d1
+        None,                                    // 0x5d2
+        None,                                    // 0x5d3
+        None,                                    // 0x5e0
+        None,                                    // 0x5e1
+        None,                                    // 0x5e2
+        None,                                    // 0x5e3
+        None,                                    // 0x5f0
+        None,                                    // 0x5f1
+        None,                                    // 0x5f2
+        None,                                    // 0x5f3
+        None,                                    // 0x600
+        None,                                    // 0x601
+        None,                                    // 0x602
+        None,                                    // 0x603
+        None,                                    // 0x610
+        None,                                    // 0x611
+        None,                                    // 0x612
+        None,                                    // 0x613
+        None,                                    // 0x620
+        None,                                    // 0x621
+        None,                                    // 0x622
+        None,                                    // 0x623
+        None,                                    // 0x630
+        None,                                    // 0x631
+        None,                                    // 0x632
+        None,                                    // 0x633
+        None,                                    // 0x640
+        None,                                    // 0x641
+        None,                                    // 0x642
+        None,                                    // 0x643
+        None,                                    // 0x650
+        None,                                    // 0x651
+        None,                                    // 0x652
+        None,                                    // 0x653
+        None,                                    // 0x660
+        None,                                    // 0x661
+        None,                                    // 0x662
+        None,                                    // 0x663
+        None,                                    // 0x670
+        None,                                    // 0x671
+        None,                                    // 0x672
+        None,                                    // 0x673
+        None,                                    // 0x680
+        None,                                    // 0x681
+        None,                                    // 0x682
+        None,                                    // 0x683
+        None,                                    // 0x690
+        None,                                    // 0x691
+        None,                                    // 0x692
+        None,                                    // 0x693
+        None,                                    // 0x6a0
+        None,                                    // 0x6a1
+        None,                                    // 0x6a2
+        None,                                    // 0x6a3
+        None,                                    // 0x6b0
+        None,                                    // 0x6b1
+        None,                                    // 0x6b2
+        None,                                    // 0x6b3
+        None,                                    // 0x6c0
+        None,                                    // 0x6c1
+        None,                                    // 0x6c2
+        None,                                    // 0x6c3
+        None,                                    // 0x6d0
+        None,                                    // 0x6d1
+        None,                                    // 0x6d2
+        None,                                    // 0x6d3
+        None,                                    // 0x6e0
+        None,                                    // 0x6e1
+        None,                                    // 0x6e2
+        None,                                    // 0x6e3
+        None,                                    // 0x6f0
+        None,                                    // 0x6f1
+        None,                                    // 0x6f2
+        None,                                    // 0x6f3
+        None,                                    // 0x700
+        None,                                    // 0x701
+        None,                                    // 0x702
+        None,                                    // 0x703
+        None,                                    // 0x710
+        None,                                    // 0x711
+        None,                                    // 0x712
+        None,                                    // 0x713
+        None,                                    // 0x720
+        None,                                    // 0x721
+        None,                                    // 0x722
+        None,                                    // 0x723
+        None,                                    // 0x730
+        None,                                    // 0x731
+        None,                                    // 0x732
+        None,                                    // 0x733
+        None,                                    // 0x740
+        None,                                    // 0x741
+        None,                                    // 0x742
+        None,                                    // 0x743
+        None,                                    // 0x750
+        None,                                    // 0x751
+        None,                                    // 0x752
+        None,                                    // 0x753
+        None,                                    // 0x760
+        None,                                    // 0x761
+        None,                                    // 0x762
+        None,                                    // 0x763
+        None,                                    // 0x770
+        None,                                    // 0x771
+        None,                                    // 0x772
+        None,                                    // 0x773
+        None,                                    // 0x780
+        None,                                    // 0x781
+        None,                                    // 0x782
+        None,                                    // 0x783
+        None,                                    // 0x790
+        None,                                    // 0x791
+        None,                                    // 0x792
+        None,                                    // 0x793
+        None,                                    // 0x7a0
+        None,                                    // 0x7a1
+        None,                                    // 0x7a2
+        None,                                    // 0x7a3
+        None,                                    // 0x7b0
+        None,                                    // 0x7b1
+        None,                                    // 0x7b2
+        None,                                    // 0x7b3
+        None,                                    // 0x7c0
+        None,                                    // 0x7c1
+        None,                                    // 0x7c2
+        None,                                    // 0x7c3
+        None,                                    // 0x7d0
+        None,                                    // 0x7d1
+        None,                                    // 0x7d2
+        None,                                    // 0x7d3
+        None,                                    // 0x7e0
+        None,                                    // 0x7e1
+        None,                                    // 0x7e2
+        None,                                    // 0x7e3
+        None,                                    // 0x7f0
+        None,                                    // 0x7f1
+        None,                                    // 0x7f2
+        None,                                    // 0x7f3
+        None,                                    // 0x800
+        None,                                    // 0x801
+        None,                                    // 0x802
+        None,                                    // 0x803
+        None,                                    // 0x810
+        None,                                    // 0x811
+        None,                                    // 0x812
+        None,                                    // 0x813
+        None,                                    // 0x820
+        None,                                    // 0x821
+        None,                                    // 0x822
+        None,                                    // 0x823
+        None,                                    // 0x830
+        None,                                    // 0x831
+        None,                                    // 0x832
+        None,                                    // 0x833
+        None,                                    // 0x840
+        None,                                    // 0x841
+        None,                                    // 0x842
+        None,                                    // 0x843
+        None,                                    // 0x850
+        None,                                    // 0x851
+        None,                                    // 0x852
+        None,                                    // 0x853
+        None,                                    // 0x860
+        None,                                    // 0x861
+        None,                                    // 0x862
+        None,                                    // 0x863
+        None,                                    // 0x870
+        None,                                    // 0x871
+        None,                                    // 0x872
+        None,                                    // 0x873
+        None,                                    // 0x880
+        None,                                    // 0x881
+        None,                                    // 0x882
+        None,                                    // 0x883
+        None,                                    // 0x890
+        None,                                    // 0x891
+        None,                                    // 0x892
+        None,                                    // 0x893
+        None,                                    // 0x8a0
+        None,                                    // 0x8a1
+        None,                                    // 0x8a2
+        None,                                    // 0x8a3
+        None,                                    // 0x8b0
+        None,                                    // 0x8b1
+        None,                                    // 0x8b2
+        None,                                    // 0x8b3
+        None,                                    // 0x8c0
+        None,                                    // 0x8c1
+        None,                                    // 0x8c2
+        None,                                    // 0x8c3
+        None,                                    // 0x8d0
+        None,                                    // 0x8d1
+        None,                                    // 0x8d2
+        None,                                    // 0x8d3
+        None,                                    // 0x8e0
+        None,                                    // 0x8e1
+        None,                                    // 0x8e2
+        None,                                    // 0x8e3
+        None,                                    // 0x8f0
+        None,                                    // 0x8f1
+        None,                                    // 0x8f2
+        None,                                    // 0x8f3
+        None,                                    // 0x900
+        None,                                    // 0x901
+        None,                                    // 0x902
+        None,                                    // 0x903
+        None,                                    // 0x910
+        None,                                    // 0x911
+        None,                                    // 0x912
+        None,                                    // 0x913
+        None,                                    // 0x920
+        None,                                    // 0x921
+        None,                                    // 0x922
+        None,                                    // 0x923
+        None,                                    // 0x930
+        None,                                    // 0x931
+        None,                                    // 0x932
+        None,                                    // 0x933
+        None,                                    // 0x940
+        None,                                    // 0x941
+        None,                                    // 0x942
+        None,                                    // 0x943
+        None,                                    // 0x950
+        None,                                    // 0x951
+        None,                                    // 0x952
+        None,                                    // 0x953
+        None,                                    // 0x960
+        None,                                    // 0x961
+        None,                                    // 0x962
+        None,                                    // 0x963
+        None,                                    // 0x970
+        None,                                    // 0x971
+        None,                                    // 0x972
+        None,                                    // 0x973
+        None,                                    // 0x980
+        None,                                    // 0x981
+        None,                                    // 0x982
+        None,                                    // 0x983
+        None,                                    // 0x990
+        None,                                    // 0x991
+        None,                                    // 0x992
+        None,                                    // 0x993
+        None,                                    // 0x9a0
+        None,                                    // 0x9a1
+        None,                                    // 0x9a2
+        None,                                    // 0x9a3
+        None,                                    // 0x9b0
+        None,                                    // 0x9b1
+        None,                                    // 0x9b2
+        None,                                    // 0x9b3
+        None,                                    // 0x9c0
+        None,                                    // 0x9c1
+        None,                                    // 0x9c2
+        None,                                    // 0x9c3
+        None,                                    // 0x9d0
+        None,                                    // 0x9d1
+        None,                                    // 0x9d2
+        None,                                    // 0x9d3
+        None,                                    // 0x9e0
+        None,                                    // 0x9e1
+        None,                                    // 0x9e2
+        None,                                    // 0x9e3
+        None,                                    // 0x9f0
+        None,                                    // 0x9f1
+        None,                                    // 0x9f2
+        None,                                    // 0x9f3
+        None,                                    // 0xa00
+        None,                                    // 0xa01
+        None,                                    // 0xa02
+        None,                                    // 0xa03
+        None,                                    // 0xa10
+        None,                                    // 0xa11
+        None,                                    // 0xa12
+        None,                                    // 0xa13
+        None,                                    // 0xa20
+        None,                                    // 0xa21
+        None,                                    // 0xa22
+        None,                                    // 0xa23
+        None,                                    // 0xa30
+        None,                                    // 0xa31
+        None,                                    // 0xa32
+        None,                                    // 0xa33
+        None,                                    // 0xa40
+        None,                                    // 0xa41
+        None,                                    // 0xa42
+        None,                                    // 0xa43
+        None,                                    // 0xa50
+        None,                                    // 0xa51
+        None,                                    // 0xa52
+        None,                                    // 0xa53
+        None,                                    // 0xa60
+        None,                                    // 0xa61
+        None,                                    // 0xa62
+        None,                                    // 0xa63
+        None,                                    // 0xa70
+        None,                                    // 0xa71
+        None,                                    // 0xa72
+        None,                                    // 0xa73
+        None,                                    // 0xa80
+        None,                                    // 0xa81
+        None,                                    // 0xa82
+        None,                                    // 0xa83
+        None,                                    // 0xa90
+        None,                                    // 0xa91
+        None,                                    // 0xa92
+        None,                                    // 0xa93
+        None,                                    // 0xaa0
+        None,                                    // 0xaa1
+        None,                                    // 0xaa2
+        None,                                    // 0xaa3
+        None,                                    // 0xab0
+        None,                                    // 0xab1
+        None,                                    // 0xab2
+        None,                                    // 0xab3
+        None,                                    // 0xac0
+        None,                                    // 0xac1
+        None,                                    // 0xac2
+        None,                                    // 0xac3
+        None,                                    // 0xad0
+        None,                                    // 0xad1
+        None,                                    // 0xad2
+        None,                                    // 0xad3
+        None,                                    // 0xae0
+        None,                                    // 0xae1
+        None,                                    // 0xae2
+        None,                                    // 0xae3
+        None,                                    // 0xaf0
+        None,                                    // 0xaf1
+        None,                                    // 0xaf2
+        None,                                    // 0xaf3
+        None,                                    // 0xb00
+        None,                                    // 0xb01
+        None,                                    // 0xb02
+        None,                                    // 0xb03
+        None,                                    // 0xb10
+        None,                                    // 0xb11
+        None,                                    // 0xb12
+        None,                                    // 0xb13
+        None,                                    // 0xb20
+        None,                                    // 0xb21
+        None,                                    // 0xb22
+        None,                                    // 0xb23
+        None,                                    // 0xb30
+        None,                                    // 0xb31
+        None,                                    // 0xb32
+        None,                                    // 0xb33
+        None,                                    // 0xb40
+        None,                                    // 0xb41
+        None,                                    // 0xb42
+        None,                                    // 0xb43
+        None,                                    // 0xb50
+        None,                                    // 0xb51
+        None,                                    // 0xb52
+        None,                                    // 0xb53
+        None,                                    // 0xb60
+        None,                                    // 0xb61
+        None,                                    // 0xb62
+        None,                                    // 0xb63
+        None,                                    // 0xb70
+        None,                                    // 0xb71
+        None,                                    // 0xb72
+        None,                                    // 0xb73
+        None,                                    // 0xb80
+        None,                                    // 0xb81
+        None,                                    // 0xb82
+        None,                                    // 0xb83
+        None,                                    // 0xb90
+        None,                                    // 0xb91
+        None,                                    // 0xb92
+        None,                                    // 0xb93
+        None,                                    // 0xba0
+        None,                                    // 0xba1
+        None,                                    // 0xba2
+        None,                                    // 0xba3
+        None,                                    // 0xbb0
+        None,                                    // 0xbb1
+        None,                                    // 0xbb2
+        None,                                    // 0xbb3
+        None,                                    // 0xbc0
+        None,                                    // 0xbc1
+        None,                                    // 0xbc2
+        None,                                    // 0xbc3
+        None,                                    // 0xbd0
+        None,                                    // 0xbd1
+        None,                                    // 0xbd2
+        None,                                    // 0xbd3
+        None,                                    // 0xbe0
+        None,                                    // 0xbe1
+        None,                                    // 0xbe2
+        None,                                    // 0xbe3
+        None,                                    // 0xbf0
+        None,                                    // 0xbf1
+        None,                                    // 0xbf2
+        None,                                    // 0xbf3
+        None,                                    // 0xc00
+        None,                                    // 0xc01
+        None,                                    // 0xc02
+        None,                                    // 0xc03
+        None,                                    // 0xc10
+        None,                                    // 0xc11
+        None,                                    // 0xc12
+        None,                                    // 0xc13
+        None,                                    // 0xc20
+        None,                                    // 0xc21
+        None,                                    // 0xc22
+        None,                                    // 0xc23
+        None,                                    // 0xc30
+        None,                                    // 0xc31
+        None,                                    // 0xc32
+        None,                                    // 0xc33
+        None,                                    // 0xc40
+        None,                                    // 0xc41
+        None,                                    // 0xc42
+        None,                                    // 0xc43
+        None,                                    // 0xc50
+        None,                                    // 0xc51
+        None,                                    // 0xc52
+        None,                                    // 0xc53
+        None,                                    // 0xc60
+        None,                                    // 0xc61
+        None,                                    // 0xc62
+        None,                                    // 0xc63
+        None,                                    // 0xc70
+        None,                                    // 0xc71
+        None,                                    // 0xc72
+        None,                                    // 0xc73
+        None,                                    // 0xc80
+        None,                                    // 0xc81
+        None,                                    // 0xc82
+        None,                                    // 0xc83
+        None,                                    // 0xc90
+        None,                                    // 0xc91
+        None,                                    // 0xc92
+        None,                                    // 0xc93
+        None,                                    // 0xca0
+        None,                                    // 0xca1
+        None,                                    // 0xca2
+        None,                                    // 0xca3
+        None,                                    // 0xcb0
+        None,                                    // 0xcb1
+        None,                                    // 0xcb2
+        None,                                    // 0xcb3
+        None,                                    // 0xcc0
+        None,                                    // 0xcc1
+        None,                                    // 0xcc2
+        None,                                    // 0xcc3
+        None,                                    // 0xcd0
+        None,                                    // 0xcd1
+        None,                                    // 0xcd2
+        None,                                    // 0xcd3
+        None,                                    // 0xce0
+        None,                                    // 0xce1
+        None,                                    // 0xce2
+        None,                                    // 0xce3
+        None,                                    // 0xcf0
+        None,                                    // 0xcf1
+        None,                                    // 0xcf2
+        None,                                    // 0xcf3
+        None,                                    // 0xd00
+        None,                                    // 0xd01
+        None,                                    // 0xd02
+        None,                                    // 0xd03
+        None,                                    // 0xd10
+        None,                                    // 0xd11
+        None,                                    // 0xd12
+        None,                                    // 0xd13
+        None,                                    // 0xd20
+        None,                                    // 0xd21
+        None,                                    // 0xd22
+        None,                                    // 0xd23
+        None,                                    // 0xd30
+        None,                                    // 0xd31
+        None,                                    // 0xd32
+        None,                                    // 0xd33
+        None,                                    // 0xd40
+        None,                                    // 0xd41
+        None,                                    // 0xd42
+        None,                                    // 0xd43
+        None,                                    // 0xd50
+        None,                                    // 0xd51
+        None,                                    // 0xd52
+        None,                                    // 0xd53
+        None,                                    // 0xd60
+        None,                                    // 0xd61
+        None,                                    // 0xd62
+        None,                                    // 0xd63
+        None,                                    // 0xd70
+        None,                                    // 0xd71
+        None,                                    // 0xd72
+        None,                                    // 0xd73
+        None,                                    // 0xd80
+        None,                                    // 0xd81
+        None,                                    // 0xd82
+        None,                                    // 0xd83
+        None,                                    // 0xd90
+        None,                                    // 0xd91
+        None,                                    // 0xd92
+        None,                                    // 0xd93
+        None,                                    // 0xda0
+        None,                                    // 0xda1
+        None,                                    // 0xda2
+        None,                                    // 0xda3
+        None,                                    // 0xdb0
+        None,                                    // 0xdb1
+        None,                                    // 0xdb2
+        None,                                    // 0xdb3
+        None,                                    // 0xdc0
+        None,                                    // 0xdc1
+        None,                                    // 0xdc2
+        None,                                    // 0xdc3
+        None,                                    // 0xdd0
+        None,                                    // 0xdd1
+        None,                                    // 0xdd2
+        None,                                    // 0xdd3
+        None,                                    // 0xde0
+        None,                                    // 0xde1
+        None,                                    // 0xde2
+        None,                                    // 0xde3
+        None,                                    // 0xdf0
+        None,                                    // 0xdf1
+        None,                                    // 0xdf2
+        None,                                    // 0xdf3
+        None,                                    // 0xe00
+        None,                                    // 0xe01
+        None,                                    // 0xe02
+        None,                                    // 0xe03
+        None,                                    // 0xe10
+        None,                                    // 0xe11
+        None,                                    // 0xe12
+        None,                                    // 0xe13
+        None,                                    // 0xe20
+        None,                                    // 0xe21
+        None,                                    // 0xe22
+        None,                                    // 0xe23
+        None,                                    // 0xe30
+        None,                                    // 0xe31
+        None,                                    // 0xe32
+        None,                                    // 0xe33
+        None,                                    // 0xe40
+        None,                                    // 0xe41
+        None,                                    // 0xe42
+        None,                                    // 0xe43
+        None,                                    // 0xe50
+        None,                                    // 0xe51
+        None,                                    // 0xe52
+        None,                                    // 0xe53
+        None,                                    // 0xe60
+        None,                                    // 0xe61
+        None,                                    // 0xe62
+        None,                                    // 0xe63
+        None,                                    // 0xe70
+        None,                                    // 0xe71
+        None,                                    // 0xe72
+        None,                                    // 0xe73
+        None,                                    // 0xe80
+        None,                                    // 0xe81
+        None,                                    // 0xe82
+        None,                                    // 0xe83
+        None,                                    // 0xe90
+        None,                                    // 0xe91
+        None,                                    // 0xe92
+        None,                                    // 0xe93
+        None,                                    // 0xea0
+        None,                                    // 0xea1
+        None,                                    // 0xea2
+        None,                                    // 0xea3
+        None,                                    // 0xeb0
+        None,                                    // 0xeb1
+        None,                                    // 0xeb2
+        None,                                    // 0xeb3
+        None,                                    // 0xec0
+        None,                                    // 0xec1
+        None,                                    // 0xec2
+        None,                                    // 0xec3
+        None,                                    // 0xed0
+        None,                                    // 0xed1
+        None,                                    // 0xed2
+        None,                                    // 0xed3
+        None,                                    // 0xee0
+        None,                                    // 0xee1
+        None,                                    // 0xee2
+        None,                                    // 0xee3
+        None,                                    // 0xef0
+        None,                                    // 0xef1
+        None,                                    // 0xef2
+        None,                                    // 0xef3
+        None,                                    // 0xf00
+        None,                                    // 0xf01
+        None,                                    // 0xf02
+        None,                                    // 0xf03
+        None,                                    // 0xf10
+        None,                                    // 0xf11
+        None,                                    // 0xf12
+        None,                                    // 0xf13
+        None,                                    // 0xf20
+        None,                                    // 0xf21
+        None,                                    // 0xf22
+        None,                                    // 0xf23
+        None,                                    // 0xf30
+        None,                                    // 0xf31
+        None,                                    // 0xf32
+        None,                                    // 0xf33
+        None,                                    // 0xf40
+        None,                                    // 0xf41
+        None,                                    // 0xf42
+        None,                                    // 0xf43
+        None,                                    // 0xf50
+        None,                                    // 0xf51
+        None,                                    // 0xf52
+        None,                                    // 0xf53
+        None,                                    // 0xf60
+        None,                                    // 0xf61
+        None,                                    // 0xf62
+        None,                                    // 0xf63
+        None,                                    // 0xf70
+        None,                                    // 0xf71
+        None,                                    // 0xf72
+        None,                                    // 0xf73
+        None,                                    // 0xf80
+        None,                                    // 0xf81
+        None,                                    // 0xf82
+        None,                                    // 0xf83
+        None,                                    // 0xf90
+        None,                                    // 0xf91
+        None,                                    // 0xf92
+        None,                                    // 0xf93
+        None,                                    // 0xfa0
+        None,                                    // 0xfa1
+        None,                                    // 0xfa2
+        None,                                    // 0xfa3
+        None,                                    // 0xfb0
+        None,                                    // 0xfb1
+        None,                                    // 0xfb2
+        None,                                    // 0xfb3
+        None,                                    // 0xfc0
+        None,                                    // 0xfc1
+        None,                                    // 0xfc2
+        None,                                    // 0xfc3
+        None,                                    // 0xfd0
+        None,                                    // 0xfd1
+        None,                                    // 0xfd2
+        None,                                    // 0xfd3
+        None,                                    // 0xfe0
+        None,                                    // 0xfe1
+        None,                                    // 0xfe2
+        None,                                    // 0xfe3
+        None,                                    // 0xff0
+        None,                                    // 0xff1
+        None,                                    // 0xff2
+        None,                                    // 0xff3
+    };
+}

--- a/src/debug/ee/amd64/amd64walker.cpp
+++ b/src/debug/ee/amd64/amd64walker.cpp
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 //*****************************************************************************
 // File: Amd64walker.cpp
-// 
+//
 
 //
 // AMD64 instruction decoding/stepping logic
@@ -16,6 +16,7 @@
 
 #include "frames.h"
 #include "openum.h"
+#include "amd64InstrDecode.h"
 
 #ifdef _TARGET_AMD64_
 
@@ -32,7 +33,7 @@ void NativeWalker::Decode()
     m_nextIP = NULL;
 
     BYTE rex = NULL;
-    
+
     LOG((LF_CORDB, LL_INFO100000, "NW:Decode: m_ip 0x%x\n", m_ip));
 
     BYTE prefix = *ip;
@@ -45,7 +46,7 @@ void NativeWalker::Decode()
     //
     // Skip instruction prefixes
     //
-    do 
+    do
     {
         switch (prefix)
         {
@@ -53,7 +54,7 @@ void NativeWalker::Decode()
         case 0x26: // ES
         case 0x2E: // CS
         case 0x36: // SS
-        case 0x3E: // DS 
+        case 0x3E: // DS
         case 0x64: // FS
         case 0x65: // GS
 
@@ -66,13 +67,13 @@ void NativeWalker::Decode()
 
         // String REP prefixes
         case 0xf2: // REPNE/REPNZ
-        case 0xf3: 
+        case 0xf3:
             LOG((LF_CORDB, LL_INFO10000, "NW:Decode: prefix:%0.2x ", prefix));
             ip++;
             continue;
 
         // REX register extension prefixes
-        case 0x40:            
+        case 0x40:
         case 0x41:
         case 0x42:
         case 0x43:
@@ -89,7 +90,7 @@ void NativeWalker::Decode()
         case 0x4e:
         case 0x4f:
             LOG((LF_CORDB, LL_INFO10000, "NW:Decode: REX prefix:%0.2x ", prefix));
-            // make sure to set rex to prefix, not *ip because *ip still represents the 
+            // make sure to set rex to prefix, not *ip because *ip still represents the
             // codestream which has a 0xcc in it.
             rex = prefix;
             ip++;
@@ -106,7 +107,7 @@ void NativeWalker::Decode()
     LOG((LF_CORDB, LL_INFO100000, "NW:Decode: ip 0x%x, m_opcode:%0.2x\n", ip, m_opcode));
 
     // Don't remove this, when we did the check above for the prefix we didn't modify the codestream
-    // and since m_opcode was just taken directly from the code stream it will be patched if we 
+    // and since m_opcode was just taken directly from the code stream it will be patched if we
     // didn't have a prefix
     if (m_opcode == 0xcc)
     {
@@ -136,7 +137,7 @@ void NativeWalker::Decode()
             // Ignore "inc dword ptr [reg]" instructions
             if (modrm == 0)
                 break;
-            
+
             BYTE mod = (modrm & 0xC0) >> 6;
             BYTE reg = (modrm & 0x38) >> 3;
             BYTE rm  = (modrm & 0x07);
@@ -148,27 +149,27 @@ void NativeWalker::Decode()
                 // not a valid register for a CALL or BRANCH
                 return;
             }
-            
+
             BYTE *result;
             WORD displace;
 
             // See: Tables A-15,16,17 in AMD Dev Manual 3 for information
             //      about how the ModRM/SIB/REX bytes interact.
 
-            switch (mod) 
+            switch (mod)
             {
             case 0:
             case 1:
-            case 2:     
+            case 2:
                 if ((rm & 0x07) == 4) // we have an SIB byte following
-                {   
+                {
                     //
                     // Get values from the SIB byte
                     //
                     BYTE sib   = *ip;
 
                     _ASSERT(sib != NULL);
-                    
+
                     BYTE ss    = (sib & 0xC0) >> 6;
                     BYTE index = (sib & 0x38) >> 3;
                     BYTE base  = (sib & 0x07);
@@ -184,16 +185,16 @@ void NativeWalker::Decode()
                     if ((mod == 0) && ((base & 0x07) == 5))
                     {
                         result = 0;
-                    } 
-                    else 
+                    }
+                    else
                     {
                         result = (BYTE *)(size_t)GetRegisterValue(base);
-                    } 
+                    }
 
                     //
                     // Add in the [index]
                     //
-                    if (index != 0x4) 
+                    if (index != 0x4)
                     {
                         result = result + (GetRegisterValue(index) << ss);
                     }
@@ -201,55 +202,55 @@ void NativeWalker::Decode()
                     //
                     // Finally add in the offset
                     //
-                    if (mod == 0) 
+                    if (mod == 0)
                     {
-                        if ((base & 0x07) == 5) 
+                        if ((base & 0x07) == 5)
                         {
                             result = result + *((INT32*)ip);
                             displace = 7;
-                        } 
-                        else 
+                        }
+                        else
                         {
                             displace = 3;
                         }
-                    } 
-                    else if (mod == 1) 
+                    }
+                    else if (mod == 1)
                     {
                         result = result + *((INT8*)ip);
                         displace = 4;
-                    } 
+                    }
                     else // mod == 2
                     {
                         result = result + *((INT32*)ip);
                         displace = 7;
                     }
 
-                } 
-                else 
+                }
+                else
                 {
                     //
                     // Get the value we need from the register.
                     //
 
                     // Check for RIP-relative addressing mode.
-                    if ((mod == 0) && ((rm & 0x07) == 5)) 
+                    if ((mod == 0) && ((rm & 0x07) == 5))
                     {
                         displace = 6;   // 1 byte opcode + 1 byte modrm + 4 byte displacement (signed)
                         result = const_cast<BYTE *>(m_ip) + displace + *(reinterpret_cast<const INT32*>(ip));
-                    } 
-                    else 
+                    }
+                    else
                     {
                         result = (BYTE *)GetRegisterValue(rm);
 
-                        if (mod == 0) 
+                        if (mod == 0)
                         {
                             displace = 2;
-                        } 
-                        else if (mod == 1) 
+                        }
+                        else if (mod == 1)
                         {
                             result = result + *((INT8*)ip);
                             displace = 3;
-                        } 
+                        }
                         else // mod == 2
                         {
                             result = result + *((INT32*)ip);
@@ -266,7 +267,7 @@ void NativeWalker::Decode()
                 break;
 
             case 3:
-            default:            
+            default:
                 // The operand is stored in a register.
                 result = (BYTE *)GetRegisterValue(rm);
                 displace = 2;
@@ -282,19 +283,19 @@ void NativeWalker::Decode()
                 displace++;
             }
 
-            // because we already checked register validity for CALL/BRANCH 
+            // because we already checked register validity for CALL/BRANCH
             // instructions above we can assume that there is no other option
-            if ((reg == 4) || (reg == 5)) 
+            if ((reg == 4) || (reg == 5))
             {
                 m_type = WALK_BRANCH;
             }
-            else 
+            else
             {
                 m_type = WALK_CALL;
             }
             m_nextIP = result;
             m_skipIP = m_ip + displace;
-            break; 
+            break;
         }
         case 0xe8:
         {
@@ -401,80 +402,336 @@ UINT64 NativeWalker::GetRegisterValue(int registerNumber)
 
 
 //          mod     reg     r/m
-// bits     7-6     5-3     2-0 
+// bits     7-6     5-3     2-0
 struct ModRMByte
 {
+    ModRMByte(BYTE init) :
+        rm(init & 0x7),
+        reg((init >> 3) & 0x7),
+        mod(init >> 6)
+    {
+    }
+
     BYTE rm :3;
     BYTE reg:3;
     BYTE mod:2;
-}; 
-
-//         fixed    W       R       X       B
-// bits    7-4      3       2       1       0
-struct RexByte
-{
-    BYTE b:1;
-    BYTE x:1;
-    BYTE r:1;
-    BYTE w:1;
-    BYTE fixed:4;
 };
+
+static bool IsModRm(Amd64InstrDecode::InstrForm form, int pp, bool W, bool L, bool fPrefix66)
+{
+    bool modrm = true;
+
+    switch (form)
+    {
+    case Amd64InstrDecode::InstrForm::None:
+    case Amd64InstrDecode::InstrForm::I1B:
+    case Amd64InstrDecode::InstrForm::I2B:
+    case Amd64InstrDecode::InstrForm::I3B:
+    case Amd64InstrDecode::InstrForm::I4B:
+    case Amd64InstrDecode::InstrForm::I8B:
+    case Amd64InstrDecode::InstrForm::WP_I4B_or_I4B_or_I2B:
+    case Amd64InstrDecode::InstrForm::WP_I8B_or_I4B_or_I2B:
+        modrm = false;
+        break;
+    case Amd64InstrDecode::InstrForm::I1B_W_None_or_MOp_M16B:
+        modrm = W ? false : true;
+        break;
+    default:
+        if (form & Amd64InstrDecode::InstrForm::Extension)
+            modrm = true;
+        break;
+    }
+    return modrm;
+}
+
+static bool IsWrite(Amd64InstrDecode::InstrForm form, int pp, bool W, bool L, bool fPrefix66)
+{
+    bool isWrite = false;
+    switch (form)
+    {
+    case Amd64InstrDecode::InstrForm::M1st_I1B_L_M16B_or_M8B:
+    case Amd64InstrDecode::InstrForm::M1st_I1B_W_M8B_or_M4B:
+    case Amd64InstrDecode::InstrForm::M1st_I1B_WP_M8B_or_M4B_or_M2B:
+    case Amd64InstrDecode::InstrForm::M1st_L_M32B_or_M16B:
+    case Amd64InstrDecode::InstrForm::M1st_M16B:
+    case Amd64InstrDecode::InstrForm::M1st_M16B_I1B:
+    case Amd64InstrDecode::InstrForm::M1st_M1B:
+    case Amd64InstrDecode::InstrForm::M1st_M1B_I1B:
+    case Amd64InstrDecode::InstrForm::M1st_M2B:
+    case Amd64InstrDecode::InstrForm::M1st_M2B_I1B:
+    case Amd64InstrDecode::InstrForm::M1st_M4B:
+    case Amd64InstrDecode::InstrForm::M1st_M4B_I1B:
+    case Amd64InstrDecode::InstrForm::M1st_M8B:
+    case Amd64InstrDecode::InstrForm::M1st_MUnknown:
+    case Amd64InstrDecode::InstrForm::M1st_W_M4B_or_M1B:
+    case Amd64InstrDecode::InstrForm::M1st_W_M8B_or_M2B:
+    case Amd64InstrDecode::InstrForm::M1st_W_M8B_or_M4B:
+    case Amd64InstrDecode::InstrForm::M1st_WP_M8B_I4B_or_M4B_I4B_or_M2B_I2B:
+    case Amd64InstrDecode::InstrForm::M1st_WP_M8B_or_M4B_or_M2B:
+    case Amd64InstrDecode::InstrForm::MOnly_M10B:
+    case Amd64InstrDecode::InstrForm::MOnly_M1B:
+    case Amd64InstrDecode::InstrForm::MOnly_M2B:
+    case Amd64InstrDecode::InstrForm::MOnly_M4B:
+    case Amd64InstrDecode::InstrForm::MOnly_M8B:
+    case Amd64InstrDecode::InstrForm::MOnly_MUnknown:
+    case Amd64InstrDecode::InstrForm::MOnly_P_M6B_or_M4B:
+    case Amd64InstrDecode::InstrForm::MOnly_W_M16B_or_M8B:
+    case Amd64InstrDecode::InstrForm::MOnly_W_M8B_or_M4B:
+    case Amd64InstrDecode::InstrForm::MOnly_WP_M8B_or_M4B_or_M2B:
+    case Amd64InstrDecode::InstrForm::MOnly_WP_M8B_or_M8B_or_M2B:
+        isWrite = true;
+        break;
+    default:
+        break;
+    }
+    return isWrite;
+}
+
+static int opSize(Amd64InstrDecode::InstrForm form, int pp, bool W, bool L, bool fPrefix66)
+{
+    int opSize = 0;
+    bool P = !((pp == 1) || fPrefix66);
+    switch (form)
+    {
+    // M32B
+    case Amd64InstrDecode::InstrForm::MOp_M32B:
+    case Amd64InstrDecode::InstrForm::MOp_M32B_I1B:
+        opSize = 32;
+        break;
+    // L_M32B_or_M16B
+    case Amd64InstrDecode::InstrForm::M1st_L_M32B_or_M16B:
+    case Amd64InstrDecode::InstrForm::MOp_I1B_L_M32B_or_M16B:
+    case Amd64InstrDecode::InstrForm::MOp_L_M32B_or_M16B:
+        opSize = L ? 32 : 16;
+        break;
+    // L_M32B_or_M8B
+    case Amd64InstrDecode::InstrForm::MOp_L_M32B_or_M8B:
+        opSize = L ? 32 : 8;
+        break;
+    // M16B
+    case Amd64InstrDecode::InstrForm::M1st_M16B:
+    case Amd64InstrDecode::InstrForm::M1st_M16B_I1B:
+    case Amd64InstrDecode::InstrForm::MOp_M16B:
+    case Amd64InstrDecode::InstrForm::MOp_M16B_I1B:
+        opSize = 16;
+        break;
+    // L_M16B_or_M8B
+    case Amd64InstrDecode::InstrForm::M1st_I1B_L_M16B_or_M8B:
+    case Amd64InstrDecode::InstrForm::MOp_L_M16B_or_M8B:
+        opSize = L ? 16 : 8;
+        break;
+    // W_M16B_or_M8B
+    case Amd64InstrDecode::InstrForm::MOnly_W_M16B_or_M8B:
+        opSize = W ? 16 : 8;
+        break;
+    // W_None_or_MOp_M16B
+    case Amd64InstrDecode::InstrForm::I1B_W_None_or_MOp_M16B:
+        opSize = W ? 0 : 16;
+        break;
+    // M10B
+    case Amd64InstrDecode::InstrForm::MOnly_M10B:
+        opSize = 10;
+        break;
+    // M8B
+    case Amd64InstrDecode::InstrForm::MOp_M8B:
+    case Amd64InstrDecode::InstrForm::MOp_M8B_I1B:
+        opSize = 8;
+        break;
+    // L_M8B_or_M4B
+    case Amd64InstrDecode::InstrForm::MOp_L_M8B_or_M4B:
+        opSize = L ? 8 : 4;
+        break;
+    // W_M8B_or_M4B
+    case Amd64InstrDecode::InstrForm::M1st_I1B_W_M8B_or_M4B:
+    case Amd64InstrDecode::InstrForm::M1st_W_M8B_or_M4B:
+    case Amd64InstrDecode::InstrForm::MOnly_W_M8B_or_M4B:
+    case Amd64InstrDecode::InstrForm::MOp_I1B_W_M8B_or_M4B:
+    case Amd64InstrDecode::InstrForm::MOp_I4B_W_M8B_or_M4B:
+    case Amd64InstrDecode::InstrForm::MOp_W_M8B_or_M4B:
+        opSize = W ? 8 : 4;
+        break;
+    // WP_M8B_or_M8B_or_M2B
+    case Amd64InstrDecode::InstrForm::MOnly_WP_M8B_or_M8B_or_M2B:
+        opSize = W ? 8 : P ? 8 : 2;
+        break;
+    // WP_M8B_or_M4B_or_M2B
+    case Amd64InstrDecode::InstrForm::M1st_I1B_WP_M8B_or_M4B_or_M2B:
+    case Amd64InstrDecode::InstrForm::M1st_WP_M8B_I4B_or_M4B_I4B_or_M2B_I2B:
+    case Amd64InstrDecode::InstrForm::M1st_WP_M8B_or_M4B_or_M2B:
+    case Amd64InstrDecode::InstrForm::MOnly_WP_M8B_or_M4B_or_M2B:
+    case Amd64InstrDecode::InstrForm::MOp_I1B_WP_M8B_or_M4B_or_M2B:
+    case Amd64InstrDecode::InstrForm::MOp_WP_M8B_I4B_or_M4B_I4B_or_M2B_I2B:
+    case Amd64InstrDecode::InstrForm::MOp_WP_M8B_or_M4B_or_M2B:
+        opSize = W ? 8 : P ? 4 : 2;
+        break;
+    // W_M8B_or_M2B
+    case Amd64InstrDecode::InstrForm::M1st_W_M8B_or_M2B:
+    case Amd64InstrDecode::InstrForm::MOp_W_M8B_or_M2B:
+        opSize = W ? 8 : 2;
+        break;
+    // M8B
+    case Amd64InstrDecode::InstrForm::M1st_M8B:
+    case Amd64InstrDecode::InstrForm::MOnly_M8B:
+        opSize = 8;
+        break;
+    // M6B
+    case Amd64InstrDecode::InstrForm::MOp_M6B:
+        opSize = 6;
+        break;
+    // P_M6B_or_M4B
+    case Amd64InstrDecode::InstrForm::MOnly_P_M6B_or_M4B:
+        opSize = P ? 6 : 4;
+    // M4B
+    case Amd64InstrDecode::InstrForm::M1st_M4B:
+    case Amd64InstrDecode::InstrForm::M1st_M4B_I1B:
+    case Amd64InstrDecode::InstrForm::MOnly_M4B:
+    case Amd64InstrDecode::InstrForm::MOp_M4B:
+    case Amd64InstrDecode::InstrForm::MOp_M4B_I1B:
+    case Amd64InstrDecode::InstrForm::MOp_M4B_I4B:
+        opSize = 4;
+        break;
+    // L_M4B_or_M2B
+    case Amd64InstrDecode::InstrForm::MOp_L_M4B_or_M2B:
+        opSize = L ? 4 : 2;
+        break;
+    // W_M4B_or_M1B
+    case Amd64InstrDecode::InstrForm::M1st_W_M4B_or_M1B:
+    case Amd64InstrDecode::InstrForm::MOp_W_M4B_or_M1B:
+        opSize = W ? 4 : 1;
+        break;
+    // M2B
+    case Amd64InstrDecode::InstrForm::M1st_M2B:
+    case Amd64InstrDecode::InstrForm::M1st_M2B_I1B:
+    case Amd64InstrDecode::InstrForm::MOnly_M2B:
+    case Amd64InstrDecode::InstrForm::MOp_M2B:
+    case Amd64InstrDecode::InstrForm::MOp_M2B_I1B:
+        opSize = 2;
+        break;
+    // M1B
+    case Amd64InstrDecode::InstrForm::M1st_M1B:
+    case Amd64InstrDecode::InstrForm::M1st_M1B_I1B:
+    case Amd64InstrDecode::InstrForm::MOnly_M1B:
+    case Amd64InstrDecode::InstrForm::MOp_M1B:
+    case Amd64InstrDecode::InstrForm::MOp_M1B_I1B:
+        opSize = 1;
+        break;
+    // MUnknown
+    case Amd64InstrDecode::InstrForm::M1st_MUnknown:
+    case Amd64InstrDecode::InstrForm::MOnly_MUnknown:
+    case Amd64InstrDecode::InstrForm::MOp_MUnknown:
+        // These are not expected/supported. Most/all are not for user code.
+        _ASSERT(false);
+        break;
+    default:
+        break;
+    }
+    return opSize;
+}
+
+static int immSize(Amd64InstrDecode::InstrForm form, int pp, bool W, bool L, bool fPrefix66)
+{
+    int immSize = 0;
+    bool P = !((pp == 1) || fPrefix66);
+    switch (form)
+    {
+    case Amd64InstrDecode::InstrForm::I1B:
+    case Amd64InstrDecode::InstrForm::I1B_W_None_or_MOp_M16B:
+    case Amd64InstrDecode::InstrForm::M1st_I1B_L_M16B_or_M8B:
+    case Amd64InstrDecode::InstrForm::M1st_I1B_W_M8B_or_M4B:
+    case Amd64InstrDecode::InstrForm::M1st_I1B_WP_M8B_or_M4B_or_M2B:
+    case Amd64InstrDecode::InstrForm::M1st_M16B_I1B:
+    case Amd64InstrDecode::InstrForm::M1st_M1B_I1B:
+    case Amd64InstrDecode::InstrForm::M1st_M2B_I1B:
+    case Amd64InstrDecode::InstrForm::M1st_M4B_I1B:
+    case Amd64InstrDecode::InstrForm::MOp_I1B_L_M32B_or_M16B:
+    case Amd64InstrDecode::InstrForm::MOp_I1B_W_M8B_or_M4B:
+    case Amd64InstrDecode::InstrForm::MOp_I1B_WP_M8B_or_M4B_or_M2B:
+    case Amd64InstrDecode::InstrForm::MOp_M16B_I1B:
+    case Amd64InstrDecode::InstrForm::MOp_M1B_I1B:
+    case Amd64InstrDecode::InstrForm::MOp_M2B_I1B:
+    case Amd64InstrDecode::InstrForm::MOp_M32B_I1B:
+    case Amd64InstrDecode::InstrForm::MOp_M4B_I1B:
+    case Amd64InstrDecode::InstrForm::MOp_M8B_I1B:
+        immSize = 1;
+        break;
+    case Amd64InstrDecode::InstrForm::I2B:
+        immSize = 2;
+        break;
+    case Amd64InstrDecode::InstrForm::I3B:
+        immSize = 3;
+        break;
+    case Amd64InstrDecode::InstrForm::I4B:
+    case Amd64InstrDecode::InstrForm::MOp_I4B_W_M8B_or_M4B:
+    case Amd64InstrDecode::InstrForm::MOp_M4B_I4B:
+        immSize = 4;
+        break;
+    case Amd64InstrDecode::InstrForm::I8B:
+        immSize = 8;
+        break;
+    case Amd64InstrDecode::InstrForm::M1st_WP_M8B_I4B_or_M4B_I4B_or_M2B_I2B:
+    case Amd64InstrDecode::InstrForm::MOp_WP_M8B_I4B_or_M4B_I4B_or_M2B_I2B:
+    case Amd64InstrDecode::InstrForm::WP_I4B_or_I4B_or_I2B:
+        immSize = W ? 4 : P ? 4 : 2;
+        break;
+    case Amd64InstrDecode::InstrForm::WP_I8B_or_I4B_or_I2B:
+        immSize = W ? 8 : P ? 4 : 2;
+        break;
+        break;
+    default:
+        break;
+    }
+    return immSize;
+}
 
 // static
 void NativeWalker::DecodeInstructionForPatchSkip(const BYTE *address, InstructionAttribute * pInstrAttrib)
 {
-    //
-    // Skip instruction prefixes
-    //
-
     LOG((LF_CORDB, LL_INFO10000, "Patch decode: "));
-
-    // for reads and writes where the destination is a RIP-relative address pInstrAttrib->m_cOperandSize will contain the size in bytes of the pointee; in all other
-    // cases it will be zero.  if the RIP-relative address is being written to then pInstrAttrib->m_fIsWrite will be true; in all other cases it will be false.
-    // similar to cbImmedSize in some cases we'll set pInstrAttrib->m_cOperandSize to 0x3 meaning that the prefix will determine the size if one is specified.
-    pInstrAttrib->m_cOperandSize = 0;
-    pInstrAttrib->m_fIsWrite = false;
 
     if (pInstrAttrib == NULL)
     {
         return;
     }
 
+    pInstrAttrib->Reset();
+
     // These three legacy prefixes are used to modify some of the two-byte opcodes.
     bool  fPrefix66 = false;
     bool  fPrefixF2 = false;
     bool  fPrefixF3 = false;
 
-    bool  fRex      = false;
-    bool  fModRM    = false;
+    bool  W     = false;
+    bool  L     = false;
 
-    RexByte   rex   = {0};
-    ModRMByte modrm = {0};
-
-    // We use 0x3 to indicate that we need to look at the operand-size override and the rex byte 
-    // to determine whether the immediate size is 2 bytes or 4 bytes.
-    BYTE      cbImmedSize = 0; 
+    int pp = 0;
 
     const BYTE* originalAddr = address;
-    
+
+    // Code below doesn't handle patched opcodes
+    _ASSERT((*address != 0xcc) || ((BYTE)DebuggerController::GetPatchedOpcode(address) == 0xcc));
+
+    //
+    // Skip instruction prefixes
+    //
     do
     {
+        bool done = false;
         switch (*address)
         {
         // Operand-Size override
         case 0x66:
             fPrefix66 = true;
-            goto LLegacyPrefix;
+            break;
 
         // Repeat (REP/REPE/REPZ)
         case 0xf2:
             fPrefixF2 = true;
-            goto LLegacyPrefix;
+            break;
 
         // Repeat (REPNE/REPNZ)
         case 0xf3:
             fPrefixF3 = true;
-            goto LLegacyPrefix;
+            break;
 
         // Address-Size override
         case 0x67:          // fall through
@@ -489,13 +746,10 @@ void NativeWalker::DecodeInstructionForPatchSkip(const BYTE *address, Instructio
 
         // Lock
         case 0xf0:
-LLegacyPrefix:
-            LOG((LF_CORDB, LL_INFO10000, "prefix:%0.2x ", *address));
-            address++;
-            continue;
+            break;
 
-        // REX register extension prefixes
-        case 0x40:            
+        // REX register extension prefixes w/o W
+        case 0x40:
         case 0x41:
         case 0x42:
         case 0x43:
@@ -503,6 +757,9 @@ LLegacyPrefix:
         case 0x45:
         case 0x46:
         case 0x47:
+            break;
+
+        // REX register extension prefixes with W
         case 0x48:
         case 0x49:
         case 0x4a:
@@ -511,670 +768,215 @@ LLegacyPrefix:
         case 0x4d:
         case 0x4e:
         case 0x4f:
-            LOG((LF_CORDB, LL_INFO10000, "prefix:%0.2x ", *address));
-            fRex = true;
-            rex  = *(RexByte*)address;
-            address++;
-            continue;
+            W = true;
+            break;
 
         default:
+            done = true;
             break;
         }
-    } while (0);
 
-    pInstrAttrib->Reset();
+        if (done)
+            break;
+        LOG((LF_CORDB, LL_INFO10000, "prefix:%0.2x ", *address));
+        address++;
+    } while (true);
 
-    BYTE opcode0 = *address;
-    BYTE opcode1 = *(address + 1);      // this is only valid if the first opcode byte is 0x0F
-
-    // Handle AVX encodings.  Note that these can mostly be handled as if they are aliases
-    // for a corresponding SSE encoding.
-    // See Figure 2-9 in "Intel 64 and IA-32 Architectures Software Developer's Manual".
-
-    if (opcode0 == 0xC4 || opcode0 == 0xC5)
+    // See "AMD64 Architecture Programmer's Manual Volume 3 Rev 3.26 Figure 1-1 Instruction encoding syntax"
+    enum OpcodeMap
     {
-        BYTE pp;
-        if (opcode0 == 0xC4)
-        {
-            BYTE opcode2 = *(address + 2);
-            address++;
+        Primary = 0x0,
+        Secondary = 0xF,
+        Escape0F_0F = 0x0F0F, // 3D Now
+        Escape0F_38 = 0x0F38,
+        Escape0F_3A = 0x0F3A,
+        VexMap1 = 0xc401,
+        VexMap2 = 0xc402,
+        VexMap3 = 0xc403,
+        XopMap8 = 0x8f08,
+        XopMap9 = 0x8f09,
+        XopMapA = 0x8f0A
+    } opCodeMap;
 
-            // REX bits are encoded in inverted form.
-            // R,X, and B are the top bits (in that order) of opcode1.
+    switch (*address)
+    {
+        case 0xf:
+           switch (address[1])
+           {
+           case 0xF:
+               opCodeMap = Escape0F_0F;
+               address += 2;
+               break;
+            case 0x38:
+               opCodeMap = Escape0F_38;
+               address += 2;
+               break;
+            case 0x3A:
+               opCodeMap = Escape0F_3A;
+               address += 2;
+               break;
+            default:
+                opCodeMap = Secondary;
+                address += 1;
+            }
+            if (fPrefix66)
+                pp = 0x1;
+
+            if (fPrefixF2)
+                pp = 0x3;
+            else if (fPrefixF3)
+                pp = 0x2;
+            break;
+
+        case 0x8f: // XOP
+            if ((address[1] & 0x38) == 0)
+            {
+                opCodeMap = Primary;
+                break;
+            }
+            // Fall through
+        case 0xc4: // Vex 3-byte
+            opCodeMap = (OpcodeMap)(int(address[0]) << 8 | (address[1] & 0x1f));
             // W is the top bit of opcode2.
-            if ((opcode1 & 0x80) != 0)
+            if ((address[2] & 0x80) != 0)
             {
-                rex.b = 1;
-                fRex = true;
+                W = true;
             }
-            if ((opcode1 & 0x40) == 0)
+            if ((address[2] & 0x04) != 0)
             {
-                rex.x = 1;
-                fRex = true;
-            }
-            if ((opcode1 & 0x20) == 0)
-            {
-                rex.b = 1;
-                fRex = true;
-            }
-            if ((opcode2 & 0x80) != 0)
-            {
-                rex.w = 1;
-                fRex = true;
+                L = true;
             }
 
-            pp = opcode2 & 0x3;
-
-            BYTE mmBits = opcode1 & 0x1f;
-            BYTE impliedOpcode1 = 0;
-            switch(mmBits)
+            pp = address[2] & 0x3;
+            address += 3;
+            break;
+        case 0xc5: // Vex 2-byte
+            opCodeMap = VexMap1;
+            W = true;
+            if ((address[1] & 0x04) != 0)
             {
-            case 1:  break;     // No implied leading byte.
-            case 2:  impliedOpcode1 = 0x38;                   break;
-            case 3:  impliedOpcode1 = 0x3A;                   break;
-            default: _ASSERTE(!"NW::DIFPS - invalid opcode"); break;
+                L = true;
             }
 
-            if (impliedOpcode1 != 0)
-            {
-                opcode1 = impliedOpcode1;
-            }
-            else
-            {
-                opcode1 = *address;
-                address++;
-            }
-        }
-        else
-        {
-            pp = opcode1 & 0x3;
-            if ((opcode1 & 0x80) == 0)
-            {
-                // The two-byte VEX encoding only encodes the 'R' bit.
-                fRex = true;
-                rex.r = 1;
-            }
-            opcode1 = *address;
-            address++;
-        }
-        opcode0 = 0x0f;
-        switch (pp)
-        {
-        case 1: fPrefix66 = true; break;
-        case 2: fPrefixF3 = true; break;
-        case 3: fPrefixF2 = true; break;
-        }
+            pp = address[1] & 0x3;
+            address += 2;
+            break;
+        default:
+            opCodeMap = Primary;
     }
 
-    // The following opcode decoding follows the tables in "Appendix A Opcode and Operand Encodings" of 
-    // "AMD64 Architecture Programmer's Manual Volume 3" 
-
-    // one-byte opcodes
-    if (opcode0 != 0x0F)
+    Amd64InstrDecode::InstrForm form = Amd64InstrDecode::InstrForm::None;
+    switch (opCodeMap)
     {
-        BYTE highNibble = (opcode0 & 0xF0) >> 4;
-        BYTE lowNibble  = (opcode0 & 0x0F);
-
-        switch (highNibble)
-        {
-        case 0x0:
-        case 0x1:
-        case 0x2:
-        case 0x3:
-            if ((lowNibble == 0x6) || (lowNibble == 0x7) || (lowNibble == 0xE) || (lowNibble == 0xF))
-            {
-                _ASSERTE(!"NW::DIFPS - invalid opcode");
-            }
-
-            // CMP
-            if ( (lowNibble <= 0x3) ||
-                 ((lowNibble >= 0x8) && (lowNibble <= 0xB)) )
-            {
-                fModRM = true;    
-            }
-
-            // ADD/XOR reg/mem, reg
-            if (lowNibble == 0x0)
-            {
-                pInstrAttrib->m_cOperandSize = 0x1;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            else if (lowNibble == 0x1)
-            {
-                pInstrAttrib->m_cOperandSize = 0x3;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            // XOR reg, reg/mem
-            else if (lowNibble == 0x2)
-            {
-                pInstrAttrib->m_cOperandSize = 0x1;
-            }
-            else if (lowNibble == 0x3)
-            {
-                pInstrAttrib->m_cOperandSize = 0x3;
-            }
-
-            break;
-
-        case 0x4:
-        case 0x5:
-            break;
-
-        case 0x6:                
-            // IMUL
-            if (lowNibble == 0x9)
-            {
-                fModRM = true;
-                cbImmedSize = 0x3;
-            }
-            else if (lowNibble == 0xB)
-            {
-                fModRM = true;
-                cbImmedSize = 0x1;
-            }
-            else if (lowNibble == 0x3)
-            {                 
-                if (fRex)
-                {
-                    // MOVSXD
-                    fModRM = true;
-                }
-            }
-            break;
-
-        case 0x7:
-            break;
-
-        case 0x8:
-            fModRM = true;
-
-            // Group 1: lowNibble in [0x0, 0x3]
-            _ASSERTE(lowNibble != 0x2);
-
-            // ADD/XOR reg/mem, imm
-            if (lowNibble == 0x0)
-            {
-                cbImmedSize = 1;
-                pInstrAttrib->m_cOperandSize = 1;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            else if (lowNibble == 0x1)
-            {
-                cbImmedSize = 3;
-                pInstrAttrib->m_cOperandSize = 3;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            else if (lowNibble == 0x3)
-            {
-                cbImmedSize = 1;
-                pInstrAttrib->m_cOperandSize = 3;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            // MOV reg/mem, reg
-            else if (lowNibble == 0x8)
-            {
-                pInstrAttrib->m_cOperandSize = 0x1;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            else if (lowNibble == 0x9)
-            {
-                pInstrAttrib->m_cOperandSize = 0x3;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            // MOV reg, reg/mem
-            else if (lowNibble == 0xA)
-            {
-                pInstrAttrib->m_cOperandSize = 0x1;
-            }
-            else if (lowNibble == 0xB)
-            {
-                pInstrAttrib->m_cOperandSize = 0x3;
-            }
-
-            break;
-
-        case 0x9:
-        case 0xA:
-        case 0xB:
-            break;
-
-        case 0xC:
-            if ((lowNibble == 0x4) || (lowNibble == 0x5) || (lowNibble == 0xE))
-            {
-                _ASSERTE(!"NW::DIFPS - invalid opcode");
-            }
-
-            // RET
-            if ((lowNibble == 0x2) || (lowNibble == 0x3))
-            {
-                break;
-            }
-
-            // Group 2 (part 1): lowNibble in [0x0, 0x1]
-            // RCL reg/mem, imm
-            if (lowNibble == 0x0)
-            {
-                fModRM = true;
-                cbImmedSize = 0x1;
-                pInstrAttrib->m_cOperandSize = 0x1;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            else if (lowNibble == 0x1)
-            {
-                fModRM = true;
-                cbImmedSize = 0x1;
-                pInstrAttrib->m_cOperandSize = 0x3;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            // Group 11: lowNibble in [0x6, 0x7]
-            // MOV reg/mem, imm
-            else if (lowNibble == 0x6)
-            {
-                fModRM = true;
-                cbImmedSize = 1;
-                pInstrAttrib->m_cOperandSize = 1;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            else if (lowNibble == 0x7)
-            {
-                fModRM = true;
-                cbImmedSize = 3;
-                pInstrAttrib->m_cOperandSize = 3;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            break;
-
-        case 0xD:
-            // Group 2 (part 2): lowNibble in [0x0, 0x3] 
-            // RCL reg/mem, 1/reg
-            if (lowNibble == 0x0 || lowNibble == 0x2)
-            {
-                fModRM = true;
-                pInstrAttrib->m_cOperandSize = 0x1;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            else if (lowNibble == 0x1 || lowNibble == 0x3)
-            {
-                fModRM = true;
-                pInstrAttrib->m_cOperandSize = 0x3;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-
-            // x87 instructions: lowNibble in [0x8, 0xF]
-            // - the entire ModRM byte is used to modify the opcode, 
-            //   so the ModRM byte cannot be used in RIP-relative addressing
-            break;
-
-        case 0xE:
-            break;
-
-        case 0xF:
-            // Group 3: lowNibble in [0x6, 0x7]
-            // TEST
-            if  ((lowNibble == 0x6) || (lowNibble == 0x7))
-            {
-                fModRM = true;
-
-                modrm = *(ModRMByte*)(address + 1);
-                if ((modrm.reg == 0x0) || (modrm.reg == 0x1))
-                {
-                    if (lowNibble == 0x6)
-                    {
-                        cbImmedSize = 0x1;
-                    }
-                    else
-                    {
-                        cbImmedSize = 0x3;
-                    }
-                }
-            }
-            // Group 4: lowNibble == 0xE
-            // INC reg/mem
-            else if (lowNibble == 0xE)
-            {
-                fModRM = true;
-                pInstrAttrib->m_cOperandSize = 1;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            // Group 5: lowNibble == 0xF
-            else if (lowNibble == 0xF)
-            {
-                fModRM = true;
-                pInstrAttrib->m_cOperandSize = 3;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            break;
-        }
-
-        address += 1;
-        if (fModRM)
-        {
-            modrm = *(ModRMByte*)address;
-            address += 1;
-        }
-    }
-    // two-byte opcodes
-    else
-    {
-        BYTE highNibble = (opcode1 & 0xF0) >> 4;
-        BYTE lowNibble  = (opcode1 & 0x0F);
-
-        switch (highNibble)
-        {
-        case 0x0:
-            // Group 6: lowNibble == 0x0
-            if (lowNibble == 0x0)
-            {
-                fModRM = true;
-            }
-            // Group 7: lowNibble == 0x1
-            else if (lowNibble == 0x1)
-            {
-                fModRM = true;
-            }
-            else if ((lowNibble == 0x2) || (lowNibble == 0x3))
-            {
-                fModRM = true;
-            }
-            // Group p: lowNibble == 0xD
-            else if (lowNibble == 0xD)
-            {
-                fModRM = true;
-            }
-            // 3DNow! instructions: lowNibble == 0xF
-            // - all 3DNow! instructions use the ModRM byte
-            else if (lowNibble == 0xF)
-            {
-                fModRM = true;
-                cbImmedSize = 0x1;
-            }
-            break;
-
-        case 0x1:   // Group 16: lowNibble == 0x8
-            // MOVSS xmm, xmm/mem (low nibble 0x0)
-            // MOVSS xmm/mem, xmm (low nibble 0x1)
-            if (lowNibble <= 0x1)
-            {
-                fModRM = true;
-                if (fPrefixF2 || fPrefixF3)
-                    pInstrAttrib->m_cOperandSize = 0x8;
-                else
-                    pInstrAttrib->m_cOperandSize = 0x10;
-
-                if (lowNibble == 0x1)
-                    pInstrAttrib->m_fIsWrite = true;
-
-                break;
-            }
-        case 0x2:   // fall through
-            fModRM = true;
-            if (lowNibble == 0x8 || lowNibble == 0x9)
-            {
-                pInstrAttrib->m_cOperandSize = 0x10;
-
-                if (lowNibble == 0x9)
-                    pInstrAttrib->m_fIsWrite = true;
-            }
-            break;
-
-        case 0x3:
-            break;
-
-        case 0x4:
-        case 0x5:
-        case 0x6:   // fall through
-            fModRM = true;
-            break;
-
-        case 0x7:
-            if (lowNibble == 0x0)
-            {
-                fModRM = true;
-                cbImmedSize = 0x1;
-            }
-            else if ((lowNibble >= 0x1) && (lowNibble <= 0x3))
-            {
-                _ASSERTE(!fPrefixF2 && !fPrefixF3);
-
-                // Group 12: lowNibble == 0x1
-                // Group 13: lowNibble == 0x2
-                // Group 14: lowNibble == 0x3
-                fModRM = true;
-                cbImmedSize = 0x1;
-            }
-            else if ((lowNibble >= 0x4) && (lowNibble <= 0x6))
-            {
-                fModRM = true;
-            }
-            // MOVD reg/mem, mmx for 0F 7E
-            else if ((lowNibble == 0xE) || (lowNibble == 0xF))
-            {
-                _ASSERTE(!fPrefixF2);
-
-                fModRM = true;
-            }
-            break;
-
-        case 0x8:
-            break;
-
-        case 0x9:
-            fModRM = true;
-            break;
-
-        case 0xA:
-            if ((lowNibble >= 0x3) && (lowNibble <= 0x5))
-            {
-                // BT reg/mem, reg
-                fModRM = true;
-                if (lowNibble == 0x3)
-                {
-                    pInstrAttrib->m_cOperandSize = 0x3;
-                    pInstrAttrib->m_fIsWrite = true;
-                }
-                // SHLD reg/mem, imm
-                else if (lowNibble == 0x4)
-                {
-                    cbImmedSize = 0x1;
-                }
-            }
-            else if (lowNibble >= 0xB)
-            {
-                fModRM = true;
-                // BTS reg/mem, reg
-                if (lowNibble == 0xB)
-                {
-                    pInstrAttrib->m_cOperandSize = 0x3;
-                    pInstrAttrib->m_fIsWrite = true;
-                }
-                // SHRD reg/mem, imm
-                else if (lowNibble == 0xC)
-                {
-                    cbImmedSize = 0x1;
-                }
-                // Group 15: lowNibble == 0xE
-            }
-            break;
-
-        case 0xB:
-            // Group 10: lowNibble == 0x9
-            // - this entire group is invalid
-            _ASSERTE((lowNibble != 0x8) && (lowNibble != 0x9));
-
-            fModRM = true;
-            // CMPXCHG reg/mem, reg
-            if (lowNibble == 0x0)
-            {
-                pInstrAttrib->m_cOperandSize = 0x1;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            else if (lowNibble == 0x1)
-            {
-                pInstrAttrib->m_cOperandSize = 0x3;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            // Group 8: lowNibble == 0xA
-            // BTS reg/mem, imm
-            else if (lowNibble == 0xA)
-            {
-                cbImmedSize = 0x1;
-                pInstrAttrib->m_cOperandSize = 0x3;
-                pInstrAttrib->m_fIsWrite = true;
-            }
-            // MOVSX reg, reg/mem
-            else if (lowNibble == 0xE)
-            {
-                pInstrAttrib->m_cOperandSize = 1;
-            }
-            else if (lowNibble == 0xF)
-            {
-                pInstrAttrib->m_cOperandSize = 2;
-            }
-            break;
-
-        case 0xC:
-            if (lowNibble <= 0x7)
-            {
-                fModRM = true;
-                // XADD reg/mem, reg
-                if (lowNibble == 0x0)
-                {
-                    pInstrAttrib->m_cOperandSize = 0x1;
-                    pInstrAttrib->m_fIsWrite = true;
-                }
-                else if (lowNibble == 0x1)
-                {
-                    pInstrAttrib->m_cOperandSize = 0x3;
-                    pInstrAttrib->m_fIsWrite = true;
-                }
-                else if ( (lowNibble == 0x2) || 
-                     ((lowNibble >= 0x4) && (lowNibble <= 0x6)) )
-                {
-                    cbImmedSize = 0x1;
-                }
-            }
-            break;
-
-        case 0xD:
-        case 0xE:
-        case 0xF:   // fall through
-            fModRM = true;
-            break;
-        }
-
-        address += 2;
-        if (fModRM)
-        {
-            modrm = *(ModRMByte*)address; 
-            address += 1;
-        }
+    case Primary:
+        form = Amd64InstrDecode::instrFormPrimary[*address];
+        break;
+    case Secondary:
+        form = Amd64InstrDecode::instrFormSecondary[(size_t(*address) << 2)| pp];
+        break;
+    case Escape0F_0F: // 3DNow
+        form = Amd64InstrDecode::InstrForm::MOp_M8B_I1B;
+        break;
+    case Escape0F_38:
+        form = Amd64InstrDecode::instrFormF38[(size_t(*address) << 2)| pp];
+        break;
+    case Escape0F_3A:
+        form = Amd64InstrDecode::instrFormF3A[(size_t(*address) << 2)| pp];
+        break;
+    case VexMap1:
+        form = Amd64InstrDecode::instrFormVex1[(size_t(*address) << 2)| pp];
+        break;
+    case VexMap2:
+        form = Amd64InstrDecode::instrFormVex2[(size_t(*address) << 2)| pp];
+        break;
+    case VexMap3:
+        form = Amd64InstrDecode::instrFormVex3[(size_t(*address) << 2)| pp];
+        break;
+    case XopMap8:
+        form = Amd64InstrDecode::instrFormXOP8[(size_t(*address) << 2)| pp];
+        break;
+    case XopMap9:
+        form = Amd64InstrDecode::instrFormXOP9[(size_t(*address) << 2)| pp];
+        break;
+    case XopMapA:
+        form = Amd64InstrDecode::instrFormXOPA[(size_t(*address) << 2)| pp];
+        break;
+    default:
+        _ASSERTE(false);
     }
 
-    // Check for RIP-relative addressing
+    bool fModRM = IsModRm(form, pp, W, L, fPrefix66);
+    ModRMByte modrm = ModRMByte(address[1]);
+
     if (fModRM && (modrm.mod == 0x0) && (modrm.rm == 0x5))
     {
-        // SIB byte cannot be present with RIP-relative addressing.
+        // RIP-relative addressing.
+        if (form & Amd64InstrDecode::InstrForm::Extension)
+        {
+            form = Amd64InstrDecode::instrFormExtension[(size_t(form ^ Amd64InstrDecode::InstrForm::Extension) << 3) | modrm.reg];
+        }
 
-        pInstrAttrib->m_dwOffsetToDisp = (DWORD)(address - originalAddr);
+        pInstrAttrib->m_dwOffsetToDisp = (DWORD)(address - originalAddr) + 1 /* op */ + 1 /* modrm */;
         _ASSERTE(pInstrAttrib->m_dwOffsetToDisp <= MAX_INSTRUCTION_LENGTH);
 
-        // Add 4 to the address for the displacement.
-        address += 4;
+        const int dispBytes = 4;
+        const int immBytes = immSize(form, pp, W, L, fPrefix66);
 
-        // Further adjust the address by the size of the cbImmedSize (if any).
-        if (cbImmedSize == 0x3)
-        {
-            // The size of the cbImmedSizeiate depends on the effective operand size:
-            // 2 bytes if the effective operand size is 16-bit, or
-            // 4 bytes if the effective operand size is 32- or 64-bit.
-            if (fPrefix66)
-            {
-                cbImmedSize = 0x2;
-            }
-            else
-            {
-                cbImmedSize = 0x4;
-            }
-        }
-        address += cbImmedSize;
-
-        // if this is a read or write to a RIP-relative address then update pInstrAttrib->m_cOperandSize with the size of the pointee.
-        if (pInstrAttrib->m_cOperandSize == 0x3)
-        {
-            if (fPrefix66)
-                pInstrAttrib->m_cOperandSize = 0x2; // WORD*
-            else
-                pInstrAttrib->m_cOperandSize = 0x4; // DWORD*
-
-            if (fRex && rex.w == 0x1)
-            {
-                _ASSERTE(pInstrAttrib->m_cOperandSize == 0x4);
-                pInstrAttrib->m_cOperandSize = 0x8; // QWORD*
-            }
-        }
-
-        pInstrAttrib->m_cbInstr = (DWORD)(address - originalAddr);
+        pInstrAttrib->m_cbInstr = pInstrAttrib->m_dwOffsetToDisp + dispBytes + immBytes;
         _ASSERTE(pInstrAttrib->m_cbInstr <= MAX_INSTRUCTION_LENGTH);
-    }
-    else
-    {
-        // not a RIP-relative address so set to default values
-        pInstrAttrib->m_cOperandSize = 0;
-        pInstrAttrib->m_fIsWrite = false;
+
+        pInstrAttrib->m_fIsWrite = IsWrite(form, pp, W, L, fPrefix66);
+        pInstrAttrib->m_cOperandSize = opSize(form, pp, W, L, fPrefix66);
     }
 
-    //
-    // Look at opcode to tell if it's a call or an
-    // absolute branch.
-    //
-    switch (opcode0)
+    if (opCodeMap == Primary)
     {
-        case 0xC2: // RET
-        case 0xC3: // RET N
-            pInstrAttrib->m_fIsAbsBranch = true;
-            LOG((LF_CORDB, LL_INFO10000, "ABS:%0.2x\n", opcode0));
-            break;
+        BYTE opcode0 = *address;
+        //
+        // Look at opcode to tell if it's a call or an
+        // absolute branch.
+        //
+        switch (opcode0)
+        {
+            case 0xC2: // RET
+            case 0xC3: // RET N
+                pInstrAttrib->m_fIsAbsBranch = true;
+                LOG((LF_CORDB, LL_INFO10000, "ABS:%0.2x\n", opcode0));
+                break;
 
-        case 0xE8: // CALL relative
-            pInstrAttrib->m_fIsCall = true;
-            LOG((LF_CORDB, LL_INFO10000, "CALL REL:%0.2x\n", opcode0));
-            break;
+            case 0xE8: // CALL relative
+                pInstrAttrib->m_fIsCall = true;
+                LOG((LF_CORDB, LL_INFO10000, "CALL REL:%0.2x\n", opcode0));
+                break;
 
-        case 0xC8: // ENTER
-            pInstrAttrib->m_fIsCall = true;
-            pInstrAttrib->m_fIsAbsBranch = true;
-            LOG((LF_CORDB, LL_INFO10000, "CALL ABS:%0.2x\n", opcode0));
-            break;
+            case 0xC8: // ENTER
+                pInstrAttrib->m_fIsCall = true;
+                pInstrAttrib->m_fIsAbsBranch = true;
+                LOG((LF_CORDB, LL_INFO10000, "CALL ABS:%0.2x\n", opcode0));
+                break;
 
-        case 0xFF: // CALL/JMP modr/m
-            //
-            // Read opcode modifier from modr/m
-            //
+            case 0xFF: // CALL/JMP modr/m
+                //
+                // Read opcode modifier from modr/m
+                //
 
-            _ASSERTE(fModRM);
-            switch (modrm.reg)
-            {
-                case 2:
-                case 3:
-                    pInstrAttrib->m_fIsCall = true;
-                    // fall through
-                case 4:
-                case 5:
-                    pInstrAttrib->m_fIsAbsBranch = true;
-            }
-            LOG((LF_CORDB, LL_INFO10000, "CALL/JMP modr/m:%0.2x\n", opcode0));
-            break;
+                _ASSERTE(fModRM);
+                switch (modrm.reg)
+                {
+                    case 2:
+                    case 3:
+                        pInstrAttrib->m_fIsCall = true;
+                        // fall through
+                    case 4:
+                    case 5:
+                        pInstrAttrib->m_fIsAbsBranch = true;
+                }
+                LOG((LF_CORDB, LL_INFO10000, "CALL/JMP modr/m:%0.2x\n", opcode0));
+                break;
 
-        default:
-            LOG((LF_CORDB, LL_INFO10000, "NORMAL:%0.2x\n", opcode0));
-    }
-
-    if (pInstrAttrib->m_cOperandSize == 0x0)
-    {
-        // if an operand size wasn't computed (likely because the decoder didn't understand the instruction) then set
-        // the size to the max buffer size.  this is a fall-back to the dev10 behavior and is applicable for reads only.
-        _ASSERTE(!pInstrAttrib->m_fIsWrite);
-        pInstrAttrib->m_cOperandSize = SharedPatchBypassBuffer::cbBufferBypass;
+            default:
+                LOG((LF_CORDB, LL_INFO10000, "NORMAL:%0.2x\n", opcode0));
+        }
     }
 }
 

--- a/src/debug/ee/amd64/gen_amd64InstrDecode/Amd64InstructionTableGenerator.cs
+++ b/src/debug/ee/amd64/gen_amd64InstrDecode/Amd64InstructionTableGenerator.cs
@@ -1,0 +1,936 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Amd64InstructionTableGenerator
+{
+    [Flags]
+    public enum EncodingFlags : int
+    {
+        None = 0x0,
+        P = 0x1, // OpSize (P)refix
+        F2 = 0x2,
+        F3 = 0x4,
+        Rex = 0x8,
+
+        W = 0x10,
+        L = 0x100,
+    }
+
+    [Flags]
+    enum SuffixFlags : int
+    {
+        None     =      0x0, // No flags set
+        MOp      =      0x1, // Instruction supports modrm RIP memory operations
+        M1st     =      0x3, // Memory op is first operand normally src/dst
+        MOnly    =      0x7, // Memory op is only operand.  May not be a write...
+        MUnknown =      0x8, // Memory op size is unknown.  Size not included in disassemby
+        MAddr    =     0x10, // Memory op is address load effective address
+        M1B      =     0x20, // Memory op is 1  byte
+        M2B      =     0x40, // Memory op is 2  bytes
+        M4B      =     0x80, // Memory op is 4  bytes
+        M8B      =    0x100, // Memory op is 8  bytes
+        M16B     =    0x200, // Memory op is 16 bytes
+        M32B     =    0x400, // Memory op is 32 bytes
+        M6B      =    0x800, // Memory op is 6  bytes
+        M10B     =   0x1000, // Memory op is 10 bytes
+        I1B      =   0x2000, // Instruction includes 1  byte  of immediates
+        I2B      =   0x4000, // Instruction includes 2  bytes of immediates
+        I3B      =   0x8000, // Instruction includes 3  bytes of immediates
+        I4B      =  0x10000, // Instruction includes 4  bytes of immediates
+        I8B      =  0x20000, // Instruction includes 8  bytes of immediates
+        Unknown  =  0x40000, // Instruction sample did not include a modrm configured to produce RIP addressing
+    }
+
+    enum Map
+    {
+        // Map
+        None,
+        Primary,
+        Secondary,
+        F38,
+        F3A,
+        NOW3D,
+        Vex1,
+        Vex2,
+        Vex3,
+        XOP8,
+        XOP9,
+        XOPA,
+    }
+
+    class Amd64InstructionSample
+    {
+        static readonly Regex encDisassemblySplit;
+        static readonly Regex encOperandSplit;
+        static readonly Regex encOperandIsMemOp;
+        static readonly Regex encOperandIsMOp;
+        static readonly HashSet<string> allOperands;
+        static readonly Dictionary<string, SuffixFlags> memOpSize;
+        static readonly Dictionary<string, Func<EncodingFlags, SuffixFlags>> unknownMemOps;
+
+        public readonly string disassembly;
+        readonly string address;
+        readonly List<byte> encoding;
+        public readonly string mnemonic;
+        readonly List<string> operands;
+
+        public readonly Map map;
+        public readonly EncodingFlags encodingFlags;
+        readonly byte opIndex;
+
+        public int opCodeExt
+        {
+            get
+            {
+                const byte BytePP = 0x3;
+                switch (map)
+                {
+                    case Map.Primary:
+                        return encoding[opIndex] << 4;
+                    case Map.Secondary:
+                    case Map.F38:
+                    case Map.F3A:
+                        return (((int)encoding[opIndex]) << 4) +
+                                (encodingFlags.HasFlag(EncodingFlags.F2) ? 0x3 :
+                                    (encodingFlags.HasFlag(EncodingFlags.P) ? 0x1 :
+                                        (encodingFlags.HasFlag(EncodingFlags.F3) ? 0x2 : 0)));
+                    case Map.NOW3D:
+                        return encoding[opIndex + 6] << 4;
+                    case Map.Vex1:
+                    case Map.Vex2:
+                    case Map.Vex3:
+                    case Map.XOP8:
+                    case Map.XOP9:
+                    case Map.XOPA:
+                        return (((int)encoding[opIndex]) << 4) + (encoding[opIndex - 1] & BytePP);
+                    default:
+                        return 0;
+                };
+            }
+        }
+
+        int suffixBytes { get { return encoding.Count - opIndex - 1; } }
+        public int modrm { get { return (suffixBytes > 0) ? encoding[opIndex + 1] : 0; } }
+        public int modrm_reg { get { return (modrm >> 3) & 0x7; } }
+
+        public static HashSet<string> AllOperands { get { return allOperands; } }
+
+        static Amd64InstructionSample()
+        {
+            encDisassemblySplit =
+                new Regex(@"^\s*(?<address>0x[a-f0-9]+)\s[^:]*:\s*(?<encoding>[0-9a-f ]*)\t(?<prefixes>(((rex[.WRXB]*)|(rep[nez]*)|(data16)|(addr32)|(lock)|(bnd)|([cdefgs]s)) +)*)(?<mnemonic>\S+) *(?<operands>(\S[^#]*?)?)\s*(?<comment>#.*)?$",
+                        RegexOptions.ExplicitCapture);
+            encOperandSplit = new Regex(@"^\s*,?\s*(?<op>[^\(,]*(\([^\)]*\))?)?(?<rest>.+$)?",
+                        RegexOptions.ExplicitCapture);
+            encOperandIsMemOp = new Regex(@"\[.*\]$");
+            encOperandIsMOp = new Regex(@"\[rip.*\]$");
+
+            allOperands = new HashSet<string>();
+
+            memOpSize = new Dictionary<string, SuffixFlags>()
+            {
+                { "[rip+0x53525150]", SuffixFlags.MUnknown },
+                { "BYTE PTR [rip+0x53525150]", SuffixFlags.M1B },
+                { "WORD PTR [rip+0x53525150]", SuffixFlags.M2B },
+                { "DWORD PTR [rip+0x53525150]", SuffixFlags.M4B },
+                { "QWORD PTR [rip+0x53525150]", SuffixFlags.M8B },
+                { "OWORD PTR [rip+0x53525150]", SuffixFlags.M16B },
+                { "XMMWORD PTR [rip+0x53525150]", SuffixFlags.M16B },
+                { "YMMWORD PTR [rip+0x53525150]", SuffixFlags.M32B },
+                { "FWORD PTR [rip+0x53525150]", SuffixFlags.M6B },
+                { "TBYTE PTR [rip+0x53525150]", SuffixFlags.M10B },
+            };
+
+            unknownMemOps = new Dictionary<string, Func<EncodingFlags, SuffixFlags>>()
+            {
+                {"lddqu",   (e) => { return SuffixFlags.M16B;}},
+                {"lea",     (e) => { return SuffixFlags.MAddr;}},
+                {"lgdt",    (e) => { return SuffixFlags.M10B;}},
+                {"lidt",    (e) => { return SuffixFlags.M10B;}},
+                {"sgdt",    (e) => { return SuffixFlags.M10B;}},
+                {"sidt",    (e) => { return SuffixFlags.M10B;}},
+                {"vlddqu",  (e) => { return Amd64InstructionTableGenerator.Amd64L(SuffixFlags.M32B, SuffixFlags.M16B, e);}},
+                {"vprotb",  (e) => { return SuffixFlags.M16B;}},
+                {"vprotd",  (e) => { return SuffixFlags.M16B;}},
+                {"vprotq",  (e) => { return SuffixFlags.M16B;}},
+                {"vprotw",  (e) => { return SuffixFlags.M16B;}},
+                {"vpshab",  (e) => { return SuffixFlags.M16B;}},
+                {"vpshad",  (e) => { return SuffixFlags.M16B;}},
+                {"vpshaq",  (e) => { return SuffixFlags.M16B;}},
+                {"vpshaw",  (e) => { return SuffixFlags.M16B;}},
+                {"vpshlb",  (e) => { return SuffixFlags.M16B;}},
+                {"vpshld",  (e) => { return SuffixFlags.M16B;}},
+                {"vpshlq",  (e) => { return SuffixFlags.M16B;}},
+                {"vpshlw",  (e) => { return SuffixFlags.M16B;}},
+            };
+        }
+
+        public Amd64InstructionSample(string disassembly_)
+        {
+            disassembly = disassembly_;
+
+            var match = encDisassemblySplit.Match(disassembly);
+
+            if (match == null)
+                throw new ArgumentException($"Unable to parse disassembly: {disassembly}");
+
+            // foreach (Group g in match.Groups)
+            // {
+            //     Console.WriteLine($"{g.Name}:'{g.ToString()}");
+            // }
+
+            address = match.Groups["address"].ToString();
+            encoding = parseEncoding(match.Groups["encoding"].ToString());
+
+            mnemonic = match.Groups["mnemonic"].ToString();
+
+            if (mnemonic.Length == 0)
+                throw new ArgumentException($"Missing mnemonic: {disassembly}");
+
+            operands = parseOperands(match.Groups["operands"].ToString());
+
+            (map, opIndex, encodingFlags) = parsePrefix(encoding);
+        }
+
+        static List<byte> parseEncoding(string encodingDisassembly)
+        {
+            var encoding = new List<byte>();
+            foreach (var b in encodingDisassembly.Split(' '))
+            {
+                // Console.WriteLine(b);
+                encoding.Add(Byte.Parse(b, NumberStyles.HexNumber));
+            }
+            return encoding;
+        }
+
+        static List<string> parseOperands(string operandDisassemby)
+        {
+            var operands = new List<string>();
+            string rest = operandDisassemby;
+
+            while (rest?.Length != 0)
+            {
+                var opMatch = encOperandSplit.Match(rest);
+
+                if (opMatch != null)
+                {
+                    string op = opMatch.Groups["op"].ToString();
+                    operands.Add(op);
+                    allOperands.Add(op);
+                    rest = opMatch.Groups["rest"].ToString();
+                }
+                else
+                {
+                    throw new Exception($"Op parsing failed {operandDisassemby}");
+                }
+            }
+            return operands;
+        }
+
+        enum Prefixes : byte
+        {
+            Secondary = 0xf,
+            ES = 0x26,
+            CS = 0x2E,
+            SS = 0x36,
+            F38 = 0x38,
+            F3A = 0x3A,
+            DS = 0x3E,
+            Rex = 0x40,
+            FS = 0x64,
+            GS = 0x65,
+            OpSize = 0x66,
+            AddSize = 0x67,
+            Xop = 0x8f,
+            Vex = 0xc4,
+            VexShort = 0xc5,
+            Lock = 0xf0,
+            Rep = 0xf2,
+            Repne = 0xf3
+        };
+
+        static (Map, byte, EncodingFlags) parsePrefix(List<byte> encoding)
+        {
+            Map map = Map.Primary;
+            byte operandIndex = 0;
+            EncodingFlags flags = 0;
+            bool done = false;
+
+            const byte RexMask = 0xf0;
+            const byte RexW = 0x8;
+            const byte ByteL = 0x04;
+            const byte ByteW = 0x80;
+
+            while (!done)
+            {
+                switch ((Prefixes)encoding[operandIndex])
+                {
+                    case Prefixes.OpSize:
+                        flags |= EncodingFlags.P;
+                        operandIndex++;
+                        break;
+                    case Prefixes.Rep:
+                        flags |= EncodingFlags.F2;
+                        operandIndex++;
+                        break;
+                    case Prefixes.Repne:
+                        flags |= EncodingFlags.F3;
+                        operandIndex++;
+                        break;
+                    case Prefixes.ES:
+                    case Prefixes.CS:
+                    case Prefixes.SS:
+                    case Prefixes.DS:
+                    case Prefixes.FS:
+                    case Prefixes.GS:
+                    case Prefixes.AddSize:
+                    case Prefixes.Lock:
+                        operandIndex++;
+                        break;
+                    default:
+                        done = true;
+                        break;
+                }
+            }
+
+            // Handle Rex prefix
+            if ((encoding[operandIndex] & RexMask) == (byte)Prefixes.Rex)
+            {
+                byte rex = encoding[operandIndex++];
+
+                flags |= EncodingFlags.Rex;
+
+                if ((rex & RexW) != 0)
+                    flags |= EncodingFlags.W;
+            }
+
+            switch ((Prefixes)encoding[operandIndex])
+            {
+                case Prefixes.Secondary:
+                    switch ((Prefixes)encoding[operandIndex + 1])
+                    {
+                        case Prefixes.Secondary:
+                            map = Map.NOW3D;
+                            operandIndex += 1;
+                            break;
+                        case Prefixes.F38:
+                            map = Map.F38;
+                            operandIndex += 2;
+                            break;
+                        case Prefixes.F3A:
+                            map = Map.F3A;
+                            operandIndex += 2;
+                            break;
+                        default:
+                            map = Map.Secondary;
+                            operandIndex += 1;
+                            break;
+                    }
+                    break;
+                case Prefixes.Vex:
+                case Prefixes.Xop:
+                    {
+                        var byte1 = encoding[operandIndex + 1];
+                        var byte2 = encoding[operandIndex + 2];
+                        if ((Prefixes)encoding[operandIndex] == Prefixes.Vex)
+                        {
+                            switch (encoding[operandIndex + 1] & 0x1f)
+                            {
+                                case 0x1:
+                                    map = Map.Vex1;
+                                    break;
+                                case 0x2:
+                                    map = Map.Vex2;
+                                    break;
+                                case 0x3:
+                                    map = Map.Vex3;
+                                    break;
+                                default:
+                                    throw new Exception($"Unexpected VEX map {encoding.ToString()}");
+                            }
+                        }
+                        else
+                        {
+                            switch (encoding[operandIndex + 1] & 0x1f)
+                            {
+                                case 0x0:
+                                case 0x1:
+                                case 0x2:
+                                case 0x3:
+                                case 0x4:
+                                case 0x5:
+                                case 0x6:
+                                case 0x7:
+                                    map = Map.Primary;
+                                    break;
+                                case 0x8:
+                                    map = Map.XOP8;
+                                    break;
+                                case 0x9:
+                                    map = Map.XOP9;
+                                    break;
+                                case 0xA:
+                                    map = Map.XOPA;
+                                    break;
+                                default:
+                                    {
+                                        string encodingString = new string("");
+
+                                        foreach (var b in encoding)
+                                        {
+                                            encodingString += $"{b:x} ";
+                                        }
+
+                                        throw new Exception($"Unexpected XOP map \noperandIndex:{operandIndex}\nflags:{flags}\nencoding:{encodingString}");
+                                    }
+                            }
+                            if (map == Map.Primary)
+                                goto default;
+                        }
+
+                        if ((byte2 & ByteW) != 0)
+                            flags |= EncodingFlags.W;
+                        if ((byte2 & ByteL) != 0)
+                            flags |= EncodingFlags.L;
+
+                        operandIndex += 3;
+                        break;
+                    }
+                case Prefixes.VexShort:
+                    {
+                        var byte1 = encoding[operandIndex + 1];
+                        map = Map.Vex1;
+
+                        if ((byte1 & ByteL) != 0)
+                            flags |= EncodingFlags.L;
+
+                        operandIndex += 3;
+                        break;
+                    }
+                default:
+                    map = Map.Primary;
+                    break;
+            }
+
+            return (map, operandIndex, flags);
+
+        }
+
+        public SuffixFlags parseSuffix()
+        {
+            if (suffixBytes == 0)
+                return SuffixFlags.None;
+
+            byte modrm = encoding[opIndex + 1];
+
+            int mod = modrm >> 6;
+            int rm = modrm & 0x7;
+
+            SuffixFlags flags = 0;
+
+            if (mod == 0x3)
+                return SuffixFlags.Unknown;
+
+            int accounted = 0;
+            for (int i = 0; i < operands.Count; i++)
+            {
+                string operand = operands[i];
+                bool memop = encOperandIsMemOp.IsMatch(operand);
+
+                if (encOperandIsMemOp.IsMatch(operand))
+                {
+                    bool hasSIB = (rm == 0x4);
+
+                    accounted += hasSIB ? 6 : 5;
+
+                    if (encOperandIsMOp.IsMatch(operand))
+                    {
+                        if (i == 0)
+                        {
+                            flags |= SuffixFlags.M1st;
+                            if (operands.Count == 1)
+                                flags |= SuffixFlags.MOnly;
+                        }
+                        flags |= SuffixFlags.MOp;
+
+                        flags |= memOpSize?[operand] ?? SuffixFlags.MUnknown;
+
+                        if (flags.HasFlag(SuffixFlags.MUnknown))
+                        {
+                            if (unknownMemOps.ContainsKey(mnemonic))
+                            {
+                                flags |= unknownMemOps[mnemonic](encodingFlags);
+                                flags ^= SuffixFlags.MUnknown;
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+
+            switch (suffixBytes - accounted)
+            {
+                case 8: if (accounted > 0) goto default; flags |= SuffixFlags.I8B; break;
+                case 4: flags |= SuffixFlags.I4B; break;
+                case 3: flags |= SuffixFlags.I3B; break;
+                case 2: flags |= SuffixFlags.I2B; break;
+                case 1: flags |= SuffixFlags.I1B; break;
+                case 0: break;
+                default:
+                    if (suffixBytes < accounted)
+                    {
+                        throw new Exception($"Encoding too short m:{map} o:{opIndex} s:{suffixBytes} a:{accounted}?? : {disassembly} ");
+                    }
+                    else if (suffixBytes - accounted > 8)
+                    {
+                        throw new Exception($"Encoding too long m:{map} o:{opIndex} s:{suffixBytes} a:{accounted}???? : {disassembly}");
+                    }
+                    else
+                    {
+                        throw new Exception($"Encoding Immediate too long m:{map} o:{opIndex} s:{suffixBytes} a:{accounted}???? : {disassembly}");
+                    }
+            }
+
+            return flags;
+        }
+    }
+
+
+    class Amd64InstructionTableGenerator
+    {
+        List<Amd64InstructionSample> samples = new List<Amd64InstructionSample>();
+
+        static readonly string assemblyPrefix = "   0x000000000";
+        static readonly string preTerminator = "58\t";
+        static readonly string groupTerminator = "59\tpop";
+        static readonly Regex badDisassembly = new Regex(@"((\(bad\))|(\srex(\.[WRXB]*)?\s*(#.*)?$))");
+        List<(Map, int)> regExpandOpcodes;
+
+        // C++ Code generation
+        HashSet<string> rules;
+        Dictionary<Map, Dictionary<int, string>> opcodes;
+        int currentExtension = -8;
+
+        Amd64InstructionTableGenerator()
+        {
+            regExpandOpcodes = new List<(Map, int)>()
+            {
+                // Code assunes ordered list
+                (Map.Primary, 0xd9),
+                (Map.Primary, 0xdb),
+                (Map.Primary, 0xdd),
+                (Map.Primary, 0xdf),
+                (Map.Primary, 0xf6),
+                (Map.Primary, 0xf7),
+                (Map.Primary, 0xff),
+                (Map.Secondary, 0x01),
+                (Map.Secondary, 0xae),
+                (Map.Secondary, 0xc7),
+            };
+
+            rules = new HashSet<string>();
+            opcodes = new Dictionary<Map, Dictionary<int, string>>()
+            {
+                { Map.None,      new Dictionary<int, string>() },
+                { Map.Primary,   new Dictionary<int, string>() },
+                { Map.Secondary, new Dictionary<int, string>() },
+                { Map.F38,       new Dictionary<int, string>() },
+                { Map.F3A,       new Dictionary<int, string>() },
+                { Map.NOW3D,     new Dictionary<int, string>() },
+                { Map.Vex1,      new Dictionary<int, string>() },
+                { Map.Vex2,      new Dictionary<int, string>() },
+                { Map.Vex3,      new Dictionary<int, string>() },
+                { Map.XOP8,      new Dictionary<int, string>() },
+                { Map.XOP9,      new Dictionary<int, string>() },
+                { Map.XOPA,      new Dictionary<int, string>() },
+            };
+
+            ParseSamples();
+            WriteCode();
+        }
+
+        void ParseSamples()
+        {
+            string line;
+            string sample = null;
+            bool saw58 = false;
+            while ((line = Console.In.ReadLine()) != null)
+            {
+                if (sample == null)
+                {
+                    // Ignore non-assembly lines
+                    if (line.StartsWith(assemblyPrefix))
+                        sample = line.Trim();
+                    continue;
+                }
+
+                // Each sample may contain multiple instructions
+                // We are only interested in the first of each group
+                // Each group is terminated by 0x58 then 0x59 which is a pop instruction
+                if (!saw58)
+                {
+                    saw58 = line.Contains(preTerminator);
+                    continue;
+                }
+                else if (!line.Contains(groupTerminator))
+                {
+                    saw58 = false;
+                    continue;
+                }
+
+                if (!badDisassembly.IsMatch(sample))
+                {
+                    try
+                    {
+                        // We expect samples to be disassembled instruction in intel disassembly syntax
+                        // Roughly like this:
+                        //    0x0000000000713cd0 <+1125488>:	c4 01 02 7f 05 50 51 52 53	vmovdqu XMMWORD PTR [rip+0x53525150],xmm8        # 0x53c38e29
+                        var s = new Amd64InstructionSample(sample);
+
+                        SuffixFlags suffix = s.parseSuffix();
+                        AddSample(s);
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine($"Exception:{e.Message}");
+                    }
+                }
+
+                saw58 = false;
+                sample = null;
+
+                continue;
+            };
+        }
+
+        void AddSample(Amd64InstructionSample sample)
+        {
+            if (samples.Count > 0)
+            {
+                bool regEnc = (regExpandOpcodes.Count > 0) && ((samples[0].map, samples[0].opCodeExt >> 4) == regExpandOpcodes[0]);
+
+                if ((sample.opCodeExt != samples[0].opCodeExt) || (regEnc && (sample.modrm_reg != samples[0].modrm_reg)))
+                {
+                    SummarizeSamples(regEnc);
+                    if (regEnc && ((sample.opCodeExt >> 4) != (samples[0].opCodeExt >> 4)))
+                    {
+                        // Console.WriteLine($"Removing {regExpandOpcodes[0]}");
+                        regExpandOpcodes.RemoveAt(0);
+                    }
+                    samples.Clear();
+                }
+            }
+            samples.Add(sample);
+        }
+
+        void SummarizeSamples(bool reg)
+        {
+            var sample = samples[0];
+            SuffixFlags intersectionSuffix = (SuffixFlags)~0;
+            SuffixFlags unionSuffix = 0;
+            var map = new Dictionary<SuffixFlags, List<Amd64InstructionSample>>();
+            HashSet<string> mnemonics = new HashSet<string>();
+            foreach (var s in samples)
+            {
+                SuffixFlags suffix = s.parseSuffix();
+
+                if (!map.ContainsKey(suffix))
+                {
+                    map[suffix] = new List<Amd64InstructionSample>() { };
+                }
+                map[suffix].Add(s);
+
+                mnemonics.Add(s.mnemonic);
+
+                intersectionSuffix &= suffix;
+                unionSuffix |= suffix;
+            }
+            string rules = Enum.Format(typeof(SuffixFlags), intersectionSuffix, "F").Replace(", ", "_");
+
+            rules = rules.Replace("None", "^");
+
+            SuffixFlags sometimesSuffix = unionSuffix & ~intersectionSuffix;
+            switch (sometimesSuffix)
+            {
+                case SuffixFlags.None:
+                    break;
+                case SuffixFlags.M32B | SuffixFlags.M16B:
+                    if (TestHypothesis((e) => Amd64L(SuffixFlags.M32B, SuffixFlags.M16B, e), sometimesSuffix, map))
+                        rules += "_L_M32B_or_M16B";
+                    else
+                        goto default;
+                    break;
+                case SuffixFlags.M32B | SuffixFlags.M8B:
+                    if (TestHypothesis((e) => Amd64L(SuffixFlags.M32B, SuffixFlags.M8B, e), sometimesSuffix, map))
+                        rules += "_L_M32B_or_M8B";
+                    else
+                        goto default;
+                    break;
+                case SuffixFlags.M16B | SuffixFlags.M8B:
+                    if (TestHypothesis((e) => Amd64L(SuffixFlags.M16B, SuffixFlags.M8B, e), sometimesSuffix, map))
+                        rules += "_L_M16B_or_M8B";
+                    else if (TestHypothesis((e) => Amd64W(SuffixFlags.M16B, SuffixFlags.M8B, e), sometimesSuffix, map))
+                        rules += "_W_M16B_or_M8B";
+                    else
+                        goto default;
+                    break;
+                case SuffixFlags.M16B | SuffixFlags.MOp:
+                    if (TestHypothesis((e) => Amd64W(SuffixFlags.None, SuffixFlags.M16B | SuffixFlags.MOp, e), sometimesSuffix, map))
+                        rules += "_W_None_or_MOp_M16B";
+                    else
+                        goto default;
+                    break;
+                case SuffixFlags.M8B | SuffixFlags.M4B:
+                    if (TestHypothesis((e) => Amd64W(SuffixFlags.M8B, SuffixFlags.M4B, e), sometimesSuffix, map))
+                        rules += "_W_M8B_or_M4B";
+                    else if (TestHypothesis((e) => Amd64L(SuffixFlags.M8B, SuffixFlags.M4B, e), sometimesSuffix, map))
+                        rules += "_L_M8B_or_M4B";
+                    else
+                        goto default;
+                    break;
+                case SuffixFlags.M8B | SuffixFlags.M4B | SuffixFlags.M2B:
+                    if (TestHypothesis((e) => Amd64WP(SuffixFlags.M8B, SuffixFlags.M4B, SuffixFlags.M2B, e), sometimesSuffix, map))
+                        rules += "_WP_M8B_or_M4B_or_M2B";
+                    else
+                        goto default;
+                    break;
+                case SuffixFlags.M8B | SuffixFlags.M2B:
+                    if (TestHypothesis((e) => Amd64W(SuffixFlags.M8B, SuffixFlags.M2B, e), sometimesSuffix, map))
+                        rules += "_W_M8B_or_M2B";
+                    else if (TestHypothesis((e) => Amd64WP(SuffixFlags.M8B, SuffixFlags.M8B, SuffixFlags.M2B, e), sometimesSuffix, map))
+                        rules += "_WP_M8B_or_M8B_or_M2B";
+                    else
+                        goto default;
+                    break;
+                case SuffixFlags.M6B | SuffixFlags.M4B:
+                    if (TestHypothesis((e) => Amd64P(SuffixFlags.M6B, SuffixFlags.M4B, e), sometimesSuffix, map))
+                        rules += "_P_M6B_or_M4B";
+                    else
+                        goto default;
+                    break;
+                case SuffixFlags.M4B | SuffixFlags.M2B:
+                    if (TestHypothesis((e) => Amd64L(SuffixFlags.M4B, SuffixFlags.M2B, e), sometimesSuffix, map))
+                        rules += "_L_M4B_or_M2B";
+                    else
+                        goto default;
+                    break;
+                case SuffixFlags.M4B | SuffixFlags.M1B:
+                    if (TestHypothesis((e) => Amd64W(SuffixFlags.M4B, SuffixFlags.M1B, e), sometimesSuffix, map))
+                        rules += "_W_M4B_or_M1B";
+                    else
+                        goto default;
+                    break;
+                case SuffixFlags.I8B | SuffixFlags.I4B | SuffixFlags.I2B:
+                    if (TestHypothesis((e) => Amd64WP(SuffixFlags.I8B, SuffixFlags.I4B, SuffixFlags.I2B, e), sometimesSuffix, map))
+                        rules += "_WP_I8B_or_I4B_or_I2B";
+                    else
+                        goto default;
+                    break;
+                case SuffixFlags.I4B | SuffixFlags.I2B:
+                    if (TestHypothesis((e) => Amd64WP(SuffixFlags.I4B, SuffixFlags.I4B, SuffixFlags.I2B, e), sometimesSuffix, map))
+                        rules += "_WP_I4B_or_I4B_or_I2B";
+                    else
+                        goto default;
+                    break;
+                case SuffixFlags.M8B | SuffixFlags.M4B | SuffixFlags.M2B | SuffixFlags.I4B | SuffixFlags.I2B:
+                    if (TestHypothesis((e) => Amd64WP(SuffixFlags.M8B | SuffixFlags.I4B, SuffixFlags.M4B | SuffixFlags.I4B, SuffixFlags.M2B | SuffixFlags.I2B, e), sometimesSuffix, map))
+                        rules += "_WP_M8B_I4B_or_M4B_I4B_or_M2B_I2B";
+                    else
+                        goto default;
+                    break;
+                default:
+                    throw new Exception($"Unhandled rule...{sometimesSuffix}");
+            }
+            rules = rules.Replace("^_", "").Replace("^", "None");
+
+            AddOpCode(sample.map, sample.opCodeExt, reg, sample.modrm_reg, rules, mnemonics);
+            // string op = reg ? $"OpReg(0x{sample.opCode:x3}, 0x{sample.modrm_reg})" : $"Op(0x{sample.opCode:x3})";
+            // Console.WriteLine($"Amd64Op({sample.map}, {op}, {sample.mnemonic}, {rules})");
+        }
+
+        bool TestHypothesis(Func<EncodingFlags, SuffixFlags> hypothesis, SuffixFlags sometimes, Dictionary<SuffixFlags, List<Amd64InstructionSample>> samples)
+        {
+            foreach ((SuffixFlags e, List<Amd64InstructionSample> l) in samples)
+            {
+                foreach (var sample in l)
+                {
+                    if (hypothesis(sample.encodingFlags) != (e & sometimes))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        public static SuffixFlags Test(EncodingFlags e, SuffixFlags t, SuffixFlags f, EncodingFlags g) => g.HasFlag(e) ? t : f;
+
+        public static SuffixFlags Amd64L(SuffixFlags t, SuffixFlags f, EncodingFlags g) => Test(EncodingFlags.L, t, f, g);
+        public static SuffixFlags Amd64W(SuffixFlags t, SuffixFlags f, EncodingFlags g) => Test(EncodingFlags.W, t, f, g);
+        public static SuffixFlags Amd64P(SuffixFlags t, SuffixFlags f, EncodingFlags g) => Test(EncodingFlags.P, f, t, g);
+        public static SuffixFlags Amd64WP(SuffixFlags tx, SuffixFlags ft, SuffixFlags ff, EncodingFlags g) => Amd64W(tx, Amd64P(ft, ff, g), g);
+
+        void AddOpCode(Map map, int opCode, bool reg, int modrmReg, string rule, HashSet<string> mnemonics)
+        {
+            rules.Add(rule);
+
+            if (reg)
+            {
+                if (!opcodes[map].ContainsKey(opCode))
+                {
+                    currentExtension += 8;
+                    string ext = $"InstrForm(int(Extension)|0x{(currentExtension >> 3):x2})";
+                    opcodes[map][opCode] = $"        {ext + ",",-40} // 0x{opCode:x3}";
+                }
+                opcodes[Map.None][currentExtension|modrmReg] = $"        {rule + ",",-40} // {map}:0x{opCode:x3}/{modrmReg} {string.Join(",", mnemonics.OrderBy(s => s))}";
+            }
+            else
+            {
+                opcodes[map][opCode] = $"        {rule + ",",-40} // 0x{opCode:x3} {string.Join(",", mnemonics.OrderBy(s => s))}";
+            }
+        }
+
+        void WriteCode()
+        {
+            string none = "None";
+            string none3dnow = "MOp_M8B_I1B"; // All 3DNow instructions include a memOp.  All current 3DNow instructions encode the operand as I1B
+            rules.Add(none3dnow);
+
+            Console.WriteLine("// Licensed to the .NET Foundation under one or more agreements.");
+            Console.WriteLine("// The .NET Foundation licenses this file to you under the MIT license.");
+            Console.WriteLine("// See the LICENSE file in the project root for more information.");
+            Console.WriteLine();
+            Console.WriteLine();
+            Console.WriteLine("// File machine generated. See gen_amd64InstrDecode/README.md");
+            Console.WriteLine();
+            Console.WriteLine();
+            Console.WriteLine("namespace Amd64InstrDecode");
+            Console.WriteLine("{");
+            Console.WriteLine("    // The enumeration below encodes the various amd64 instruction forms");
+            Console.WriteLine("    // Each enumeration is an '_' separated set of flags");
+            Console.WriteLine("    //      None     // No flags set");
+            Console.WriteLine("    //      MOp      // Instruction supports modrm RIP memory operations");
+            Console.WriteLine("    //      M1st     // Memory op is first operand normally src/dst");
+            Console.WriteLine("    //      MOnly    // Memory op is only operand.  May not be a write...");
+            Console.WriteLine("    //      MUnknown // Memory op size is unknown.  Size not included in disassemby");
+            Console.WriteLine("    //      MAddr    // Memory op is address load effective address");
+            Console.WriteLine("    //      M1B      // Memory op is 1  byte");
+            Console.WriteLine("    //      M2B      // Memory op is 2  bytes");
+            Console.WriteLine("    //      M4B      // Memory op is 4  bytes");
+            Console.WriteLine("    //      M8B      // Memory op is 8  bytes");
+            Console.WriteLine("    //      M16B     // Memory op is 16 bytes");
+            Console.WriteLine("    //      M32B     // Memory op is 32 bytes");
+            Console.WriteLine("    //      M6B      // Memory op is 6  bytes");
+            Console.WriteLine("    //      M10B     // Memory op is 10 bytes");
+            Console.WriteLine("    //      I1B      // Instruction includes 1  byte  of immediates");
+            Console.WriteLine("    //      I2B      // Instruction includes 2  bytes of immediates");
+            Console.WriteLine("    //      I3B      // Instruction includes 3  bytes of immediates");
+            Console.WriteLine("    //      I4B      // Instruction includes 4  bytes of immediates");
+            Console.WriteLine("    //      I8B      // Instruction includes 8  bytes of immediates");
+            Console.WriteLine("    //      Unknown  // Instruction samples did not include a modrm configured to produce RIP addressing");
+            Console.WriteLine("    //      L        // Flags depend on L bit in encoding.  L_<flagsLTrue>_or_<flagsLFalse>");
+            Console.WriteLine("    //      W        // Flags depend on W bit in encoding.  W_<flagsWTrue>_or_<flagsWFalse>");
+            Console.WriteLine("    //      P        // Flags depend on OpSize prefix for encoding.  P_<flagsNoOpSizePrefix>_or_<flagsOpSizePrefix>");
+            Console.WriteLine("    //      WP       // Flags depend on W bit in encoding and OpSize prefix.  WP_<flagsWTrue>_or__<flagsNoOpSizePrefix>_or_<flagsOpSizePrefix>");
+            Console.WriteLine("    //      or       // Flag option separator used in W, L, P, and WP above");
+            Console.WriteLine("    enum InstrForm : uint8_t");
+            Console.WriteLine("    {");
+            Console.WriteLine($"       None,");
+            foreach (string rule in rules.OrderBy(s => s))
+            {
+                if (rule == "None")
+                    continue;
+                Console.WriteLine($"       {rule},");
+            }
+            Console.WriteLine($"       Extension = 0x80, // The instruction encoding form depends on the modrm.reg field. Extension table location in encoded in lower bits");
+            Console.WriteLine("    };");
+
+            Console.WriteLine();
+            Console.WriteLine("    // The following instrForm maps correspond to the amd64 instr maps");
+            Console.WriteLine("    // The comments are for debugging convenience.  The comments use a packed opcode followed by a list of observed mnemonics");
+            Console.WriteLine("    // The opcode is packed to be human readable.  PackedOpcode = opcode << 4 + pp");
+            Console.WriteLine("    //   - For Vex* and Xop* the pp is directly included in the encoding");
+            Console.WriteLine("    //   - For the Secondary, F38, and F3A pages the pp is not defined in the encoding, but affects instr form.");
+            Console.WriteLine("    //          - pp = 0 implies no prefix.");
+            Console.WriteLine("    //          - pp = 1 implies 0x66 OpSize prefix only.");
+            Console.WriteLine("    //          - pp = 2 implies 0xF3 prefix.");
+            Console.WriteLine("    //          - pp = 3 implies 0xF2 prefix.");
+            Console.WriteLine("    //   - For the primary and 3DNow pp is not used. And is always 0 in the comments");
+            Console.WriteLine();
+            Console.WriteLine();
+            Console.WriteLine("    // Instruction which change forms based on modrm.reg are encoded in this extension table.");
+            Console.WriteLine("    // Since there are 8 modrm.reg values, they occur is groups of 8.");
+            Console.WriteLine("    // Each group is referenced from the other tables below using Extension|(index >> 3).");
+            currentExtension += 8;
+            Console.WriteLine($"    static const InstrForm instrFormExtension[{currentExtension + 1}]");
+            Console.WriteLine("    {");
+            for (int i = 0; i < currentExtension; i++)
+            {
+                if (opcodes[Map.None].ContainsKey(i))
+                    Console.WriteLine(opcodes[Map.None][i]);
+                else
+                    Console.WriteLine($"        {none},");
+            }
+            Console.WriteLine("    };");
+
+            Console.WriteLine();
+            Console.WriteLine($"    static const InstrForm instrFormPrimary[256]");
+            Console.WriteLine("    {");
+            for (int i = 0; i < 4096; i+= 16)
+            {
+                if (opcodes[Map.Primary].ContainsKey(i))
+                    Console.WriteLine(opcodes[Map.Primary][i]);
+                else
+                    Console.WriteLine($"        {none + ",",-40} // 0x{i:x3}");
+            }
+            Console.WriteLine("    };");
+
+            Console.WriteLine();
+            Console.WriteLine($"    static const InstrForm instrForm3DNow[256]");
+            Console.WriteLine("    {");
+            for (int i = 0; i < 4096; i+= 16)
+            {
+                if (opcodes[Map.NOW3D].ContainsKey(i))
+                    Console.WriteLine(opcodes[Map.NOW3D][i]);
+                else
+                    Console.WriteLine($"        {none3dnow + ",",-40} // 0x{i:x3}");
+            }
+            Console.WriteLine("    };");
+
+            var mapTuples = new List<(string, Map)>()
+            {("Secondary", Map.Secondary), ("F38", Map.F38), ("F3A", Map.F3A), ("Vex1", Map.Vex1), ("Vex2", Map.Vex2), ("Vex3", Map.Vex3), ("XOP8", Map.XOP8), ("XOP9", Map.XOP9), ("XOPA", Map.XOPA)};
+
+            foreach((string name, Map map) in mapTuples)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"    static const InstrForm instrForm{name}[1024]");
+                Console.WriteLine("    {");
+                for (int i = 0; i < 4096; i+= 16)
+                {
+                    for (int pp = 0; pp < 4; pp++)
+                    {
+                        if (opcodes[map].ContainsKey(i + pp))
+                            Console.WriteLine(opcodes[map][i + pp]);
+                        else
+                            Console.WriteLine($"        {none + ",",-40} // 0x{i + pp:x3}");
+                    }
+                }
+                Console.WriteLine("    };");
+            }
+
+            Console.WriteLine("}");
+        }
+
+        static void Main(string[] args)
+        {
+            new Amd64InstructionTableGenerator();
+        }
+    }
+}

--- a/src/debug/ee/amd64/gen_amd64InstrDecode/Amd64InstructionTableGenerator.csproj
+++ b/src/debug/ee/amd64/gen_amd64InstrDecode/Amd64InstructionTableGenerator.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/debug/ee/amd64/gen_amd64InstrDecode/README.md
+++ b/src/debug/ee/amd64/gen_amd64InstrDecode/README.md
@@ -1,0 +1,371 @@
+# Generating `amd64InstrDecode.h`
+
+## TL;DR - What do I do? Process
+
+The following process was executed on an amd64 Linux host in this directory.
+
+```bash
+# Create the program createOpcodes
+gcc createOpcodes.cpp -o createOpcodes
+
+# Execute the program to create opcodes.cpp
+./createOpcodes > opcodes.cpp
+
+# Compile opcodes.cpp to opcodes
+gcc -g opcodes.cpp -o opcodes
+
+# Disassemble opcodes
+gdb opcodes -batch -ex "set disassembly-flavor intel" -ex "disass /r opcodes" > opcodes.intel
+
+# Parse disassembly and generate code
+cat opcodes.intel | dotnet run > ../amd64InstrDecode.h
+```
+
+## Technical design
+
+`amd64InstrDecode.h`'s primary purpose is to provide a reliable
+and accurately mechanism to implement
+`Amd64 NativeWalker::DecodeInstructionForPatchSkip(..)`.
+
+This function needs to be able to decode an arbitrary `amd64`
+instruction.  The decoder currently must be able to identify:
+
+- Whether the instruction includes an instruction pointer relative memory access
+- The location of the memory displacement within the instruction
+- The instruction length in bytes
+- The size of the memory operation in bytes
+
+To get this right is complicated, because the `amd64` instruction set is
+complicated.
+
+A high level view of the `amd64` instruction set can be seen by looking at
+`AMD64 Architecture Programmer’s
+ Manual Volume 3:
+ General-Purpose and System Instructions`
+ `Section 1.1 Instruction Encoding Overview`
+ `Figure 1-1.  Instruction Encoding Syntax`
+
+The general behavior of each instruction can be modified by many of the
+bytes in the 1-15 byte instruction.
+
+This set of files generates a metadata table by extracting the data from
+sample instruction disassembly.
+
+The process entails
+- Generating a necessary set of instructions
+- Generating parsable disassembly for the instructions
+- Parsing the disassembly
+
+### Generating a necessary set of instructions
+
+#### The necessary set
+
+- All instruction forms which use instruction pointer relative memory accesses.
+- All combinations of modifier bits which affect the instruction form
+    - presence and/or size of the memory access
+    - size or presence of immediates
+
+So with modrm.mod = 0, modrm.rm = 0x5 (instruction pointer relative memory access)
+we need all combinations of:
+- `opcodemap`
+- `opcode`
+- `modrm.reg`
+- `pp`, `W`, `L`
+- Some combinations of `vvvv`
+- Optional prefixes: `repe`, `repne`, `opSize`
+
+#### Padding
+
+We will iterate through all the necessary set. Many of these combinations
+will lead to invalid/undefined encodings.  This will cause the disassembler
+to give up and mark the disassemble as bad.
+
+The disassemble will then resume trying to disassemble at the next boundary.
+
+To make sure the disassembler attempts to disassemble every instruction,
+we need to make sure the preceding instruction is always valid and terminates
+at our desired instruction boundary.
+
+Through examination of the `Primary` opcode map, it is observed that
+0x50-0x5f are all 1 byte instructions.  These become convenient padding.
+
+After each necessary instruction we insert enough padding bytes to fill
+the maximum instruction length and leave at least one additional one byte
+instruction.
+
+#### Fixed suffix
+
+Using a fixed suffix makes disassembly parsing simpler.
+
+After the modrm byte, the generated instructions always include a
+`postamble`,
+
+```C++
+const char* postamble = "0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59,\n";
+```
+
+This meets the padding consistency needs.
+
+#### Ordering
+
+As a convenience to the parser the encoded instructions are logically
+ordered.  The ordering is generally, but can vary slightly depending on
+the needs of the particular opcode map:
+
+- map
+- opcode
+- pp & some prefixes
+- modrm.reg
+- W, L, vvvv
+
+This is to keep related instruction grouped together.
+
+#### Encoding the instructions
+
+The simplest way to get these instructions into an object file for
+disassembly is to place them into a C++ BYTE array.
+
+The file `createOpcodes.cpp` is the source for a program which will
+generate `opcodes.cpp`
+
+```bash
+# Create the program createOpcodes
+gcc createOpcodes.cpp -o createOpcodes
+
+# Execute the program to create opcodes.cpp
+./createOpcodes > opcodes.cpp
+```
+
+`opcodes.cpp` will now be a C++ source file with `uint8_t opcodes[]`
+initialized with our set of necessary instructions and padding.
+
+We need to compile this to an executable to prepare for disassembly.
+
+```bash
+# Compile opcodes.cpp to opcodes
+gcc -g opcodes.cpp -o opcodes
+```
+
+### Generating parsable disassembly
+
+In investigating the various disassembly formats, the `intel`
+disassembly format is superior to the `att` format. This is because the
+`intel` format clearly marks the the instruction relative accesses and
+their sizes. For instance:
+
+- "BYTE PTR [rip+0x53525150]"
+- "WORD PTR [rip+0x53525150]"
+- "DWORD PTR [rip+0x53525150]"
+- "QWORD PTR [rip+0x53525150]"
+- "OWORD PTR [rip+0x53525150]"
+- "XMMWORD PTR [rip+0x53525150]"
+- "YMMWORD PTR [rip+0x53525150]"
+- "FWORD PTR [rip+0x53525150]"
+- "TBYTE PTR [rip+0x53525150]"
+
+Also it is important to have all the raw bytes in the disassembly.  This
+allows accurately determining the instruction length.
+
+It also helps identifying which instructions are from our needed set.
+
+I happened to have used `gdb` as a disassembler.
+
+```bash
+# Disassemble opcodes
+gdb opcodes -batch -ex "set disassembly-flavor intel" -ex "disass /r opcodes" > opcodes.intel
+```
+
+#### Alternative disassemblers
+
+It seems `objdump` could provide similar results. Untested, the parser may need to
+be modified for subtle differences.
+```bash
+objdump -D -M intel -b --insn-width=15 -j .data opcodes
+```
+
+The lldb parser aborts parsing when it observes bad instruction. It
+might be usable with additional python scripts.
+
+Windows disassembler may also work.  Not attempted.
+
+### Parsing the disassembly
+```bash
+# Parse disassembly and generate code
+cat opcodes.intel | dotnet run > ../amd64InstrDecode.h
+```
+#### Finding relevant disassembly lines
+
+We are not interested in all lines in the disassembly. The disassembler
+stray comments, recovery and our padding introduce lines we need to ignore.
+
+We filter out and ignore non-disassembly lines using a `Regex` for a
+disassembly line.
+
+We expect the generated instruction samples to be in a group.  The first
+instruction in the group is the only one we are interested in.  This is
+the one we are interested in.
+
+The group is terminated by a pair of instructions.  The first terminal
+instruction must have `0x58` as the last byte in it encoding. The final
+terminal instruction must be a `0x59\tpop`.
+
+We continue parsing the first line of each group.
+
+#### Ignoring bad encodings
+
+Many encodings are not valid.  For `gdb`, these instructions are marked
+`(bad)`.  We filter and ignore these.
+
+#### Parsing the disassambly for each instruction sample
+
+For each sample, we need to calculate the important properties:
+- mnemonic
+- raw encoding
+- disassembly (for debug)
+- Encoding
+    - map
+    - opcode position
+- Encoding Flags
+    - pp, W, L, prefix and encoding flags
+- `SuffixFlags`
+    - presence of instruction relative accesses
+        - size of operation
+        - position in the list of operands
+        - number of immediate bytes
+
+##### Supplementing the disassembler
+
+In a few cases it was observed the disassembly of some memory operations
+did not include a size. These were manually researched.  For the ones with
+reasonable sizes, these were added to a table to manually override these
+unknown sizes.
+
+#### `opCodeExt`
+
+To facilitate identifying sets of instructions, the creates an `opCodeExt`.
+
+For the `Primary` map this is simply the encoded opcode from the instruction
+shifted left by 4 bits.
+
+For the 3D Now `NOW3D` map this is simply the encoded immediate from the
+instruction shifted left by 4 bits.
+
+For the `Secondary` `F38`, and `F39` maps this is the encoded opcode from
+the instruction shifted left by 4 bits orred with a synthetic `pp`. The
+synthetic `pp` is constructed to match the rules of
+`Table 1-22. VEX/XOP.pp Encoding` from the
+`AMD64 Architecture Programmer’s
+ Manual Volume 3:
+ General-Purpose and System Instructions`.  For the case where the opSize
+ 0x66 prefix is present with a `rep*` prefix, the `rep*` prefix is used
+ to encode `pp`.
+
+For the `VEX*` and `XOP*` maps this is the encoded opcode from
+the instruction shifted left by 4 bits orred with `pp`.
+
+#### Identifying sets of instructions
+
+For most instructions, the opCodeExt will uniquely identify the instruction.
+
+For many instructions, `modrm.reg` is used to uniquely identify the instruction.
+These instruction typically change mnemonic and behavior as `modrm.reg`
+changes. These become problematic, when the form of these instructions vary.
+
+For a few other instructions the `L`, `W`, `vvvv` value may the instruction
+change behavior. Usually these do not change mnemonic.
+
+The set of instructions is therefore usually grouped by the opcode map and
+`opCodeExt` generated above.  For these a change in `opCodeExt` or `map`
+will start a new group.
+
+For select problematic groups of `modrm.reg` sensitive instructions, a
+change in modrm.reg will start a new group.
+
+#### For each set of instructions
+
+- Calculate the `intersection` and `union` of the `SuffixFlags` for the set.
+- The flags in the `intersection` are common to all instructions in the set.
+- The ones in the `union`, but not in the `intersection` vary within the
+set based on the encoding flags.  These are the `sometimesFlags`
+- Determine the rules for the `sometimesFlags`.  For each combination of
+`sometimesFlags`, check each rule by calling `TestHypothesis`.  This
+determines if the rule corresponds to the set of observations.
+
+Encode the rule as a string.
+
+Add the rule to the set of all observed rules.
+Add the set's rule with comment to a dictionary.
+
+#### Generating the C++ code
+
+At this point generating the code is rather simple.
+
+Iterate through the set of rules to create an enumeration of `InstrForm`.
+
+For each map iterate through the dictionary, filling missing instructions
+with an appropriate pattern for undefined instructions.
+
+##### Encoding
+
+The design uses a simple fully populated direct look up table to
+provide a nice simple means of looking up. This direct map approach is
+expected to consume ~10K bytes.
+
+Other approaches like a sparse list may reduce total memory usage. The
+added complexity did not seem worth it.
+
+
+## Benefits
+
+This approach is intended to reduce the human error introduced by
+manually parsing and encoding the various instruction forms from their
+respective descriptions.
+
+## Limitations
+
+The approach of using a single object file as the source of disassembly
+samples, is restricted to a max compilation/link unit size. Early drafts
+were generating more instructions, and couldn't be compiled.
+
+However, there is no restriction that all the samples must come from
+single executable.  These could easily be separated by opcode map...
+
+## Risks
+
+### New instruction sets
+
+This design is for existing instruction sets.  New instruction sets will
+require more work.
+
+Further this methodology uses the disassembler to generate the tables.
+Until a reasonably featured disassembler is created, the new instruction
+set can not be supported by this methodology.
+
+The previous methodology of manually encoding these new instruction set
+would still be possible....
+
+### Disassembler errors
+
+This design presumes the disassembler is correct. The specific version
+of the disassembler may have disassembly bugs.  Using newer disassemblers
+would mitigate this to some extent.
+
+### Bugs
+- Inadequate samples.  Are there other bits which modify instruction
+behavior which we missed?
+- Parser/Table generator implementation bugs. Does the parser do what it
+was intended to do?
+
+## Reasons to regenerate the file
+
+### Disassembler error discovered
+
+Add a patch to the parser to workaround the bug and regenerate the table
+
+### Newer disassembler available
+
+Regenerate and compare.
+
+### New debugger feature requires more metadata
+
+Add new feature code, regenerate

--- a/src/debug/ee/amd64/gen_amd64InstrDecode/createOpcodes.cpp
+++ b/src/debug/ee/amd64/gen_amd64InstrDecode/createOpcodes.cpp
@@ -1,0 +1,257 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <stdio.h>
+
+int main(int argc, char*argv[])
+{
+    printf("#include <stdio.h>\n");
+    printf("#include <inttypes.h>\n");
+
+    const char* postamble = "0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59,\n";
+
+    printf("uint8_t opcodes[] = {\n");
+
+    printf("// Primary Opcode\n");
+    for (int i = 0; i < 256; ++i)
+    {
+        int last = 64;
+        switch(i)
+        {
+            case 0x0f: // Secondary Escape
+            case 0x26: // ES
+            case 0x2e: // CS
+            case 0x36: // SS
+            case 0x40: // REX
+            case 0x41: // REX
+            case 0x42: // REX
+            case 0x43: // REX
+            case 0x44: // REX
+            case 0x45: // REX
+            case 0x46: // REX
+            case 0x47: // REX
+            case 0x48: // REX
+            case 0x49: // REX
+            case 0x4A: // REX
+            case 0x4B: // REX
+            case 0x4C: // REX
+            case 0x4D: // REX
+            case 0x4E: // REX
+            case 0x4F: // REX
+            case 0x64: // FS
+            case 0x65: // GS
+            case 0x66: // OpSize
+            case 0x67: // AddrSize
+            case 0xc4: // Vex 1 Byte
+            case 0xc5: // VEx 2 Byte
+            case 0xf0: // Lock
+            case 0xf2: // Repne
+            case 0xf3: // Rep
+                continue;
+            case 0x8f: // XOP except modrm.reg == 0
+                last = 8;
+                break;
+            default:
+                break;
+        };
+        for (int modrm = 0x5; modrm < 64; modrm += 8)
+        {
+            printf( "0x%02x, 0x%02x, %s", i, modrm, postamble);
+            printf( "0x66, 0x%02x, 0x%02x, %s", i, modrm, postamble);
+            // REX
+            printf( "0x40, 0x%02x, 0x%02x, %s", i, modrm, postamble);
+            printf( "0x66, 0x40, 0x%02x, 0x%02x, %s", i, modrm, postamble);
+            // REX.WRXB
+            printf( "0x4f, 0x%02x, 0x%02x, %s", i, modrm, postamble);
+            printf( "0x66, 0x4f, 0x%02x, 0x%02x, %s", i, modrm, postamble);
+        }
+        printf("\n");
+    }
+
+    const char* const ppString[] = {"", "0x66, ", "0xf3, ", "0xf2, "};
+    printf("// Secondary Opcode\n");
+    for (int i = 0; i < 256; ++i)
+    {
+        if (i == 0xf)
+            continue;
+        if (i == 0x38)
+            continue;
+        if (i == 0x3A)
+            continue;
+
+        for (int pp = 0; pp < 4; ++pp)
+        {
+            for (int modrm = 0x5; modrm < 64; modrm += 8)
+            {
+                printf( "%s0x0f, 0x%02x, 0x%02x, %s", ppString[pp], i, modrm, postamble);
+                // REX
+                printf( "0x40, %s0x0f, 0x%02x, 0x%02x, %s", ppString[pp], i, modrm, postamble);
+                // REX.WRXB
+                printf( "0x4f, %s0x0f, 0x%02x, 0x%02x, %s", ppString[pp], i, modrm, postamble);
+            }
+        }
+        printf("\n");
+    }
+
+    printf("// 3D Now\n");
+    for (int i = 0; i < 256; ++i)
+    {
+        printf( "0x0f, 0x0f, 0x05, 0x50, 0x51, 0x52, 0x53, 0x%02x, %s", i, postamble);
+        // REX
+        printf( "0x40, 0x0f, 0x0f, 0x05, 0x50, 0x51, 0x52, 0x53, 0x%02x, %s", i, postamble);
+        // REX.WRXB
+        printf( "0x4f, 0x0f, 0x0f, 0x05, 0x50, 0x51, 0x52, 0x53, 0x%02x, %s", i, postamble);
+        printf("\n");
+    }
+
+    printf("// Ox0f_0x38\n");
+    for (int i = 0; i < 256; ++i)
+    {
+        for (int pp = 0; pp < 4; ++pp)
+        {
+            bool rowF = ((i & 0xF0) == 0xF);
+            if (pp == 2) continue;
+            if ((pp == 3) & (!rowF)) continue;
+            if ((pp == 1) & (rowF)) continue;
+
+            for (int modrm = 0x5; modrm < 64; modrm += 8)
+            {
+                printf( "%s0x0f, 0x38, 0x%02x, 0x%02x, %s", ppString[pp], i, modrm, postamble);
+                if (rowF)
+                    printf( "0x66, %s0x0f, 0x38, 0x%02x, 0x%02x, %s", ppString[pp], i, modrm, postamble);
+                // REX
+                printf( "%s0x40, 0x0f, 0x38, 0x%02x, 0x%02x, %s", ppString[pp], i, modrm, postamble);
+                if (rowF)
+                    printf( "0x66, %s0x40, 0x0f, 0x38, 0x%02x, 0x%02x, %s", ppString[pp], i, modrm, postamble);
+                // REX.WRXB
+                printf( "%s0x4f, 0x0f, 0x38, 0x%02x, 0x%02x, %s", ppString[pp], i, modrm, postamble);
+                if (rowF)
+                    printf( "0x66, %s0x4f, 0x0f, 0x38, 0x%02x, 0x%02x, %s", ppString[pp], i, modrm, postamble);
+            }
+        }
+        printf("\n");
+    }
+
+    printf("// Ox0f_0x3A\n");
+    for (int i = 0; i < 256; ++i)
+    {
+        for (int pp = 0; pp < 2; ++pp)
+        {
+            for (int modrm = 0x5; modrm < 64; modrm += 8)
+            {
+                printf( "%s0x0f, 0x3A, 0x%02x, 0x%02x, %s", ppString[pp], i, modrm, postamble);
+                // REX
+                printf( "%s0x40, 0x0f, 0x3A, 0x%02x, 0x%02x, %s", ppString[pp], i, modrm, postamble);
+                // REX.WRXB
+                printf( "%s0x4f, 0x0f, 0x3A, 0x%02x, 0x%02x, %s", ppString[pp], i, modrm, postamble);
+            }
+        }
+        printf("\n");
+    }
+
+    int byte3cases[] = { 0x00, 0x04, 0x78, 0x7C, 0x80, 0x84, 0xF8, 0xFC };
+
+    printf("// VEX1\n");
+    for (int i = 0; i < 256; ++i)
+    {
+        for (int pp = 0; pp < 4; ++pp)
+        {
+            for (int modrm = 0x5; modrm < 64; modrm += 8)
+            {
+                for (int c = 0; c < sizeof(byte3cases)/sizeof(byte3cases[0]); ++c)
+                {
+                    printf( "0xc4, 0x01, 0x%02x, 0x%02x, 0x%02x, %s", pp + byte3cases[c],   i, modrm, postamble);
+                }
+            }
+        }
+        printf("\n");
+    }
+
+    printf("// VEX2\n");
+    for (int i = 0; i < 256; ++i)
+    {
+        for (int pp = 0; pp < 4; ++pp)
+        {
+            for (int modrm = 0x5; modrm < 64; modrm += 8)
+            {
+                for (int c = 0; c < sizeof(byte3cases)/sizeof(byte3cases[0]); ++c)
+                {
+                    printf( "0xc4, 0x02, 0x%02x, 0x%02x, 0x%02x, %s", pp + byte3cases[c],   i, modrm, postamble);
+                }
+            }
+        }
+        printf("\n");
+    }
+
+    printf("// VEX3\n");
+    for (int i = 0; i < 256; ++i)
+    {
+        for (int pp = 0; pp < 4; ++pp)
+        {
+            for (int modrm = 0x5; modrm < 64; modrm += 8)
+            {
+                for (int c = 0; c < sizeof(byte3cases)/sizeof(byte3cases[0]); ++c)
+                {
+                    printf( "0xc4, 0x03, 0x%02x, 0x%02x, 0x%02x, %s", pp + byte3cases[c],   i, modrm, postamble);
+                }
+            }
+        }
+        printf("\n");
+    }
+
+    printf("// XOP8\n");
+    for (int i = 0; i < 256; ++i)
+    {
+        for (int pp = 0; pp < 4; ++pp)
+        {
+            for (int modrm = 0x5; modrm < 64; modrm += 8)
+            {
+                for (int c = 0; c < sizeof(byte3cases)/sizeof(byte3cases[0]); ++c)
+                {
+                    printf( "0x8f, 0x08, 0x%02x, 0x%02x, 0x%02x, %s", pp + byte3cases[c],   i, modrm, postamble);
+                }
+            }
+        }
+        printf("\n");
+    }
+
+    printf("// XOP9\n");
+    for (int i = 0; i < 256; ++i)
+    {
+        for (int pp = 0; pp < 4; ++pp)
+        {
+            for (int modrm = 0x5; modrm < 64; modrm += 8)
+            {
+                for (int c = 0; c < sizeof(byte3cases)/sizeof(byte3cases[0]); ++c)
+                {
+                    printf( "0x8f, 0x09, 0x%02x, 0x%02x, 0x%02x, %s", pp + byte3cases[c],   i, modrm, postamble);
+                }
+            }
+        }
+        printf("\n");
+    }
+
+    printf("// XOPA\n");
+    for (int i = 0; i < 256; ++i)
+    {
+        for (int pp = 0; pp < 4; ++pp)
+        {
+            for (int modrm = 0x5; modrm < 64; modrm += 8)
+            {
+                for (int c = 0; c < sizeof(byte3cases)/sizeof(byte3cases[0]); ++c)
+                {
+                    printf( "0x8f, 0x0A, 0x%02x, 0x%02x, 0x%02x, %s", pp + byte3cases[c],   i, modrm, postamble);
+                }
+            }
+        }
+        printf("\n");
+    }
+    printf("0\n");
+    printf("};\n");
+    printf("\n");
+    printf("int main(int argc, char*argv[])\n");
+    printf("{\n");
+        printf("for (size_t i = 0; i < sizeof(opcodes) ; ++i) printf(\"opcodes[i] = 0x%%02x\\n\", opcodes[i]);");
+    printf("};\n");
+}

--- a/src/vm/amd64/jithelpers_fast.S
+++ b/src/vm/amd64/jithelpers_fast.S
@@ -33,8 +33,13 @@ LEAF_ENTRY JIT_CheckedWriteBarrier, _TEXT
         // See if this is in GCHeap
         PREPARE_EXTERNAL_VAR g_lowest_address, rax
         cmp     rdi, [rax]
+#ifdef FEATURE_WRITEBARRIER_COPY
+        // jb      NotInHeap
+        .byte 0x72, 0x12
+#else
         // jb      NotInHeap
         .byte 0x72, 0x0e
+#endif
         PREPARE_EXTERNAL_VAR g_highest_address, rax
         cmp     rdi, [rax]
 


### PR DESCRIPTION
Merge v3.1.7 to release/3.1-crossdac branch.

This corresponds to `git merge v3.1.7` and fixing the merge conflicts in `eng\pipelines\internal.yml` by ignoring irrelevant release/3.1 changes.

Do not squash into this branch to make merge commits easier.

Hold off on merging until #28077 is merged/built.
