### PR TITLE
GCStress eventing fix

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -699,11 +699,17 @@ bool EventPipe::WalkManagedStackForThread(Thread *pThread, StackContents &stackC
 
     stackContents.Reset();
 
+    // Before we call into StackWalkFrames we need to mark GC_ON_TRANSITIONS as FALSE
+    // because under GCStress runs (GCStress=0x3), a GC will be triggered for every transition,
+    // which will cause the GC to try to walk the stack while we are in the middle of walking the stack.
+    bool gcOnTransitions = GC_ON_TRANSITIONS(FALSE);
+
     StackWalkAction swaRet = pThread->StackWalkFrames(
         (PSTACKWALKFRAMESCALLBACK)&StackWalkCallback,
         &stackContents,
         ALLOW_ASYNC_STACK_WALK | FUNCTIONSONLY | HANDLESKIPPEDFRAMES | ALLOW_INVALID_OBJECTS);
 
+    GC_ON_TRANSITIONS(gcOnTransitions);
     return ((swaRet == SWA_DONE) || (swaRet == SWA_CONTINUE));
 }
 


### PR DESCRIPTION
Port #26776 to 3.1. 

EventPipe had an issue where it would see a reentrant stackwalk during GCStress, which triggers asserts on checked or debug builds.

## Customer Impact
Having tests fail under GCStress means we are less confident when preparing fixes for 3.1. We could alternatively disable these tests under GCStress, but that would mean less testing when doing GCStress runs.

## Testing
This fix was in master for effectively all of the 5.0 release, and I verified that it fixes the failing eventing tests by running the tests manually.

## Risk
The risk is low, this fix shipped in 5.0.