### PR TITLE
Fix return address hijacking in the stack probing loop

### DIFF
--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -6727,6 +6727,17 @@ void HandleGCSuspensionForInterruptedThread(CONTEXT *interruptedContext)
 
         BOOL unused;
 
+#if defined(FEATURE_PAL) && (defined(_TARGET_AMD64_) || defined(_TARGET_X86_))
+        // Stack probing loop that JIT generates in prolog on x64 / x86 Unix for methods with
+        // large frame is not unwindable, so it is not possible to get the return address location
+        // for hijacking.
+        // This is a hotfix for release/3.1 only.
+        if (IsIPInProlog(&codeInfo) && codeInfo.GetFixedStackSize() >= 0x3000)
+        {
+            return;
+        }
+#endif // _TARGET_UNIX_ && (TARGET_AMD64 || TARGET_X86)
+
         if (IsIPInEpilog(interruptedContext, &codeInfo, &unused))
             return;
 


### PR DESCRIPTION
When return address hijacking occurs when the target thread is running
in the stack probing loop in a method with large frame, the unwinder cannot
unwind to the caller frame correctly. That results in a wrong stack slot
being patched by the modified return address, leading to corruption of
locals of the method being executed.

This change fixes the problem by not attempting to hijack a method that's
running in prolog.

This change is not a port, as the .NET 5.0 uses a different method to do stack 
probing. That method would require a too large change to be ported though, 
so this is a targeted fix.

# Customer impact
Customer (RavenDB) database servers processing customer data are crashing on a regular basis (few times a week) with SIGSEGV.
There is no workaround for the problem.
See https://github.com/dotnet/runtime/issues/42885 for more details.

# Regression?
No

# Testing
Customer testing a custom libcoreclr.so based on 3.1.8 containing this fix. They were testing the change on their production servers for about a month. The intermittent crashes they were seeing on a regular basis have disappeared and their systems were working flawlessly.

# Risk
Low, the change just prevents return address hijacking to happen in prolog of methods with large frames. Hijacking attempt is not required to succeed, there are other cases when we cannot hijack a method already, like when running in an epilog, when executing native code etc.
