### PR TITLE
Revert "Disable publish to dotnet/versions in 3.1"

### DIFF
--- a/eng/finalize-publish.yml
+++ b/eng/finalize-publish.yml
@@ -38,27 +38,27 @@ jobs:
         artifactName: PackageArtifacts
         downloadPath: ${{ parameters.artifactsDir }}/nuget
 
-    - powershell: |
-        $prefix = "refs/heads/"
-        $branch = "$(Build.SourceBranch)"
-        $branchName = $branch
-        if ($branchName.StartsWith($prefix))
-        {
-          $branchName = $branchName.Substring($prefix.Length)
-        }
-        Write-Host "For Build.SourceBranch $branch, FullBranchName is $branchName"
-        Write-Host "##vso[task.setvariable variable=FullBranchName;]$branchName"
-        ls -R ${{ parameters.artifactsDir }}/nuget/*.nupkg
-        $(Build.SourcesDirectory)/UpdatePublishedVersions.ps1 `
-        -gitHubUser ${{ parameters.gitHubUser }} `
-        -gitHubEmail ${{ parameters.gitHubEmail }} `
-        -gitHubAuthToken ${{ parameters.gitHubAuthToken }} `
-        -versionsRepoOwner ${{ parameters.versionsRepoOwner }} `
-        -versionsRepo ${{ parameters.versionsRepo }} `
-        -versionsRepoPath build-info/dotnet/coreclr/$branchName `
-        -nupkgPath ${{ parameters.artifactsDir }}/nuget/*.nupkg
+    #- powershell: |
+    #    $prefix = "refs/heads/"
+    #    $branch = "$(Build.SourceBranch)"
+    #    $branchName = $branch
+    #    if ($branchName.StartsWith($prefix))
+    #    {
+    #      $branchName = $branchName.Substring($prefix.Length)
+    #    }
+    #    Write-Host "For Build.SourceBranch $branch, FullBranchName is $branchName"
+    #    Write-Host "##vso[task.setvariable variable=FullBranchName;]$branchName"
+    #    ls -R ${{ parameters.artifactsDir }}/nuget/*.nupkg
+    #    $(Build.SourcesDirectory)/UpdatePublishedVersions.ps1 `
+    #    -gitHubUser ${{ parameters.gitHubUser }} `
+    #    -gitHubEmail ${{ parameters.gitHubEmail }} `
+    #    -gitHubAuthToken ${{ parameters.gitHubAuthToken }} `
+    #    -versionsRepoOwner ${{ parameters.versionsRepoOwner }} `
+    #    -versionsRepo ${{ parameters.versionsRepo }} `
+    #    -versionsRepoPath build-info/dotnet/coreclr/$branchName `
+    #    -nupkgPath ${{ parameters.artifactsDir }}/nuget/*.nupkg
 
-      displayName: Run UpdatePublishedVersions.ps1
+    # displayName: Run UpdatePublishedVersions.ps1
 
     - task: CopyFiles@2
       displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs

--- a/eng/pipelines/internal.yml
+++ b/eng/pipelines/internal.yml
@@ -50,20 +50,20 @@ stages:
     # product build job), and publishes them to the build assets
     # registry. Its dependencies should be updated to include all of the
     # official builds if we add more platform/arch combinations.
-    # - template: /eng/finalize-publish.yml
-    #   parameters:
-    #     dependsOn:
-    #     - build_Linux_arm_release
-    #     - build_Linux_arm64_release
-    #     - build_Linux_musl_x64_release
-    #     - build_Linux_musl_arm64_release
-    #     - build_Linux_rhel6_x64_release
-    #     - build_Linux_x64_release
-    #     - build_OSX_x64_release
-    #     - build_Windows_NT_x64_release
-    #     - build_Windows_NT_x86_release
-    #     - build_Windows_NT_arm_release
-    #     - build_Windows_NT_arm64_release
+    - template: /eng/finalize-publish.yml
+      parameters:
+        dependsOn:
+        - build_Linux_arm_release
+        - build_Linux_arm64_release
+        - build_Linux_musl_x64_release
+        - build_Linux_musl_arm64_release
+        - build_Linux_rhel6_x64_release
+        - build_Linux_x64_release
+        - build_OSX_x64_release
+        - build_Windows_NT_x64_release
+        - build_Windows_NT_x86_release
+        - build_Windows_NT_arm_release
+        - build_Windows_NT_arm64_release
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/common/templates/post-build/post-build.yml


### PR DESCRIPTION
Reverts dotnet/coreclr#28171 & removes just the "updatepublishversions.ps1"  segment from the relevant job. The removed job includes the final publish stage: https://dev.azure.com/dnceng/internal/_build/results?buildId=1134919&view=results