### PR TITLE
[release/3.1] Handle Counter Polling Interval of 0

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
@@ -240,10 +240,9 @@ namespace System.Diagnostics.Tracing
                 lock (s_counterGroupLock)
                 {
                     _timeStampSinceCollectionStarted = now;
-                    do
-                    {
-                        _nextPollingTimeStamp += new TimeSpan(0, 0, 0, 0, _pollingIntervalInMilliseconds);
-                    } while (_nextPollingTimeStamp <= now);
+                    TimeSpan delta = now - _nextPollingTimeStamp;
+                    if (delta > TimeSpan.Zero && _pollingIntervalInMilliseconds > 0)
+                        _nextPollingTimeStamp += TimeSpan.FromMilliseconds(_pollingIntervalInMilliseconds * Math.Ceiling(delta.TotalMilliseconds / _pollingIntervalInMilliseconds));
                 }
             }
         }

--- a/tests/src/tracing/eventcounter/gh53564.cs
+++ b/tests/src/tracing/eventcounter/gh53564.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
+using System.Diagnostics.Tracing;
+#endif
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Diagnostics;
+
+namespace gh53564Tests
+{
+    public class RuntimeCounterListener : EventListener
+    {
+        public RuntimeCounterListener(){}
+
+        private DateTime? setToZeroTimestamp = null;
+        private DateTime? mostRecentTimestamp = null;
+        public ManualResetEvent ReadyToVerify { get; } = new ManualResetEvent(initialState: false);
+
+        protected override void OnEventSourceCreated(EventSource source)
+        {
+            if (source.Name.Equals("System.Runtime"))
+            {
+                Dictionary<string, string> refreshInterval = new Dictionary<string, string>();
+
+                Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] Setting interval to 1");
+                // first set interval to 1 seconds
+                refreshInterval["EventCounterIntervalSec"] = "1";
+                EnableEvents(source, EventLevel.Informational, (EventKeywords)(-1), refreshInterval);
+
+                // wait a moment to get some events
+                Thread.Sleep(TimeSpan.FromSeconds(3));
+
+                // then set interval to 0
+                Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] Setting interval to 0");
+                refreshInterval["EventCounterIntervalSec"] = "0";
+                EnableEvents(source, EventLevel.Informational, (EventKeywords)(-1), refreshInterval);
+                setToZeroTimestamp = DateTime.Now + TimeSpan.FromSeconds(1); // Stash timestamp 1 second after setting to 0
+
+                // then attempt to set interval back to 1
+                Thread.Sleep(TimeSpan.FromSeconds(3));
+                Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] Setting interval to 1");
+                refreshInterval["EventCounterIntervalSec"] = "1";
+                EnableEvents(source, EventLevel.Informational, (EventKeywords)(-1), refreshInterval);
+                Thread.Sleep(TimeSpan.FromSeconds(3));
+                Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] Setting ReadyToVerify");
+                ReadyToVerify.Set();
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            mostRecentTimestamp = eventData.TimeStamp;
+        }
+
+        public bool Verify()
+        {
+            if (!ReadyToVerify.WaitOne(0))
+                return false;
+
+            return (setToZeroTimestamp is null || mostRecentTimestamp is null) ? false : setToZeroTimestamp < mostRecentTimestamp;
+        }
+    }
+
+    public partial class TestRuntimeEventCounter
+    {
+        public static int Main(string[] args)
+        {
+            // Create an EventListener.
+            using (RuntimeCounterListener myListener = new RuntimeCounterListener())
+            {
+                if (myListener.ReadyToVerify.WaitOne(TimeSpan.FromSeconds(15)))
+                {
+                Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] Ready to verify");
+                    if (myListener.Verify())
+                    {
+                        Console.WriteLine("Test passed");
+                        return 100;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Test Failed - did not see one or more of the expected runtime counters.");
+                        return 1;
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("Test Failed - timed out waiting for reset");
+                    return 1;
+                }
+            }
+        }
+    }
+}

--- a/tests/src/tracing/eventcounter/gh53564.csproj
+++ b/tests/src/tracing/eventcounter/gh53564.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>0</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- This test has a secondary thread with an infinite loop -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="gh53564.cs" />
+    <ProjectReference Include="../common/common.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/src/tracing/eventcounter/gh53564.csproj
+++ b/tests/src/tracing/eventcounter/gh53564.csproj
@@ -1,17 +1,31 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{8E3244CB-407F-4142-BAAB-E7A55901A5FA}</ProjectGuid>
     <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <CLRTestKind>BuildAndRun</CLRTestKind>
+    <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
-    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="gh53564.cs" />
     <ProjectReference Include="../common/common.csproj" />
   </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>
+


### PR DESCRIPTION
Backport of dotnet/runtime#53836 to release/3.1

## Customer Impact

When listening to EventCounters there is a dedicated thread that is supposed to publish the metric values via EventSource on a periodic timer. However due a bug it is possible to put it into an infinite loop [here](https://github.com/dotnet/runtime/blob/01b7e73cd378145264a7cb7a09365b41ed42b240/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs#L254-L257). This occurs any time _pollingIntervalMilliseconds <= 0, which could occur for a few reasons:
1. The listener specified EventCounterIntervalSec=0 after previously specifying a non-zero value. We would never expect a well-behaved listener to request a 0 sec interval, but the runtime shouldn't blindly trust this input.
2. The listener enables and then disables the EventSource. Due to a race the infinite loop code could be run prior to re-checking _eventSource.IsEnabled() and it would observe _pollingIntervaMilliseconds=0

(from dotnet/runtime#53564)

## Testing

The included test covers scenario 1, and manual testing was done for scenario 2.

## Risk

This patch reduces overall risk by removing any looping based on user input. This should prevent scenario 1 and 2 above.