### PR TITLE
[release/3.1] Backport the fix for dotnet/runtime issue 46529

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -461,12 +461,26 @@ GenTree* Compiler::fgMorphCast(GenTree* tree)
                         // Don't try to optimize.
                         assert(!canPushCast);
                     }
-                    else if ((shiftAmountValue >= 32) && ((tree->gtFlags & GTF_ALL_EFFECT) == 0))
+                    else if (shiftAmountValue >= 32)
                     {
-                        // Result of the shift is zero.
-                        DEBUG_DESTROY_NODE(tree);
-                        GenTree* zero = gtNewZeroConNode(TYP_INT);
-                        return fgMorphTree(zero);
+                        // We know that we have a narrowing cast ([u]long -> [u]int)
+                        // and that we are casting to a 32-bit value, which will result in zero.
+                        //
+                        // Check to see if we have any side-effects that we must keep
+                        //
+                        if ((tree->gtFlags & GTF_ALL_EFFECT) == 0)
+                        {
+                            // Result of the shift is zero.
+                            DEBUG_DESTROY_NODE(tree);
+                            GenTree* zero = gtNewZeroConNode(TYP_INT);
+                            return fgMorphTree(zero);
+                        }
+                        else // We do have a side-effect
+                        {
+                            // We could create a GT_COMMA node here to keep the side-effect and return a zero
+                            // Instead we just don't try to optimize this case.
+                            canPushCast = false;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
5.0.x version of this change: https://github.com/dotnet/runtime/pull/47741

### Incorrect behavior a 64-bit long with shift of 32 or more combined with a cast to int 

The JIT generates incorrect code for this code pattern:

`(int) (X << C)`

where C >= 32 and
and  X is anything with a potential side-effect and is 64-bit integer type

## Customer Impact

Reported by customer who was migrating to .Net Core from the Desktop runtime.

## Regression?

This is a regression that was introduced in the .Net 3.X timeframe by 
https://github.com/dotnet/coreclr/pull/19899


## Risk

Low

Fixes issue #47724