### PR TITLE
[release/2.1] Add support for building CoreCLR using python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ OPTION(CLR_CMAKE_ENABLE_CODE_COVERAGE "Enable code coverage" OFF)
 OPTION(CLR_CMAKE_WARNINGS_ARE_ERRORS "Warnings are errors" ON)
 
 # Ensure that python is present
-find_program(PYTHON NAMES python2.7 python2 python)
+find_program(PYTHON NAMES python2.7 python2 python python3)
 if (PYTHON STREQUAL "PYTHON-NOTFOUND")
     message(FATAL_ERROR "PYTHON not found: Please install Python 2.7.9 or later from https://www.python.org/downloads/")
 endif()

--- a/build.sh
+++ b/build.sh
@@ -7,9 +7,9 @@ export ghprbCommentBody=
 
 # resolve python-version to use
 if [ "$PYTHON" == "" ] ; then
-    if ! PYTHON=$(command -v python2.7 || command -v python2 || command -v python)
+    if ! PYTHON=$(command -v python2.7 || command -v python2 || command -v python || command -v python3)
     then
-       echo "Unable to locate build-dependency python2.x!" 1>&2
+       echo "Unable to locate build-dependency python!" 1>&2
        exit 1
     fi
 fi
@@ -18,9 +18,11 @@ fi
 # useful in case of explicitly set option.
 if ! command -v $PYTHON > /dev/null
 then
-   echo "Unable to locate build-dependency python2.x ($PYTHON)!" 1>&2
+   echo "Unable to locate build-dependency python ($PYTHON)!" 1>&2
    exit 1
 fi
+
+export PYTHON
 
 usage()
 {

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -640,7 +640,7 @@
     <PropertyGroup>
       <CMakeDefinitionSaveFile>$(IntermediateOutputPath)..\cmake.definitions</CMakeDefinitionSaveFile>
     </PropertyGroup>
-    <Exec Command="python $(MSBuildThisFileDirectory)..\scripts\check-definitions.py &quot;$(CMakeDefinitionSaveFile)&quot; &quot;$(DefineConstants)&quot; &quot;$(IgnoreDefineConstants)&quot; " />
+    <Exec Command="&quot;$(PYTHON)&quot; $(MSBuildThisFileDirectory)..\scripts\check-definitions.py &quot;$(CMakeDefinitionSaveFile)&quot; &quot;$(DefineConstants)&quot; &quot;$(IgnoreDefineConstants)&quot; " />
   </Target>
   <PropertyGroup Condition="'$(BuildOS)' == 'Windows_NT'">
     <EnableDotnetAnalyzers Condition="'$(EnableDotnetAnalyzers)'==''">true</EnableDotnetAnalyzers>


### PR DESCRIPTION
This is a combined fix from 3 different PRs and one additional fix for 2.1:

- https://github.com/dotnet/coreclr/pull/19043
- https://github.com/dotnet/coreclr/pull/19356
- https://github.com/dotnet/coreclr/pull/22145

The 2.1-specific fix is that python3 is is only used as a fallback, in case all other python program names dont work.

As for the original PRs, they perform these changes:

build.sh and build.cmd contain logic to identify a working version of python to use. System.Private.CoreLib ignores that and directly invokes'python', which may not work, or even execute a different program. Fix that.

The windows build scripts try finding python in order of python3, python2 and then python. The unix build scripts dont. They just try python2 variants and then fail. This change makes brings them closer together by letting users build using only python3.

Use the same logic in CMakeLists.txt that's used in build.sh/build.cmd to lookup python.