### PR TITLE
[release/3.1] Backport test build fix when a newer Windows SDK is installed.

### DIFF
--- a/tests/src/Interop/WinRT/NativeComponent/CMakeLists.txt
+++ b/tests/src/Interop/WinRT/NativeComponent/CMakeLists.txt
@@ -5,7 +5,7 @@ include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake")
 include_directories("../Contracts")
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-add_definition(-DWINRT_NO_MAKE_DETECTION)
+add_definitions(-DWINRT_NO_MAKE_DETECTION)
 
 set(SOURCES
   Component.Contracts.ArrayTesting.cpp

--- a/tests/src/Interop/WinRT/NativeComponent/CMakeLists.txt
+++ b/tests/src/Interop/WinRT/NativeComponent/CMakeLists.txt
@@ -5,6 +5,8 @@ include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake")
 include_directories("../Contracts")
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
+add_definition(-DWINRT_NO_MAKE_DETECTION)
+
 set(SOURCES
   Component.Contracts.ArrayTesting.cpp
   Component.Contracts.BindingProjectionsTesting.cpp

--- a/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.BindingViewModel.h
+++ b/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.BindingViewModel.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "Component/Contracts/BindingViewModel.g.h"
+#include "winrt/Windows.Foundation.Collections.h"
+#include "winrt/Windows.UI.Xaml.Interop.h"
 #include <vector>
 
 template<typename T>

--- a/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.KeyValuePairTesting.cpp
+++ b/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.KeyValuePairTesting.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #include "pch.h"
 #include "Component.Contracts.KeyValuePairTesting.h"
+#include "winrt/Windows.Foundation.Collections.h"
 #include <utility>
 #include <vector>
 

--- a/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.NullableTesting.cpp
+++ b/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.NullableTesting.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #include "pch.h"
 #include "Component.Contracts.NullableTesting.h"
+#include "winrt/Windows.Foundation.h"
 
 namespace winrt::Component::Contracts::implementation
 {

--- a/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.UriTesting.cpp
+++ b/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.UriTesting.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #include "pch.h"
 #include "Component.Contracts.UriTesting.h"
+#include "winrt/Windows.Foundation.h"
 
 namespace winrt::Component::Contracts::implementation
 {


### PR DESCRIPTION
Backport https://github.com/dotnet/runtime/pull/34513. This change enables people to build coreclr on a machine with the 10.0.19041.0 Windows SDK installed.

This is a test-only change, so this has no product risk.