### PR TITLE
Adding --preinstall flag to brew update

### DIFF
--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -10,7 +10,7 @@ if [ "$1" = "Linux" ]; then
         exit 1;
     fi
 elif [ "$1" = "OSX" ]; then
-    brew update
+    brew update --preinstall
     if [ "$?" != "0" ]; then
         exit 1;
     fi


### PR DESCRIPTION
Fixes https://dev.azure.com/dnceng/internal/_build/results?buildId=851404&view=logs&j=8fda0d10-4a57-56af-7add-7281436b36e1&t=d354d20b-3af3-59c3-d621-c743753ae5da

brew update fetchs the newest version of Homebrew and all formulae from GitHub using git and perform any necessary migrations. There was problem fetching those issues.
preinstall helps 
```
--preinstall: Run on auto-updates (e.g. before brew install). Skips some slower steps.
```

i looked at the what we were differently in dotnet runtime to find the --preinstall flag. 
