### PR TITLE
[3.1] Use native code slot for default interface methods (#25770)

### DIFF
--- a/src/vm/codeversion.cpp
+++ b/src/vm/codeversion.cpp
@@ -200,7 +200,7 @@ void NativeCodeVersionNode::SetGCCoverageInfo(PTR_GCCoverageInfo gcCover)
 #endif // HAVE_GCCOVER
 
 NativeCodeVersion::NativeCodeVersion() :
-    m_storageKind(StorageKind::Unknown)
+    m_storageKind(StorageKind::Unknown), m_pVersionNode(PTR_NULL)
 {}
 
 NativeCodeVersion::NativeCodeVersion(const NativeCodeVersion & rhs) :

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -1315,7 +1315,9 @@ bool IsGcCoverageInterrupt(LPVOID ip)
         return false;
     }
 
-    GCCoverageInfo *gcCover = codeInfo.GetNativeCodeVersion().GetGCCoverageInfo();
+    NativeCodeVersion nativeCodeVersion = codeInfo.GetNativeCodeVersion();
+    _ASSERTE(!nativeCodeVersion.IsNull());
+    GCCoverageInfo *gcCover = nativeCodeVersion.GetGCCoverageInfo();
     if (gcCover == nullptr)
     {
         return false;
@@ -1377,7 +1379,9 @@ BOOL OnGcCoverageInterrupt(PCONTEXT regs)
     forceStack[1] = &pMD;                // This is so I can see it fastchecked
     forceStack[2] = &offset;             // This is so I can see it fastchecked
 
-    GCCoverageInfo* gcCover = codeInfo.GetNativeCodeVersion().GetGCCoverageInfo();
+    NativeCodeVersion nativeCodeVersion = codeInfo.GetNativeCodeVersion();
+    _ASSERTE(!nativeCodeVersion.IsNull());
+    GCCoverageInfo* gcCover = nativeCodeVersion.GetGCCoverageInfo();
     forceStack[3] = &gcCover;            // This is so I can see it fastchecked
     if (gcCover == 0)
         return(FALSE);        // we aren't doing code gcCoverage on this function

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -1022,6 +1022,7 @@ PCODE MethodDesc::GetNativeCode()
 {
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
+    _ASSERTE(!IsDefaultInterfaceMethod() || HasNativeCodeSlot());
 
     g_IBCLogger.LogMethodDescAccess(this);
 
@@ -5037,6 +5038,8 @@ BOOL MethodDesc::SetNativeCodeInterlocked(PCODE addr, PCODE pExpected /*=NULL*/)
         GC_NOTRIGGER;
     } CONTRACTL_END;
 
+    _ASSERTE(!IsDefaultInterfaceMethod() || HasNativeCodeSlot());
+
     if (HasNativeCodeSlot())
     {
 #ifdef _TARGET_ARM_
@@ -5060,11 +5063,6 @@ BOOL MethodDesc::SetNativeCodeInterlocked(PCODE addr, PCODE pExpected /*=NULL*/)
             (TADDR&)value, (TADDR&)expected) == (TADDR&)expected;
     }
     
-    if (IsDefaultInterfaceMethod() && HasPrecode())
-    {        
-        return GetPrecode()->SetTargetInterlocked(addr);
-    }
-
     _ASSERTE(pExpected == NULL);
     return SetStableEntryPointInterlocked(addr);
 }

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -6973,6 +6973,20 @@ MethodTableBuilder::NeedsNativeCodeSlot(bmtMDMethod * pMDMethod)
     }
 #endif
 
+#ifdef FEATURE_DEFAULT_INTERFACES
+    if (IsInterface())
+    {
+        DWORD attrs = pMDMethod->GetDeclAttrs();
+        if (!IsMdStatic(attrs) && IsMdVirtual(attrs) && !IsMdAbstract(attrs))
+        {
+            // Default interface method. Since interface methods currently need to have a precode, the native code slot will be
+            // used to retrieve the native code entry point, instead of getting it from the precode, which is not reliable with
+            // debuggers setting breakpoints.
+            return TRUE;
+        }
+    }
+#endif
+
 #if defined(FEATURE_JIT_PITCHING)
     if ((CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitPitchEnabled) != 0) &&
         (CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitPitchMemThreshold) != 0))

--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/sharedgenerics_d.ilproj
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/sharedgenerics_d.ilproj
@@ -15,8 +15,6 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
-    <!-- See https://github.com/dotnet/coreclr/issues/25690 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/sharedgenerics_r.ilproj
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/sharedgenerics_r.ilproj
@@ -15,8 +15,6 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
-    <!-- See https://github.com/dotnet/coreclr/issues/25690 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Partial port of https://github.com/dotnet/coreclr/pull/25770 to 3.1 (only the main change, excludes unrelated cleanup)
- Use native code slot for default interface methods so that `MethodDesc::GetNativeCode()` can retrieve the current native code entry point (instead of returning null as before), and code versioning can find a matching code version from the code start address
- Interface methods currently require having a precode, so the "method entry point" can't be used to directly store the native code entry point
- Reenabled a couple of default interface method tests under GCStress

Fixes https://github.com/dotnet/coreclr/issues/25690

### Customer impact

Mostly only affects some GCStress tests. The change can have harmless non-test effects, for example a default interface method may be jitted redundantly fewer times after the change (as expected), since before the change the call to `GetNativeCode()` here would always return null for a default interface method and the method may be jitted again unnecessarily.
https://github.com/dotnet/coreclr/blob/867aa5e1141c8801796a80171a3749d944c6b9af/src/vm/codeversion.cpp#L2304-L2309

Otherwise, the main purpose of the port is to fix some GCStress tests to make CI runs more reliable and useful for testing other fixes made to 3.1.

### Testing

@echesakovMSFT has verified that all related GCStress failures are fixed after the change on Windows arm64 where the issues were seen.

### Risk

Low:
- The change has been in all of the 5.0 releases
- The change makes tracking of the native code for default interface methods similar to other methods that have a precode and don't have a stable entry point, so the behavior would be more consistent with other types of methods
- The native code slot for default interface methods is a pointer-size extra memory per such method, it wouldn't be significant as the number of such methods is typically low compared to other types of methods, and most other methods already use a native code slot