### PR TITLE
[release/3.1] Fix deadlock in EventPipe session stop

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -411,6 +411,14 @@ EventPipeSession *EventPipe::GetSession(EventPipeSessionID id)
     }
 }
 
+bool EventPipe::IsSessionEnabled(EventPipeSessionID id)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    const EventPipeSession *const pSession = reinterpret_cast<EventPipeSession *>(id);
+    return s_pSessions[pSession->GetIndex()].Load() != nullptr;
+}
+
 EventPipeProvider *EventPipe::CreateProvider(const SString &providerName, EventPipeCallback pCallbackFunction, void *pCallbackData)
 {
     CONTRACTL

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -19,6 +19,7 @@ class EventPipeFile;
 class EventPipeEventSource;
 class EventPipeProvider;
 class EventPipeSession;
+class EventPipeSessionProvider;
 class IpcStream;
 enum class EventPipeSessionType;
 enum class EventPipeSerializationFormat;
@@ -84,6 +85,8 @@ public:
 
     // Get a provider.
     static EventPipeProvider *GetProvider(const SString &providerName);
+
+    static bool EventPipe::IsSessionEnabled(EventPipeSessionID id);
 
     // Delete a provider.
     static void DeleteProvider(EventPipeProvider *pProvider);

--- a/src/vm/eventpipebuffermanager.cpp
+++ b/src/vm/eventpipebuffermanager.cpp
@@ -36,7 +36,6 @@ EventPipeBufferManager::EventPipeBufferManager(EventPipeSession* pSession, size_
     m_pThreadSessionStateList = new SList<SListElem<EventPipeThreadSessionState *>>();
     m_sizeOfAllBuffers = 0;
     m_lock.Init(LOCK_TYPE_DEFAULT);
-    m_writeEventSuspending = FALSE;
     m_waitEvent.CreateAutoEvent(TRUE);
 
 #ifdef _DEBUG
@@ -78,8 +77,6 @@ EventPipeBufferManager::~EventPipeBufferManager()
     }
     CONTRACTL_END;
 
-    // setting this true should have no practical effect other than satisfying asserts at this point.
-    m_writeEventSuspending = TRUE;
     DeAllocateBuffers();
 }
 
@@ -106,13 +103,6 @@ EventPipeBuffer* EventPipeBufferManager::AllocateBufferForThread(EventPipeThread
 
     // Allocating a buffer requires us to take the lock.
     SpinLockHolder _slh(&m_lock);
-
-    // if we are deallocating then give up, see the comments in SuspendWriteEvents() for why this is important.
-    if (m_writeEventSuspending.Load())
-    {
-        writeSuspended = TRUE;
-        return NULL;
-    }
 
     bool allocateNewBuffer = false;
 
@@ -396,11 +386,6 @@ bool EventPipeBufferManager::WriteEvent(Thread *pThread, EventPipeSession &sessi
     EventPipeThreadSessionState* pSessionState = NULL;
     {
         SpinLockHolder _slh(pEventPipeThread->GetLock());
-        if (m_writeEventSuspending.LoadWithoutBarrier())
-        {
-            // This session is suspending, we need to avoid initializing any session state and exit
-            return false;
-        }
         pSessionState = pEventPipeThread->GetOrCreateSessionState(m_pSession);
         if (pSessionState == NULL)
         {
@@ -461,28 +446,15 @@ bool EventPipeBufferManager::WriteEvent(Thread *pThread, EventPipeSession &sessi
             _ASSERTE(pEventPipeThread != NULL);
             {
                 SpinLockHolder _slh(pEventPipeThread->GetLock());
-                if (m_writeEventSuspending.LoadWithoutBarrier())
-                {
-                    // After leaving the manager's lock in AllocateBufferForThread some other thread decided to suspend writes.
-                    // We need to immediately return the buffer we just took without storing it or writing to it.
-                    // SuspendWriteEvent() is spinning waiting for this buffer to be relinquished.
-                    pBuffer->ConvertToReadOnly();
+                pSessionState->SetWriteBuffer(pBuffer);
 
-                    // We treat this as the WriteEvent() call occurring after this session stopped listening for events, effectively the
-                    // same as if event.IsEnabled() returned false.
-                    return false;
-                }
-                else
-                {
-                    pSessionState->SetWriteBuffer(pBuffer);
+                // Try to write the event after we allocated a buffer.
+                // This is the first time if the thread had no buffers before the call to this function.
+                // This is the second time if this thread did have one or more buffers, but they were full.
+                allocNewBuffer = !pBuffer->WriteEvent(pEventThread, session, event, payload, pActivityId, pRelatedActivityId, pStack);
+                _ASSERTE(!allocNewBuffer);
+                pSessionState->IncrementSequenceNumber();
 
-                    // Try to write the event after we allocated a buffer.
-                    // This is the first time if the thread had no buffers before the call to this function.
-                    // This is the second time if this thread did have one or more buffers, but they were full.
-                    allocNewBuffer = !pBuffer->WriteEvent(pEventThread, session, event, payload, pActivityId, pRelatedActivityId, pStack);
-                    _ASSERTE(!allocNewBuffer);
-                    pSessionState->IncrementSequenceNumber();
-                }
             }
         }
     }
@@ -1008,27 +980,22 @@ void EventPipeBufferManager::SuspendWriteEvent(uint32_t sessionIndex)
         SpinLockHolder _slh(&m_lock);
         _ASSERTE(EnsureConsistency());
 
-        m_writeEventSuspending.Store(TRUE);
-        // From this point until m_writeEventSuspending is reset to FALSE it is impossible
-        // for new EventPipeThreadSessionStates to be added to the m_pThreadSessionStateList or
-        // for new EventBuffers to be added to an existing EventPipeBufferList. The only
-        // way AllocateBufferForThread is allowed to add one is by:
-        // 1) take m_lock - AllocateBufferForThread can't own it now because this thread owns it,
-        //                  but after this thread gives it up lower in this function it could be acquired.
-        // 2) observe m_writeEventSuspending = False - that won't happen, acquiring m_lock
-        //                  guarantees AllocateBufferForThread will observe all the memory changes this
-        //                  thread made prior to releasing m_lock and we've already set it TRUE.
-        // This ensures that we iterate over the list of threads below we've got the complete list.
+        // Find all threads that have used this buffer manager
         SListElem<EventPipeThreadSessionState *> *pElem = m_pThreadSessionStateList->GetHead();
         while (pElem != NULL)
         {
-            threadList.Push(pElem->GetValue()->GetThread());
+            EventPipeThread *pThread = pElem->GetValue()->GetThread();
+            threadList.Push(pThread);
             pElem = m_pThreadSessionStateList->GetNext(pElem);
+
+            // Once EventPipeSession::SuspendWriteEvent completes, we shouldn't have any
+            // in progress writes left.
+            _ASSERTE(pThread->GetSessionWriteInProgress() != sessionIndex);
         }
     }
 
-    // Iterate through all the threads, forcing them to finish writes in progress inside EventPipeThread::m_lock,
-    // relinquish any buffers stored in EventPipeThread::m_pWriteBuffer and prevent storing new ones.
+    // Iterate through all the threads, forcing them to relinquish any buffers stored in
+    // EventPipeThread::m_pWriteBuffer and prevent storing new ones.
     for (size_t i = 0; i < threadList.Size(); i++)
     {
         EventPipeThread *pThread = threadList[i];
@@ -1036,44 +1003,6 @@ void EventPipeBufferManager::SuspendWriteEvent(uint32_t sessionIndex)
             SpinLockHolder _slh(pThread->GetLock());
             EventPipeThreadSessionState *const pSessionState = pThread->GetSessionState(m_pSession);
             pSessionState->SetWriteBuffer(nullptr);
-            // From this point until m_writeEventSuspending is reset to FALSE it is impossible
-            // for this thread to set the write buffer to a non-null value which in turn means
-            // it can't write events into any buffer. To do this it would need to both:
-            // 1) Acquire the thread lock - it can't right now but it will be able to do so after
-            //                              we release the lock below
-            // 2) Observe m_writeEventSuspending = false - that won't happen, acquiring the thread
-            //                              lock guarantees WriteEvent will observe all the memory
-            //                              changes this thread made prior to releasing the thread
-            //                              lock and we already set it TRUE.
-        }
-    }
-
-    // Wait for any straggler WriteEvent threads that may have already allocated a buffer but
-    // hadn't yet relinquished it.
-    {
-        SpinLockHolder _slh(&m_lock);
-        SListElem<EventPipeThreadSessionState *> *pElem = m_pThreadSessionStateList->GetHead();
-        while (pElem != NULL)
-        {
-            // Get the list and remove it from the thread.
-            EventPipeBufferList *const pBufferList = pElem->GetValue()->GetBufferList();
-            if (pBufferList != nullptr)
-            {
-                EventPipeThread *const pEventPipeThread = pBufferList->GetThread();
-                if (pEventPipeThread != nullptr)
-                {
-                    YIELD_WHILE(pEventPipeThread->GetSessionWriteInProgress() == sessionIndex);
-                    // It still guarantees that the thread has returned its buffer, but it also now guarantees that
-                    // that the thread has returned from Session::WriteEvent() and has relinquished the session pointer
-                    // This yield is guaranteed to eventually finish because threads will eventually exit WriteEvent()
-                    // setting the flag back to -1. If the thread could quickly re-enter WriteEvent and set the flag
-                    // back to this_session_id we could theoretically get unlucky and never observe the gap, but
-                    // setting s_pSessions[this_session_id] = NULL above guaranteed that can't happen indefinately.
-                    // Sooner or later the thread is going to see the NULL value and once it does it won't store
-                    // this_session_id into the flag again.
-                }
-            }
-            pElem = m_pThreadSessionStateList->GetNext(pElem);
         }
     }
 }
@@ -1095,15 +1024,6 @@ void EventPipeBufferManager::DeAllocateBuffers()
         SpinLockHolder _slh(&m_lock);
 
         _ASSERTE(EnsureConsistency());
-        _ASSERTE(m_writeEventSuspending);
-
-        // This m_writeEventSuspending flag + locks ensures that no thread will touch any of the
-        // state we are dismantling here. This includes:
-        //   a) EventPipeThread m_sessions[session_id]
-        //   b) EventPipeThreadSessionState
-        //   c) EventPipeBufferList
-        //   d) EventPipeBuffer
-        //   e) EventPipeBufferManager.m_pThreadSessionStateList
 
         SListElem<EventPipeThreadSessionState*> *pElem = m_pThreadSessionStateList->GetHead();
         while (pElem != NULL)

--- a/src/vm/eventpipebuffermanager.h
+++ b/src/vm/eventpipebuffermanager.h
@@ -61,7 +61,6 @@ private:
 
     // Lock to protect access to the per-thread buffer list and total allocation size.
     SpinLock m_lock;
-    Volatile<BOOL> m_writeEventSuspending;
 
     // Event for synchronizing real time reading
     CLREvent m_waitEvent;

--- a/src/vm/eventpipecommontypes.h
+++ b/src/vm/eventpipecommontypes.h
@@ -115,6 +115,38 @@ private:
     SList<SListElem<EventPipeProviderCallbackData>> list;
 };
 
+template <class T>
+class EventPipeIterator
+{
+private:
+    SList<SListElem<T>> *m_pList;
+    typename SList<SListElem<T>>::Iterator m_iterator;
+
+public:
+    EventPipeIterator(SList<SListElem<T>> *pList) :
+        m_pList(pList),
+        m_iterator(pList->begin())
+    {
+        _ASSERTE(m_pList != nullptr);
+    }
+
+    bool Next(T *ppProvider)
+    {
+        CONTRACTL
+        {
+            THROWS;
+            GC_NOTRIGGER;
+            MODE_ANY;
+            PRECONDITION(ppProvider != nullptr);
+        }
+        CONTRACTL_END;
+
+        *ppProvider = *m_iterator;
+        ++m_iterator;
+        return m_iterator != m_pList->end();
+    }
+};
+
 #endif // FEATURE_PERFTRACING
 
 #endif // __EVENTPIPE_PROVIDERCALLBACKDATA_H__


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/51579.

The issue was fixed in 5.0 as part of another work https://github.com/dotnet/runtime/commit/c6d1756b69ee34cb96376fedc7a72b56975fd9ba and this fix ports the relevant portions of that commit onto 3.1. 

Originally reported by Service Profiler team that saw this hang in production after running service profiler for ~3 weeks.

### Customer Impact
This leads to a deadlock between the diagnostics server thread and any thread that was writing an event during a session stop. The diagnostics server thread will indefinitely hang and additional trace sessions cannot be started to the customers' app. It can also affect various profilers relying on EventPipe to not be able to start/stop sessions to a running process.

### Regression?
No

### Risk
The code change is fairly large but has been shipped with 5.0 for a while now and didn't get any reports of similar hang.

The fix was also validated with the service profiler team with a modified version of their profiler that would aggravate the probability of the issue happening and tested for roughly ~420 days of "real" service profiler session and saw no hang.