### PR TITLE
Port .NET 5 fix for reverse P/Invoke marshalling of structs.

### DIFF
--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -3836,10 +3836,10 @@ static void CreateNDirectStubWorker(StubState*         pss,
         // For functions with value type class, managed and unmanaged calling convention differ
         fMarshalReturnValueFirst = HasRetBuffArgUnmanagedFixup(&msig);
 #elif defined(_TARGET_ARM_)
-        fMarshalReturnValueFirst = HasRetBuffArg(&msig);
+        fMarshalReturnValueFirst = (isInstanceMethod && isReturnTypeValueType) && HasRetBuffArg(&msig);
 #else
         // On Windows-X86, the native signature might need a return buffer when the managed doesn't (specifically when the native signature is a member function).
-        fMarshalReturnValueFirst = HasRetBuffArg(&msig) || (isInstanceMethod && isReturnTypeValueType);
+        fMarshalReturnValueFirst = (!SF_IsReverseStub(dwStubFlags) && HasRetBuffArg(&msig)) || (isInstanceMethod && isReturnTypeValueType);
 #endif // UNIX_X86_ABI
 #elif defined(_TARGET_AMD64_) || defined (_TARGET_ARM64_)
         fMarshalReturnValueFirst = isInstanceMethod && isReturnTypeValueType;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/45637

.NET 5 PR https://github.com/dotnet/runtime/pull/32034. This fix represents a minor and supported change in the mentioned PR.

# Customer impact
Customer reported issue https://github.com/dotnet/runtime/issues/45637.

# Regression?
Yes, introduced in 3.0 with the reconciling of marshalling logic.

# Testing
I have verified the user's scenario. This fix has been in .NET 5 for about a year and doesn't exhibit the failing behavior.

# Risk
Medium. This area is sensitive and even though the code has been in .NET 5 there is a possible culmination of other non-obvious changes that could be missing - this is speculation based on experience in the marshalling area. @jkoritzinsky or @davidwrighton may be able to provide a more accurate risk assessment.

/cc @jkoritzinsky @davidwrighton @elinor-fung 
