### PR TITLE
Remove RedHat 6 from the test matrix

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -125,9 +125,6 @@ jobs:
         image: centos-6-3e800f1-20190501005338
         registry: mcr
       helixQueues:
-      # TODO: enable RedHat.6.Amd64.Open once https://github.com/dotnet/coreclr/issues/23580 is resolved
-      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - RedHat.6.Amd64
       ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux x64


### PR DESCRIPTION
A Core Eng alert showed that the repo sends work items to a queue (RedHat 6) that isn't supported anymore, so I want to remove the unnecessary job