### PR TITLE
Fix a deadlock in EventCounter/EventSource (backport runtime #40259)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
@@ -204,22 +204,47 @@ namespace System.Diagnostics.Tracing
 
         private void OnTimer()
         {
-            Debug.Assert(Monitor.IsEntered(s_counterGroupLock));
             if (_eventSource.IsEnabled())
             {
-                DateTime now = DateTime.UtcNow;
-                TimeSpan elapsed = now - _timeStampSinceCollectionStarted;
+                DateTime now;
+                TimeSpan elapsed;
+                int pollingIntervalInMilliseconds;
+                DiagnosticCounter[] counters;
+                lock (s_counterGroupLock)
+                {
+                    now = DateTime.UtcNow;
+                    elapsed = now - _timeStampSinceCollectionStarted;
+                    pollingIntervalInMilliseconds = _pollingIntervalInMilliseconds;
+                    counters = new DiagnosticCounter[_counters.Count];
+                    _counters.CopyTo(counters);
+                }
+
+                // MUST keep out of the scope of s_counterGroupLock because this will cause WritePayload
+                // callback can be re-entrant to CounterGroup (i.e. it's possible it calls back into EnableTimer()
+                // above, since WritePayload callback can contain user code that can invoke EventSource constructor
+                // and lead to a deadlock. (See https://github.com/dotnet/runtime/issues/40190 for details)
 
                 foreach (var counter in _counters)
                 {
-                    counter.WritePayload((float)elapsed.TotalSeconds, _pollingIntervalInMilliseconds);
+                    // NOTE: It is still possible for a race condition to occur here. An example is if the session
+                    // that subscribed to these batch of counters was disabled and it was immediately enabled in
+                    // a different session, some of the counter data that was supposed to be written to the old
+                    // session can now "overflow" into the new session.
+                    // This problem pre-existed to this change (when we used to hold lock in the call to WritePayload):
+                    // the only difference being the old behavior caused the entire batch of counters to be either
+                    // written to the old session or the new session. The behavior change is not being treated as a
+                    // significant problem to address for now, but we can come back and address it if it turns out to
+                    // be an actual issue.
+                    counter.WritePayload((float)elapsed.TotalSeconds, pollingIntervalInMilliseconds);
                 }
-                _timeStampSinceCollectionStarted = now;
-
-                do
+                lock (s_counterGroupLock)
                 {
-                    _nextPollingTimeStamp += new TimeSpan(0, 0, 0, 0, _pollingIntervalInMilliseconds);
-                } while (_nextPollingTimeStamp <= now);
+                    _timeStampSinceCollectionStarted = now;
+                    do
+                    {
+                        _nextPollingTimeStamp += new TimeSpan(0, 0, 0, 0, _pollingIntervalInMilliseconds);
+                    } while (_nextPollingTimeStamp <= now);
+                }
             }
         }
 
@@ -234,8 +259,15 @@ namespace System.Diagnostics.Tracing
         private static void PollForValues()
         {
             AutoResetEvent? sleepEvent = null;
+
+            // Cache of onTimer callbacks for each CounterGroup.
+            // We cache these outside of the scope of s_counterGroupLock because
+            // calling into the callbacks can cause a re-entrancy into CounterGroup.Enable()
+            // and result in a deadlock. (See https://github.com/dotnet/runtime/issues/40190 for details)
+            List<Action> onTimers = new List<Action>();
             while (true)
             {
+                onTimers.Clear();
                 int sleepDurationInMilliseconds = Int32.MaxValue;
                 lock (s_counterGroupLock)
                 {
@@ -245,13 +277,17 @@ namespace System.Diagnostics.Tracing
                         DateTime now = DateTime.UtcNow;
                         if (counterGroup._nextPollingTimeStamp < now + new TimeSpan(0, 0, 0, 0, 1))
                         {
-                            counterGroup.OnTimer();
+                            onTimers.Add(() => counterGroup.OnTimer());
                         }
 
                         int millisecondsTillNextPoll = (int)((counterGroup._nextPollingTimeStamp - now).TotalMilliseconds);
                         millisecondsTillNextPoll = Math.Max(1, millisecondsTillNextPoll);
                         sleepDurationInMilliseconds = Math.Min(sleepDurationInMilliseconds, millisecondsTillNextPoll);
                     }
+                }
+                foreach (Action onTimer in onTimers)
+                {
+                    onTimer.Invoke();
                 }
                 if (sleepDurationInMilliseconds == Int32.MaxValue)
                 {


### PR DESCRIPTION
This is a backport of https://github.com/dotnet/runtime/pull/40259 to 3.1

## Summary
This fixes a deadlock within EventCounter/EventListener usage. 

## Customer Impact
Any user that defines a polling variant of counter (PollingCounter, IncrementingPollingCounter) with the callback function containing a path that invokes EventSource constructor), or if a user defines an EventListener subscribed to DiagnosticCounter with its callback containing a path that invokes EventSource constructor, the app can run into a deadlock. See https://github.com/dotnet/runtime/pull/40259 for a more detailed description on how it can happen.

This was initially reported from the Application Insights SDK team where they defined an EventListener callback that invokes EventSource constructor.

## Regression
This code path was introduced between 2.2 to 3.0, but it is not a regression specific to 3.1.

## Testing 
Tested locally with a repro app: https://gist.github.com/sywhang/61277e9f40c17e05eaab85676e63e4fc

## Risk
Relatively low. The fix has been tested in all the counter tests we have in the runtime repo and diagnostics repo's CI - I've also stress-tested the fix. 

