### PR TITLE
[release/3.1] [coreclr] Fix FileStream.Dispose silently fails on Dispose when disk has run out of space

### DIFF
--- a/src/System.Private.CoreLib/shared/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/System.Private.CoreLib/shared/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -94,19 +94,9 @@ namespace Microsoft.Win32.SafeHandles
             return ((fileinfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR);
         }
 
-        /// <summary>Opens a SafeFileHandle for a file descriptor created by a provided delegate.</summary>
-        /// <param name="fdFunc">
-        /// The function that creates the file descriptor. Returns the file descriptor on success, or an invalid
-        /// file descriptor on error with Marshal.GetLastWin32Error() set to the error code.
-        /// </param>
-        /// <returns>The created SafeFileHandle.</returns>
-        internal static SafeFileHandle Open(Func<SafeFileHandle> fdFunc)
-        {
-            SafeFileHandle handle = Interop.CheckIo(fdFunc());
-
-            Debug.Assert(!handle.IsInvalid, "File descriptor is invalid");
-            return handle;
-        }
+        // Each thread will have its own copy. This prevents race conditions if the handle had the last error.
+        [ThreadStatic]
+        internal static Interop.ErrorInfo? t_lastCloseErrorInfo;
 
         protected override bool ReleaseHandle()
         {
@@ -122,7 +112,10 @@ namespace Microsoft.Win32.SafeHandles
             // to retry, as the descriptor could actually have been closed, been subsequently reassigned, and
             // be in use elsewhere in the process.  Instead, we simply check whether the call was successful.
             int result = Interop.Sys.Close(handle);
-            Debug.Assert(result == 0, $"Close failed with result {result} and error {Interop.Sys.GetLastErrorInfo()}");
+            if (result != 0)
+            {
+                t_lastCloseErrorInfo = Interop.Sys.GetLastErrorInfo();
+            }
             return result == 0;
         }
 


### PR DESCRIPTION
Backporting PR https://github.com/dotnet/runtime/pull/38742

The test goes into corefx: https://github.com/dotnet/corefx/pull/42988

Fixes: https://github.com/dotnet/runtime/issues/42360

## Customer Impact

A customer hit this issue in 3.1 when trying to deploy to AzureStorage: https://github.com/dotnet/runtime/issues/42360

On Unix, when the disk runs out of space before a `FileStream` is disposed and the buffer is flushed to disk, `Dispose` silently succeeds, causing files to be corrupted and preventing the user from taking corrective action.

On Windows, we throw at the expected moment, allowing the user to react appropriately.

The suggested fix is to save any error thrown when the `SafeFileHandle.ReleaseHandle` method is called when the handle is disposed, then check that saved error in `FileStream.Dispose`, and throw an exception if there was an error.

The customer who reported this issue stated they will not be able to migrate to 5.0 soon.

## Testing

* Manually verified using the provided manual test introduced in the corefx change.
* The customer verified the behavior in 5.0 and confirmed that their issue is gone in that version, which justifies the backport (https://github.com/dotnet/runtime/issues/42360#issuecomment-693791617)
* The customer that reported the issue for 3.1 verified this code fix with a private DLL sent to them, and verified the exception is now being thrown as expected (https://github.com/dotnet/runtime/issues/42360#issuecomment-694545520)

## Risk

Low.

This is a straight port of code already proven in 5.0. The code is simply doing an additional check that will ensure an exception is thrown so the user can be notified of failure.