### PR TITLE
[release/3.1] Fix libunwind linking with gcc10, clang11 or -fno-common

### DIFF
--- a/configurecompiler.cmake
+++ b/configurecompiler.cmake
@@ -478,6 +478,9 @@ if (CLR_CMAKE_PLATFORM_UNIX)
   #These seem to indicate real issues
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-invalid-offsetof>)
 
+  # Some newer compilers default to -fno-common; revert to -fcommon
+  add_compile_options(-fcommon)
+
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # The -ferror-limit is helpful during the porting, it makes sure the compiler doesn't stop
     # after hitting just about 20 errors.


### PR DESCRIPTION
Linking coreclr with gcc 10 or clang 11 (both of which default to -fno-common) fails with this error:

```
[31%] Linking CXX shared library libdbgshim.so                                                                                                               
/usr/bin/ld: ../../pal/src/libcoreclrpal.a(dyn-info-list.c.o):/home/omajid/devel/dotnet/coreclr/src/pal/src/libunwind/src/mi/dyn-info-list.c:28: multiple definition of `_U_dyn_info_list'; ../../pal/src/libcoreclrpal.a(Linit.c.o):/home/omajid/devel/dotnet/coreclr/src/pal/src/libunwind/src/x86_64/Ginit.c:52: first defined here
```

This PR fixes that.

~~This is of https://github.com/libunwind/libunwind/pull/166, with one change: there's no s390x file in coreclr's copy of libunwind, so I removed that chunk. Otherwise the change applies as-is.~~

~~This was also added to runtime 5.0 with https://github.com/dotnet/runtime/commit/581dc193406082f76ae3c58511f724ab5d5c0d6d#diff-c144efc97b24537a136fc6842bad278829924e76dffa2f09ad1d8f078b8c116b, as part of the larger update to libunwind 1.5~~

# Customer impact
Customers like Redhat cannot build .NET Core using clang11 without this fix.

# Regression?
No

# Testing
Redhat side testing.

# Risk
Low, the change just adds a compiler option that doesn't affect the behavior on Clang older than 11 (the ones that we use for our product builds)