### PR TITLE
Fix a potential race in iterating counters

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
@@ -224,7 +224,7 @@ namespace System.Diagnostics.Tracing
                 // above, since WritePayload callback can contain user code that can invoke EventSource constructor
                 // and lead to a deadlock. (See https://github.com/dotnet/runtime/issues/40190 for details)
 
-                foreach (var counter in _counters)
+                foreach (var counter in counters)
                 {
                     // NOTE: It is still possible for a race condition to occur here. An example is if the session
                     // that subscribed to these batch of counters was disabled and it was immediately enabled in


### PR DESCRIPTION
## Summary

There was a mistake that was made in backporting https://github.com/dotnet/runtime/pull/40259 to https://github.com/dotnet/coreclr/pull/28089 where `_counters` was used to iterate instead of the snapshotted value of `counters`. `_counters` is a list that needs to be lock-protected, but this access was happening outside of the lock, which is what the snapshot is for. This caused a race-condition on the read/write on this list, causing a crash. The problem does not exist in the 5.0 fix, only for the 3.1 backport. 

## Customer Impact

Medium/High. When hit with this issue, a customer may experience a crash. A customer may run into this issue when they turn on the runtime counters (System.Runtime) or any other set of counter providers, and then modify the list of counters while a counter callback is happening by either creating or disposing instances of EventCounters. For customers that don't consume/create their own EventCounters, this shouldn't be a problem. For those who do, it's pretty easy to hit with the likelihood increasing the shorter they set the counter polling interval.

## Regression 

Yes. From 3.1.8 -> 3.1.9 servicing release. 

## Testing 

We do not have a local repro of this failure, but we tested the fix by providing a custom build of the runtime with this fix to the  internal partner test that initially reported this problem. They ran it in production that hit this issue and reported that this addresses the issue.

## Risk 

The root cause/fix is well-understood and the fix was verified through partner testing - I would say it is relatively low.