### PR TITLE
[release/3.1] Fix Mac ICU errors by porting over dotnet/runtime#47346

### DIFF
--- a/src/corefx/System.Globalization.Native/pal_calendarData.c
+++ b/src/corefx/System.Globalization.Native/pal_calendarData.c
@@ -4,6 +4,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 #include <strings.h>
 
@@ -115,8 +116,8 @@ int32_t GlobalizationNative_GetCalendars(
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &err);
-    UEnumeration* pEnum = ucal_getKeywordValuesForLocale("calendar", locale, TRUE, &err);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &err);
+    UEnumeration* pEnum = ucal_getKeywordValuesForLocale("calendar", locale, true, &err);
     int stringEnumeratorCount = uenum_count(pEnum, &err);
     int calendarsReturned = 0;
     for (int i = 0; i < stringEnumeratorCount && calendarsReturned < calendarsCapacity; i++)
@@ -186,7 +187,7 @@ ResultCode GlobalizationNative_GetCalendarInfo(
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &err);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &err);
 
     if (U_FAILURE(err))
         return UnknownError;
@@ -198,7 +199,7 @@ ResultCode GlobalizationNative_GetCalendarInfo(
         case CalendarData_MonthDay:
             return GetMonthDayPattern(locale, result, resultCapacity);
         default:
-            assert(FALSE);
+            assert(false);
             return UnknownError;
     }
 }
@@ -219,19 +220,19 @@ static int InvokeCallbackForDatePattern(const char* locale,
     UDateFormat* pFormat = udat_open(UDAT_NONE, style, locale, NULL, 0, NULL, 0, &err);
 
     if (U_FAILURE(err))
-        return FALSE;
+        return false;
 
     UErrorCode ignore = U_ZERO_ERROR;
-    int32_t patternLen = udat_toPattern(pFormat, FALSE, NULL, 0, &ignore) + 1;
+    int32_t patternLen = udat_toPattern(pFormat, false, NULL, 0, &ignore) + 1;
 
     UChar* pattern = calloc(patternLen, sizeof(UChar));
     if (pattern == NULL)
     {
         udat_close(pFormat);
-        return FALSE;
+        return false;
     }
 
-    udat_toPattern(pFormat, FALSE, pattern, patternLen, &err);
+    udat_toPattern(pFormat, false, pattern, patternLen, &err);
     udat_close(pFormat);
 
     if (U_SUCCESS(err))
@@ -259,7 +260,7 @@ static int InvokeCallbackForDateTimePattern(const char* locale,
     UDateTimePatternGenerator* pGenerator = udatpg_open(locale, &err);
 
     if (U_FAILURE(err))
-        return FALSE;
+        return false;
 
     UErrorCode ignore = U_ZERO_ERROR;
     int32_t patternLen = udatpg_getBestPattern(pGenerator, patternSkeleton, -1, NULL, 0, &ignore) + 1;
@@ -268,7 +269,7 @@ static int InvokeCallbackForDateTimePattern(const char* locale,
     if (bestPattern == NULL)
     {
         udatpg_close(pGenerator);
-        return FALSE;
+        return false;
     }
 
     udatpg_getBestPattern(pGenerator, patternSkeleton, -1, bestPattern, patternLen, &err);
@@ -301,7 +302,7 @@ static int32_t EnumSymbols(const char* locale,
     UDateFormat* pFormat = udat_open(UDAT_DEFAULT, UDAT_DEFAULT, locale, NULL, 0, NULL, 0, &err);
 
     if (U_FAILURE(err))
-        return FALSE;
+        return false;
 
     char localeWithCalendarName[ULOC_FULLNAME_CAPACITY];
     strncpy(localeWithCalendarName, locale, ULOC_FULLNAME_CAPACITY);
@@ -314,7 +315,7 @@ static int32_t EnumSymbols(const char* locale,
     if (U_FAILURE(err))
     {
         udat_close(pFormat);
-        return FALSE;
+        return false;
     }
 
     udat_setCalendar(pFormat, pCalendar);
@@ -416,7 +417,7 @@ static int32_t EnumAbbrevEraNames(const char* locale,
     strncpy(localeNamePtr, locale, ULOC_FULLNAME_CAPACITY);
     localeNamePtr[ULOC_FULLNAME_CAPACITY - 1] = 0;
 
-    while (TRUE)
+    while (true)
     {
         UErrorCode status = U_ZERO_ERROR;
         const char* name = GetCalendarName(calendarId);
@@ -431,7 +432,7 @@ static int32_t EnumAbbrevEraNames(const char* locale,
         {
             EnumUResourceBundle(erasResBundle, callback, context);
             CloseResBundle(rootResBundle, calResBundle, targetCalResBundle, erasColResBundle, erasResBundle);
-            return TRUE;
+            return true;
         }
 
         // Couldn't find the data we need for this locale, we should fallback.
@@ -484,10 +485,10 @@ int32_t GlobalizationNative_EnumCalendarInfo(EnumCalendarInfoCallback callback,
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &err);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &err);
 
     if (U_FAILURE(err))
-        return FALSE;
+        return false;
 
     switch (dataType)
     {
@@ -528,8 +529,8 @@ int32_t GlobalizationNative_EnumCalendarInfo(EnumCalendarInfoCallback callback,
         case CalendarData_AbbrevEraNames:
             return EnumAbbrevEraNames(locale, calendarId, callback, context);
         default:
-            assert(FALSE);
-            return FALSE;
+            assert(false);
+            return false;
     }
 }
 
@@ -573,7 +574,7 @@ int32_t GlobalizationNative_GetJapaneseEraStartDate(int32_t era,
     UCalendar* pCal = ucal_open(NULL, 0, JAPANESE_LOCALE_AND_CALENDAR, UCAL_TRADITIONAL, &err);
 
     if (U_FAILURE(err))
-        return FALSE;
+        return false;
 
     ucal_set(pCal, UCAL_ERA, era);
     ucal_set(pCal, UCAL_YEAR, 1);
@@ -583,7 +584,7 @@ int32_t GlobalizationNative_GetJapaneseEraStartDate(int32_t era,
     if (U_FAILURE(err))
     {
         ucal_close(pCal);
-        return FALSE;
+        return false;
     }
 
     // set the date to Jan 1
@@ -620,5 +621,5 @@ int32_t GlobalizationNative_GetJapaneseEraStartDate(int32_t era,
     }
 
     ucal_close(pCal);
-    return FALSE;
+    return false;
 }

--- a/src/corefx/System.Globalization.Native/pal_casing.c
+++ b/src/corefx/System.Globalization.Native/pal_casing.c
@@ -5,6 +5,7 @@
 
 #include <assert.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "pal_casing.h"
 #include "pal_icushim.h"
@@ -29,7 +30,7 @@ void GlobalizationNative_ChangeCase(
     // compiler wasn't doing that optimization, and it results in an ~15-20% perf
     // improvement on longer strings.)
 
-    UBool isError = FALSE;
+    UBool isError = false;
     int32_t srcIdx = 0, dstIdx = 0;
     UChar32 srcCodepoint, dstCodepoint;
 
@@ -40,7 +41,7 @@ void GlobalizationNative_ChangeCase(
             U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
             dstCodepoint = u_toupper(srcCodepoint);
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
+            assert(isError == false && srcIdx == dstIdx);
         }
     }
     else
@@ -50,7 +51,7 @@ void GlobalizationNative_ChangeCase(
             U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
             dstCodepoint = u_tolower(srcCodepoint);
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
+            assert(isError == false && srcIdx == dstIdx);
         }
     }
 }
@@ -68,7 +69,7 @@ void GlobalizationNative_ChangeCaseInvariant(
 {
     // See algorithmic comment in ChangeCase.
 
-    UBool isError = FALSE;
+    UBool isError = false;
     int32_t srcIdx = 0, dstIdx = 0;
     UChar32 srcCodepoint, dstCodepoint;
 
@@ -82,7 +83,7 @@ void GlobalizationNative_ChangeCaseInvariant(
             U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
             dstCodepoint = ((srcCodepoint == (UChar32)0x0131) ? (UChar32)0x0131 : u_toupper(srcCodepoint));
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
+            assert(isError == false && srcIdx == dstIdx);
         }
     }
     else
@@ -95,7 +96,7 @@ void GlobalizationNative_ChangeCaseInvariant(
             U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
             dstCodepoint = ((srcCodepoint == (UChar32)0x0130) ? (UChar32)0x0130 : u_tolower(srcCodepoint));
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
+            assert(isError == false && srcIdx == dstIdx);
         }
     }
 }
@@ -112,7 +113,7 @@ void GlobalizationNative_ChangeCaseTurkish(
 {
     // See algorithmic comment in ChangeCase.
 
-    UBool isError = FALSE;
+    UBool isError = false;
     int32_t srcIdx = 0, dstIdx = 0;
     UChar32 srcCodepoint, dstCodepoint;
 
@@ -125,7 +126,7 @@ void GlobalizationNative_ChangeCaseTurkish(
             U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
             dstCodepoint = ((srcCodepoint == (UChar32)0x0069) ? (UChar32)0x0130 : u_toupper(srcCodepoint));
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
+            assert(isError == false && srcIdx == dstIdx);
         }
     }
     else
@@ -137,7 +138,7 @@ void GlobalizationNative_ChangeCaseTurkish(
             U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
             dstCodepoint = ((srcCodepoint == (UChar32)0x0049) ? (UChar32)0x0131 : u_tolower(srcCodepoint));
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
+            assert(isError == false && srcIdx == dstIdx);
         }
     }
 }

--- a/src/corefx/System.Globalization.Native/pal_collation.c
+++ b/src/corefx/System.Globalization.Native/pal_collation.c
@@ -157,7 +157,7 @@ static UCharList* GetCustomRules(int32_t options, UColAttributeValue strength, i
 
     // If we need to create customRules, the KanaType custom rule will be 88 kana characters * 4 = 352 chars long
     // and the Width custom rule will be at most 212 halfwidth characters * 5 = 1060 chars long.
-    int capacity = 
+    int capacity =
         ((needsIgnoreKanaTypeCustomRule || needsNotIgnoreKanaTypeCustomRule) ? 4 * (hiraganaEnd - hiraganaStart + 1) : 0) +
         ((needsIgnoreWidthCustomRule || needsNotIgnoreWidthCustomRule) ? 5 * g_HalfFullCharsLength : 0);
 
@@ -306,10 +306,10 @@ UCollator* CloneCollatorWithOptions(const UCollator* pCollator, int32_t options,
     return pClonedCollator;
 }
 
-// Returns TRUE if all the collation elements in str are completely ignorable
+// Returns true if all the collation elements in str are completely ignorable
 static int CanIgnoreAllCollationElements(const UCollator* pColl, const UChar* lpStr, int32_t length)
 {
-    int result = TRUE;
+    int result = true;
     UErrorCode err = U_ZERO_ERROR;
     UCollationElements* pCollElem = ucol_openElements(pColl, lpStr, length, &err);
 
@@ -320,7 +320,7 @@ static int CanIgnoreAllCollationElements(const UCollator* pColl, const UChar* lp
         {
             if (curCollElem != 0)
             {
-                result = FALSE;
+                result = false;
                 break;
             }
         }
@@ -328,7 +328,7 @@ static int CanIgnoreAllCollationElements(const UCollator* pColl, const UChar* lp
         ucol_closeElements(pCollElem);
     }
 
-    return U_SUCCESS(err) ? result : FALSE;
+    return U_SUCCESS(err) ? result : false;
 
 }
 
@@ -422,7 +422,7 @@ int32_t GlobalizationNative_GetSortVersion(SortHandle* pSortHandle)
     }
     else
     {
-        assert(FALSE && "Unexpected ucol_getVersion to fail.");
+        assert(false && "Unexpected ucol_getVersion to fail.");
 
         // we didn't use UCOL_TAILORINGS_VERSION because it is deprecated in ICU v5
         result = UCOL_RUNTIME_VERSION << 16 | UCOL_BUILDER_VERSION;
@@ -527,7 +527,7 @@ static int AreEqualOrdinalIgnoreCase(UChar32 one, UChar32 two)
 
     if (one == two)
     {
-        return TRUE;
+        return true;
     }
 
     if (one == 0x0131 || two == 0x0131)
@@ -535,7 +535,7 @@ static int AreEqualOrdinalIgnoreCase(UChar32 one, UChar32 two)
         // On Windows with InvariantCulture, the LATIN SMALL LETTER DOTLESS I (U+0131)
         // capitalizes to itself, whereas with ICU it capitalizes to LATIN CAPITAL LETTER I (U+0049).
         // We special case it to match the Windows invariant behavior.
-        return FALSE;
+        return false;
     }
 
     return u_toupper(one) == u_toupper(two);
@@ -560,19 +560,19 @@ int32_t GlobalizationNative_IndexOfOrdinalIgnoreCase(
         const UChar *src = lpSource, *trg = lpTarget;
         UChar32 srcCodepoint, trgCodepoint;
 
-        int32_t match = TRUE;
+        int32_t match = true;
         while (trgIdx < cwTargetLength)
         {
             U16_NEXT(src, srcIdx, cwSourceLength, srcCodepoint);
             U16_NEXT(trg, trgIdx, cwTargetLength, trgCodepoint);
             if (!AreEqualOrdinalIgnoreCase(srcCodepoint, trgCodepoint))
             {
-                match = FALSE; 
+                match = false;
                 break;
             }
         }
 
-        if (match) 
+        if (match)
         {
             result = i;
             if (!findLast)
@@ -598,7 +598,7 @@ int32_t GlobalizationNative_StartsWith(
                         int32_t cwSourceLength,
                         int32_t options)
 {
-    int32_t result = FALSE;
+    int32_t result = false;
     UErrorCode err = U_ZERO_ERROR;
     const UCollator* pColl = GetCollatorFromSortHandle(pSortHandle, options, &err);
 
@@ -614,7 +614,7 @@ int32_t GlobalizationNative_StartsWith(
             {
                 if (idx == 0)
                 {
-                    result = TRUE;
+                    result = true;
                 }
                 else
                 {
@@ -640,7 +640,7 @@ int32_t GlobalizationNative_EndsWith(
                         int32_t cwSourceLength,
                         int32_t options)
 {
-    int32_t result = FALSE;
+    int32_t result = false;
     UErrorCode err = U_ZERO_ERROR;
     const UCollator* pColl = GetCollatorFromSortHandle(pSortHandle, options, &err);
 
@@ -657,7 +657,7 @@ int32_t GlobalizationNative_EndsWith(
             {
                 if ((idx + usearch_getMatchedLength(pSearch)) == cwSourceLength)
                 {
-                    result = TRUE;
+                    result = true;
                 }
                 else
                 {

--- a/src/corefx/System.Globalization.Native/pal_icushim.c
+++ b/src/corefx/System.Globalization.Native/pal_icushim.c
@@ -5,6 +5,7 @@
 
 #include <dlfcn.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
@@ -38,13 +39,13 @@ static int FindICULibs(const char* versionPrefix, char* symbolName, char* symbol
 
     if (libicuuc == NULL)
     {
-        return FALSE;
+        return false;
     }
 
     // in OSX all ICU APIs exist in the same library libicucore.A.dylib
     libicui18n = libicuuc;
 
-    return TRUE;
+    return true;
 }
 
 #else // __APPLE__
@@ -103,13 +104,13 @@ static int FindSymbolVersion(int majorVer, int minorVer, int subVer, char* symbo
                 sprintf(symbolName, "u_strlen%s", symbolVersion);
                 if (dlsym(libicuuc, symbolName) == NULL)
                 {
-                    return FALSE;
+                    return false;
                 }
             }
         }
     }
 
-    return TRUE;
+    return true;
 }
 
 // Try to open the necessary ICU libraries
@@ -159,12 +160,12 @@ static int FindLibUsingOverride(const char* versionPrefix, char* symbolName, cha
         {
             if (OpenICULibraries(first, second, third, versionPrefix, symbolName, symbolVersion))
             {
-                return TRUE;
+                return true;
             }
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 // Search for library files with names including the major version.
@@ -176,7 +177,7 @@ static int FindLibWithMajorVersion(const char* versionPrefix, char* symbolName, 
     // Select the version of ICU present at build time.
     if (OpenICULibraries(MinICUVersion, -1, -1, versionPrefix, symbolName, symbolVersion))
     {
-        return TRUE;
+        return true;
     }
 
     // Select the highest supported version of ICU present on the local machine
@@ -184,11 +185,11 @@ static int FindLibWithMajorVersion(const char* versionPrefix, char* symbolName, 
     {
         if (OpenICULibraries(i, -1, -1, versionPrefix, symbolName, symbolVersion))
         {
-            return TRUE;
+            return true;
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 // Select the highest supported version of ICU present on the local machine
@@ -201,12 +202,12 @@ static int FindLibWithMajorMinorVersion(const char* versionPrefix, char* symbolN
         {
             if (OpenICULibraries(i, j, -1, versionPrefix, symbolName, symbolVersion))
             {
-                return TRUE;
+                return true;
             }
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 // Select the highest supported version of ICU present on the local machine
@@ -221,13 +222,13 @@ static int FindLibWithMajorMinorSubVersion(const char* versionPrefix, char* symb
             {
                 if (OpenICULibraries(i, j, k, versionPrefix, symbolName, symbolVersion))
                 {
-                    return TRUE;
+                    return true;
                 }
             }
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 
@@ -256,7 +257,7 @@ int32_t GlobalizationNative_LoadICU()
         if (!FindICULibs(VERSION_PREFIX_SUSE, symbolName, symbolVersion))
 #endif
         {
-            return FALSE;
+            return false;
         }
     }
 
@@ -275,7 +276,7 @@ int32_t GlobalizationNative_LoadICU()
     libicui18n = NULL;
 #endif // __APPLE__
 
-    return TRUE;
+    return true;
 }
 
 // GlobalizationNative_GetICUVersion

--- a/src/corefx/System.Globalization.Native/pal_locale.c
+++ b/src/corefx/System.Globalization.Native/pal_locale.c
@@ -5,6 +5,7 @@
 
 #include <assert.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <string.h>
 #include <stdlib.h>
 #include <locale.h>
@@ -15,7 +16,7 @@ int32_t UErrorCodeToBool(UErrorCode status)
 {
     if (U_SUCCESS(status))
     {
-        return TRUE;
+        return true;
     }
 
     // assert errors that should never occur
@@ -24,7 +25,7 @@ int32_t UErrorCodeToBool(UErrorCode status)
 
     // add possible SetLastError support here
 
-    return FALSE;
+    return false;
 }
 
 int32_t GetLocale(const UChar* localeName,
@@ -125,7 +126,7 @@ int32_t FixupLocaleName(UChar* value, int32_t valueLength)
 }
 
 // We use whatever ICU give us as the default locale except if it is en_US_POSIX. We'll map
-// this POSIX locale to Invariant instead. The reason is POSIX locale collation behavior 
+// this POSIX locale to Invariant instead. The reason is POSIX locale collation behavior
 // is not desirable at all because it doesn't support case insensitive string comparisons.
 const char* DetectDefaultLocaleName()
 {
@@ -139,41 +140,41 @@ const char* DetectDefaultLocaleName()
 }
 
 // GlobalizationNative_GetLocales gets all locale names and store it in the value buffer
-// in case of success, it returns the count of the characters stored in value buffer  
+// in case of success, it returns the count of the characters stored in value buffer
 // in case of failure, it returns negative number.
-// if the input value buffer is null, it returns the length needed to store the 
+// if the input value buffer is null, it returns the length needed to store the
 // locale names list.
-// if the value is not null, it fills the value with locale names separated by the length 
-// of each name. 
+// if the value is not null, it fills the value with locale names separated by the length
+// of each name.
 int32_t GlobalizationNative_GetLocales(UChar *value, int32_t valueLength)
 {
     int32_t totalLength = 0;
     int32_t index = 0;
     int32_t localeCount = uloc_countAvailable();
-    
+
     if (localeCount <=  0)
         return -1; // failed
-    
+
     for (int32_t i = 0; i < localeCount; i++)
     {
         const char *pLocaleName = uloc_getAvailable(i);
         if (pLocaleName[0] == 0) // unexpected empty name
             return -2;
-        
+
         int32_t localeNameLength = strlen(pLocaleName);
-        
+
         totalLength += localeNameLength + 1; // add 1 for the name length
-        
+
         if (value != NULL)
         {
             if (totalLength > valueLength)
                 return -3;
-            
+
             value[index++] = (UChar) localeNameLength;
-            
+
             for (int j=0; j<localeNameLength; j++)
             {
-                if (pLocaleName[j] == '_') // fix the locale name  
+                if (pLocaleName[j] == '_') // fix the locale name
                 {
                     value[index++] = (UChar) '-';
                 }
@@ -184,7 +185,7 @@ int32_t GlobalizationNative_GetLocales(UChar *value, int32_t valueLength)
             }
         }
     }
-    
+
     return totalLength;
 }
 
@@ -193,7 +194,7 @@ int32_t GlobalizationNative_GetLocaleName(const UChar* localeName, UChar* value,
     UErrorCode status = U_ZERO_ERROR;
 
     char localeNameBuffer[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, localeNameBuffer, ULOC_FULLNAME_CAPACITY, TRUE, &status);
+    GetLocale(localeName, localeNameBuffer, ULOC_FULLNAME_CAPACITY, true, &status);
     u_charsToUChars_safe(localeNameBuffer, value, valueLength, &status);
 
     if (U_SUCCESS(status))

--- a/src/corefx/System.Globalization.Native/pal_localeNumberData.c
+++ b/src/corefx/System.Globalization.Native/pal_localeNumberData.c
@@ -5,6 +5,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "pal_localeNumberData.h"
@@ -56,10 +57,10 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
     }
 
     int index = 0;
-    int minusAdded = FALSE;
-    int digitAdded = FALSE;
-    int currencyAdded = FALSE;
-    int spaceAdded = FALSE;
+    int minusAdded = false;
+    int digitAdded = false;
+    int currencyAdded = false;
+    int spaceAdded = false;
 
     for (int i = iStart; i <= iEnd; i++)
     {
@@ -69,7 +70,7 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
             case UCHAR_MINUS:
             case UCHAR_OPENPAREN:
             case UCHAR_CLOSEPAREN:
-                minusAdded = TRUE;
+                minusAdded = true;
                 break;
         }
     }
@@ -103,7 +104,7 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
             case UCHAR_DIGIT:
                 if (!digitAdded)
                 {
-                    digitAdded = TRUE;
+                    digitAdded = true;
                     destPattern[index++] = 'n';
                 }
                 break;
@@ -111,7 +112,7 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
             case UCHAR_CURRENCY:
                 if (!currencyAdded)
                 {
-                    currencyAdded = TRUE;
+                    currencyAdded = true;
                     destPattern[index++] = 'C';
                 }
                 break;
@@ -120,19 +121,19 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
             case UCHAR_NBSPACE:
                 if (!spaceAdded)
                 {
-                    spaceAdded = TRUE;
+                    spaceAdded = true;
                     destPattern[index++] = ' ';
                 }
                 else
                 {
-                    assert(FALSE);
+                    assert(false);
                 }
                 break;
 
             case UCHAR_MINUS:
             case UCHAR_OPENPAREN:
             case UCHAR_CLOSEPAREN:
-                minusAdded = TRUE;
+                minusAdded = true;
                 destPattern[index++] = (char)ch;
                 break;
 
@@ -162,7 +163,7 @@ static int GetNumericPattern(const UNumberFormat* pNumberFormat,
     const int MAX_DOTNET_NUMERIC_PATTERN_LENGTH = 6; // example: "(C n)" plus terminator
 
     UErrorCode ignore = U_ZERO_ERROR;
-    int32_t icuPatternLength = unum_toPattern(pNumberFormat, FALSE, NULL, 0, &ignore) + 1;
+    int32_t icuPatternLength = unum_toPattern(pNumberFormat, false, NULL, 0, &ignore) + 1;
 
     UChar* icuPattern = calloc(icuPatternLength, sizeof(UChar));
     if (icuPattern == NULL)
@@ -172,7 +173,7 @@ static int GetNumericPattern(const UNumberFormat* pNumberFormat,
 
     UErrorCode err = U_ZERO_ERROR;
 
-    unum_toPattern(pNumberFormat, FALSE, icuPattern, icuPatternLength, &err);
+    unum_toPattern(pNumberFormat, false, icuPattern, icuPatternLength, &err);
 
     assert(U_SUCCESS(err));
 
@@ -200,7 +201,7 @@ static int GetNumericPattern(const UNumberFormat* pNumberFormat,
         }
     }
 
-    assert(FALSE); // should have found a valid pattern
+    assert(false); // should have found a valid pattern
     free(normalizedPattern);
     return INVALID_FORMAT;
 }
@@ -239,7 +240,7 @@ static int GetCurrencyNegativePattern(const char* locale)
 
     if (U_SUCCESS(status))
     {
-        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), TRUE);
+        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), true);
         if (value >= 0)
         {
             unum_close(pFormat);
@@ -270,7 +271,7 @@ static int GetCurrencyPositivePattern(const char* locale)
 
     if (U_SUCCESS(status))
     {
-        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), FALSE);
+        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), false);
         if (value >= 0)
         {
             unum_close(pFormat);
@@ -301,7 +302,7 @@ static int GetNumberNegativePattern(const char* locale)
 
     if (U_SUCCESS(status))
     {
-        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), TRUE);
+        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), true);
         if (value >= 0)
         {
             unum_close(pFormat);
@@ -333,7 +334,7 @@ static int GetPercentNegativePattern(const char* locale)
 
     if (U_SUCCESS(status))
     {
-        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), TRUE);
+        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), true);
         if (value >= 0)
         {
             unum_close(pFormat);
@@ -364,7 +365,7 @@ static int GetPercentPositivePattern(const char* locale)
 
     if (U_SUCCESS(status))
     {
-        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), FALSE);
+        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), false);
         if (value >= 0)
         {
             unum_close(pFormat);
@@ -408,11 +409,11 @@ int32_t GlobalizationNative_GetLocaleInfoInt(
 {
     UErrorCode status = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &status);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &status);
 
     if (U_FAILURE(status))
     {
-        return FALSE;
+        return false;
     }
 
     switch (localeNumberData)
@@ -515,7 +516,7 @@ int32_t GlobalizationNative_GetLocaleInfoInt(
             break;
         default:
             status = U_UNSUPPORTED_ERROR;
-            assert(FALSE);
+            assert(false);
             break;
     }
 
@@ -534,7 +535,7 @@ int32_t GlobalizationNative_GetLocaleInfoGroupingSizes(
 {
     UErrorCode status = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &status);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &status);
 
     if (U_FAILURE(status))
     {

--- a/src/corefx/System.Globalization.Native/pal_localeStringData.c
+++ b/src/corefx/System.Globalization.Native/pal_localeStringData.c
@@ -5,6 +5,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "pal_localeStringData.h"
@@ -163,28 +164,28 @@ Gets the locale currency English or native name and convert the result to UChars
 static UErrorCode GetLocaleCurrencyName(const char* locale, UBool nativeName, UChar* value, int32_t valueLength)
 {
     UErrorCode status = U_ZERO_ERROR;
-    
+
     UChar currencyThreeLettersName[4]; // 3 letters currency iso name + NULL
     ucurr_forLocale(locale, currencyThreeLettersName, 4, &status);
     if (!U_SUCCESS(status))
     {
         return status;
     }
-    
+
     int32_t len;
     UBool formatChoice;
     const UChar *pCurrencyLongName = ucurr_getName(
-                                        currencyThreeLettersName, 
-                                        nativeName ? locale : ULOC_US, 
-                                        UCURR_LONG_NAME, 
-                                        &formatChoice, 
-                                        &len, 
+                                        currencyThreeLettersName,
+                                        nativeName ? locale : ULOC_US,
+                                        UCURR_LONG_NAME,
+                                        &formatChoice,
+                                        &len,
                                         &status);
     if (!U_SUCCESS(status))
     {
         return status;
     }
-    
+
     if (len >= valueLength) // we need to have room for NULL too
     {
         return U_BUFFER_OVERFLOW_ERROR;
@@ -210,7 +211,7 @@ int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeName,
 {
     UErrorCode status = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &status);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &status);
 
     if (U_FAILURE(status))
     {
@@ -268,10 +269,10 @@ int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeName,
             status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_INTL_CURRENCY_SYMBOL, value, valueLength);
             break;
         case LocaleString_CurrencyEnglishName:
-            status = GetLocaleCurrencyName(locale, FALSE, value, valueLength);
+            status = GetLocaleCurrencyName(locale, false, value, valueLength);
             break;
         case LocaleString_CurrencyNativeName:
-            status = GetLocaleCurrencyName(locale, TRUE, value, valueLength);
+            status = GetLocaleCurrencyName(locale, true, value, valueLength);
             break;
         case LocaleString_MonetaryDecimalSeparator:
             status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_MONETARY_SEPARATOR_SYMBOL, value, valueLength);
@@ -281,10 +282,10 @@ int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeName,
                 GetLocaleInfoDecimalFormatSymbol(locale, UNUM_MONETARY_GROUPING_SEPARATOR_SYMBOL, value, valueLength);
             break;
         case LocaleString_AMDesignator:
-            status = GetLocaleInfoAmPm(locale, TRUE, value, valueLength);
+            status = GetLocaleInfoAmPm(locale, true, value, valueLength);
             break;
         case LocaleString_PMDesignator:
-            status = GetLocaleInfoAmPm(locale, FALSE, value, valueLength);
+            status = GetLocaleInfoAmPm(locale, false, value, valueLength);
             break;
         case LocaleString_PositiveSign:
             status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_PLUS_SIGN_SYMBOL, value, valueLength);
@@ -352,10 +353,10 @@ int32_t GlobalizationNative_GetLocaleTimeFormat(const UChar* localeName,
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &err);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &err);
     UDateFormatStyle style = (shortFormat != 0) ? UDAT_SHORT : UDAT_MEDIUM;
     UDateFormat* pFormat = udat_open(style, UDAT_NONE, locale, NULL, 0, NULL, 0, &err);
-    udat_toPattern(pFormat, FALSE, value, valueLength, &err);
+    udat_toPattern(pFormat, false, value, valueLength, &err);
     udat_close(pFormat);
     return UErrorCodeToBool(err);
 }

--- a/src/corefx/System.Globalization.Native/pal_normalization.c
+++ b/src/corefx/System.Globalization.Native/pal_normalization.c
@@ -4,6 +4,7 @@
 //
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "pal_icushim.h"
 #include "pal_normalization.h"
@@ -48,7 +49,7 @@ int32_t GlobalizationNative_IsNormalized(
 
     if (U_SUCCESS(err))
     {
-        return isNormalized == TRUE ? 1 : 0;
+        return isNormalized == true ? 1 : 0;
     }
     else
     {

--- a/src/corefx/System.Globalization.Native/pal_timeZoneInfo.c
+++ b/src/corefx/System.Globalization.Native/pal_timeZoneInfo.c
@@ -4,6 +4,7 @@
 //
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <unistd.h>
 
 #include "pal_timeZoneInfo.h"
@@ -19,7 +20,7 @@ ResultCode GlobalizationNative_GetTimeZoneDisplayName(const UChar* localeName,
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &err);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &err);
 
     int32_t timeZoneIdLength = -1; // timeZoneId is NULL-terminated
     UCalendar* calendar = ucal_open(timeZoneId, timeZoneIdLength, locale, UCAL_DEFAULT, &err);


### PR DESCRIPTION
Changes in System.Globalization.Native:
  - Replace `TRUE` with `true` and `FALSE` with `false`
  - Add `#include <stdbool.h>`