### PR TITLE
[release/3.1] Enable additional CI testing

### DIFF
--- a/eng/pipelines/corefx-jitstress.yml
+++ b/eng/pipelines/corefx-jitstress.yml
@@ -16,26 +16,26 @@ jobs:
     jobTemplate: build-job.yml
     buildConfig: checked
     platforms:
-    # TODO: add Windows_NT_arm64, when we have hardware available, and .NET Core supports it. Note: platform-matrix.yml needs to enable a Helix queue for this.
     - Linux_arm
     - Linux_arm64
     - Linux_x64
     # TODO: re-enable Windows_NT_arm when https://github.com/dotnet/corefx/issues/38863 is resolved
     - Windows_NT_x64
     - Windows_NT_x86
+    - Windows_NT_arm64
 
 - template: /eng/platform-matrix.yml
   parameters:
     jobTemplate: test-job.yml
     buildConfig: checked
     platforms:
-    # TODO: add Windows_NT_arm64, when we have hardware available, and .NET Core supports it. Note: platform-matrix.yml needs to enable a Helix queue for this.
     - Linux_arm
     - Linux_arm64
     - Linux_x64
     # TODO: re-enable Windows_NT_arm when https://github.com/dotnet/corefx/issues/38863 is resolved
     - Windows_NT_x64
     - Windows_NT_x86
+    - Windows_NT_arm64
     helixQueueGroup: corefx
     jobParameters:
       testGroup: jitstress

--- a/eng/pipelines/corefx-jitstress2-jitstressregs.yml
+++ b/eng/pipelines/corefx-jitstress2-jitstressregs.yml
@@ -16,26 +16,26 @@ jobs:
     jobTemplate: build-job.yml
     buildConfig: checked
     platforms:
-    # TODO: add Windows_NT_arm64, when we have hardware available, and .NET Core supports it. Note: platform-matrix.yml needs to enable a Helix queue for this.
     - Linux_arm
     - Linux_arm64
     - Linux_x64
     # TODO: re-enable Windows_NT_arm when https://github.com/dotnet/corefx/issues/38863 is resolved
     - Windows_NT_x64
     - Windows_NT_x86
+    - Windows_NT_arm64
 
 - template: /eng/platform-matrix.yml
   parameters:
     jobTemplate: test-job.yml
     buildConfig: checked
     platforms:
-    # TODO: add Windows_NT_arm64, when we have hardware available, and .NET Core supports it. Note: platform-matrix.yml needs to enable a Helix queue for this.
     - Linux_arm
     - Linux_arm64
     - Linux_x64
     # TODO: re-enable Windows_NT_arm when https://github.com/dotnet/corefx/issues/38863 is resolved
     - Windows_NT_x64
     - Windows_NT_x86
+    - Windows_NT_arm64
     helixQueueGroup: corefx
     jobParameters:
       testGroup: jitstress2-jitstressregs

--- a/eng/pipelines/corefx-jitstressregs.yml
+++ b/eng/pipelines/corefx-jitstressregs.yml
@@ -16,26 +16,26 @@ jobs:
     jobTemplate: build-job.yml
     buildConfig: checked
     platforms:
-    # TODO: add Windows_NT_arm64, when we have hardware available, and .NET Core supports it. Note: platform-matrix.yml needs to enable a Helix queue for this.
     - Linux_arm
     - Linux_arm64
     - Linux_x64
     # TODO: re-enable Windows_NT_arm when https://github.com/dotnet/corefx/issues/38863 is resolved
     - Windows_NT_x64
     - Windows_NT_x86
+    - Windows_NT_arm64
 
 - template: /eng/platform-matrix.yml
   parameters:
     jobTemplate: test-job.yml
     buildConfig: checked
     platforms:
-    # TODO: add Windows_NT_arm64, when we have hardware available, and .NET Core supports it. Note: platform-matrix.yml needs to enable a Helix queue for this.
     - Linux_arm
     - Linux_arm64
     - Linux_x64
     # TODO: re-enable Windows_NT_arm when https://github.com/dotnet/corefx/issues/38863 is resolved
     - Windows_NT_x64
     - Windows_NT_x86
+    - Windows_NT_arm64
     helixQueueGroup: corefx
     jobParameters:
       testGroup: jitstressregs

--- a/eng/pipelines/corefx.yml
+++ b/eng/pipelines/corefx.yml
@@ -16,26 +16,26 @@ jobs:
     jobTemplate: build-job.yml
     buildConfig: checked
     platforms:
-    # TODO: add Windows_NT_arm64, when we have hardware available, and .NET Core supports it. Note: platform-matrix.yml needs to enable a Helix queue for this.
     - Linux_arm
     - Linux_arm64
     - Linux_x64
     # TODO: re-enable Windows_NT_arm when https://github.com/dotnet/corefx/issues/38863 is resolved
     - Windows_NT_x64
     - Windows_NT_x86
+    - Windows_NT_arm64
 
 - template: /eng/platform-matrix.yml
   parameters:
     jobTemplate: test-job.yml
     buildConfig: checked
     platforms:
-    # TODO: add Windows_NT_arm64, when we have hardware available, and .NET Core supports it. Note: platform-matrix.yml needs to enable a Helix queue for this.
     - Linux_arm
     - Linux_arm64
     - Linux_x64
     # TODO: re-enable Windows_NT_arm when https://github.com/dotnet/corefx/issues/38863 is resolved
     - Windows_NT_x64
     - Windows_NT_x86
+    - Windows_NT_arm64
     helixQueueGroup: corefx
     jobParameters:
       testGroup: outerloop

--- a/eng/pipelines/r2r.yml
+++ b/eng/pipelines/r2r.yml
@@ -13,6 +13,7 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     - Windows_NT_x86
+    - Windows_NT_arm64
 
 - template: /eng/platform-matrix.yml
   parameters:
@@ -24,6 +25,7 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     - Windows_NT_x86
+    - Windows_NT_arm64
     helixQueueGroup: ci
     jobParameters:
       testGroup: outerloop

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -282,7 +282,8 @@ jobs:
       osGroup: Windows_NT
       osIdentifier: Windows_NT
       helixQueues:
-      # TODO: Consider adding Windows.10.Arm64.Open here if capacity is enough for handling both Windows_NT/arm and Windows_NT/arm64 testing
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
+        - Windows.10.Arm64v8.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - Windows.10.Arm64
       ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -273,7 +273,7 @@ jobs:
 
 # Windows arm64
 
-- ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm64'), eq(parameters.platformGroup, 'all')) }}:
+- ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm64'), eq(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
       ignoreDependencyOnBuildJobs: ${{ parameters.ignoreDependencyOnBuildJobs }}

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -273,7 +273,7 @@ jobs:
 
 # Windows arm64
 
-- ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm64'), eq(parameters.platformGroup, 'all', 'gcstress')) }}:
+- ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
       ignoreDependencyOnBuildJobs: ${{ parameters.ignoreDependencyOnBuildJobs }}


### PR DESCRIPTION
Enable additional CI testing using new Helix queue Windows.10.Arm64v8.Open.


### Customer Impact
None

### Testing
Validated the change by manually triggering two pipelines [coreclr-ci#20210217.2](https://dev.azure.com/dnceng/public/_build/results?buildId=999073) and [coreclr-outerloop#20210217.1](https://dev.azure.com/dnceng/public/_build/results?buildId=999284)

### Risk
None - the change affects testing infrastructure only


cc @BruceForstall @JulieLeeMSFT @jeffschwMSFT 