### PR TITLE
Port to 3.1 - Fix bad configure tests

### DIFF
--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -1030,8 +1030,6 @@ if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
   list(INSERT CMAKE_REQUIRED_INCLUDES 0 ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/include ${CMAKE_CURRENT_BINARY_DIR}/libunwind/include)
 endif()
 
-set(CMAKE_REQUIRED_FLAGS "-c -Werror=implicit-function-declaration")
-
 check_c_source_compiles("
 #include <libunwind.h>
 #include <ucontext.h>
@@ -1043,29 +1041,9 @@ int main(int argc, char **argv)
         return 0;
 }" UNWIND_CONTEXT_IS_UCONTEXT_T)
 
-check_c_source_compiles("
-#include <libunwind.h>
+check_symbol_exists(unw_get_save_loc libunwind.h HAVE_UNW_GET_SAVE_LOC)
+check_symbol_exists(unw_get_accessors libunwind.h HAVE_UNW_GET_ACCESSORS)
 
-int main(int argc, char **argv) {
-  unw_cursor_t cursor;
-  unw_save_loc_t saveLoc;
-  int reg = UNW_REG_IP;
-  unw_get_save_loc(&cursor, reg, &saveLoc);
-
-  return 0;
-}" HAVE_UNW_GET_SAVE_LOC)
-
-check_c_source_compiles("
-#include <libunwind.h>
-
-int main(int argc, char **argv) {
-  unw_addr_space_t as;
-  unw_get_accessors(as);
-
-  return 0;
-}" HAVE_UNW_GET_ACCESSORS)
-
-set(CMAKE_REQUIRED_FLAGS)
 if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
   list(REMOVE_AT CMAKE_REQUIRED_INCLUDES 0 1)
 endif()


### PR DESCRIPTION
Port of https://github.com/dotnet/runtime/pull/42756

There was an extra -c in the CMAKE_REQUIRED_FLAGS set for testing
HAVE_UNW_GET_ACCESSORS and HAVE_UNW_GET_SAVE_LOC that was breaking
build of coreclr under homebrew. The option was somehow making
these checks behave on ARM Linux, even though it is not clear to
me why, as it was just causing this option to be passed to the
compiler twice at different positions of the command line of
the cmake tests.
This change fixes it by using check_symbol_exists instead of
check_c_source_compiles, since just removing the duplicite -c
was resulting in the check failing on ARM / ARM64 Linux due
to a missing symbol from libunwind during linking.

# Customer impact
We've got this issue reported by a customer who was trying to add `brew` recipe for packaging
.NET Core 3.1 on OSX. 

# Regression?
Yes, introduced in 2.1

# Testing
I've manually verified that the HAVE_UNW_GET_ACCESSORS and HAVE_UNW_GET_SAVE_LOC (and UNWIND_CONTEXT_IS_UCONTEXT_T that was not broken, but it is in the block of code influenced 
by the change) are generated correctly for all the support target platforms / architectures.

# Risk
Very low, the change influences only a compile time detection of a presence of two libunwind 
functions. 