### PR TITLE
[release/3.1] Port dotnet/runtime#40116 (MemberInfo lock contention) to 3.1

### DIFF
--- a/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -235,6 +235,48 @@ namespace System
 
                 internal MethodBase AddMethod(RuntimeType declaringType, RuntimeMethodHandleInternal method, CacheType cacheType)
                 {
+                    // First, see if we've already cached an RuntimeMethodInfo or
+                    // RuntimeConstructorInfo that corresponds to this member. Since another
+                    // thread could be updating the backing store at the same time it's
+                    // possible that the check below will result in a false negative. That's
+                    // ok; we'll handle any concurrency issues in the later call to Insert.
+
+                    T?[]? allMembersLocal = m_allMembers;
+                    if (allMembersLocal != null)
+                    {
+                        // if not a Method or a Constructor, fall through
+                        if (cacheType == CacheType.Method)
+                        {
+                            foreach (T? candidate in allMembersLocal)
+                            {
+                                if (candidate is null)
+                                {
+                                    break; // end of list; stop iteration and fall through to slower path
+                                }
+
+                                if (candidate is RuntimeMethodInfo candidateRMI && candidateRMI.MethodHandle.Value == method.Value)
+                                {
+                                    return candidateRMI; // match!
+                                }
+                            }
+                        }
+                        else if (cacheType == CacheType.Constructor)
+                        {
+                            foreach (T? candidate in allMembersLocal)
+                            {
+                                if (candidate is null)
+                                {
+                                    break; // end of list; stop iteration and fall through to slower path
+                                }
+
+                                if (candidate is RuntimeConstructorInfo candidateRCI && candidateRCI.MethodHandle.Value == method.Value)
+                                {
+                                    return candidateRCI; // match!
+                                }
+                            }
+                        }
+                    }
+
                     T[] list = null!;
                     MethodAttributes methodAttributes = RuntimeMethodHandle.GetAttributes(method);
                     bool isPublic = (methodAttributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Public;
@@ -262,6 +304,29 @@ namespace System
 
                 internal FieldInfo AddField(RuntimeFieldHandleInternal field)
                 {
+                    // First, see if we've already cached an RtFieldInfo that corresponds
+                    // to this field. Since another thread could be updating the backing
+                    // store at the same time it's possible that the check below will
+                    // result in a false negative. That's ok; we'll handle any concurrency
+                    // issues in the later call to Insert.
+
+                    T?[]? allMembersLocal = m_allMembers;
+                    if (allMembersLocal != null)
+                    {
+                        foreach (T? candidate in allMembersLocal)
+                        {
+                            if (candidate is null)
+                            {
+                                break; // end of list; stop iteration and fall through to slower path
+                            }
+
+                            if (candidate is RtFieldInfo candidateRtFI && candidateRtFI.GetFieldHandle() == field.Value)
+                            {
+                                return candidateRtFI; // match!
+                            }
+                        }
+                    }
+
                     // create the runtime field info
                     FieldAttributes fieldAttributes = RuntimeFieldHandle.GetAttributes(field);
                     bool isPublic = (fieldAttributes & FieldAttributes.FieldAccessMask) == FieldAttributes.Public;
@@ -506,7 +571,7 @@ namespace System
                             }
 
                             Debug.Assert(cachedMembers![freeSlotIndex] == null);
-                            cachedMembers[freeSlotIndex] = newMemberInfo;
+                            Volatile.Write(ref cachedMembers[freeSlotIndex], newMemberInfo); // value may be read outside of lock
                             freeSlotIndex++;
                         }
                     }


### PR DESCRIPTION
Ports the fix for https://github.com/dotnet/runtime/issues/35851 from 5.0 to 3.1 per customer request.

## Customer impact

The methods `Type.GetMethod` and `Type.GetField` take a per-Type lock while searching for the target member. This can cause lock contention in high-traffic applications if multiple threads call these methods concurrently on the same Type instance. We've received reports of customers' applications impacted by this contention and their RPS dropping precipitiously.

The fix avoids the lock entirely in the common case where all MemberInfo instances have already been cached. Multiple threads can walk this cache concurrently without contention.

## Regression

No. This is a perf improvement compared to 3.1 RTM. Aside from the perf improvement, no behavioral changes should be observed.

## Risk

Low. This change originally went in to 5.0, and we've received no bug reports for these code paths since 5.0 RTM shipped. The code path also "fails safe", meaning that if the cache appears to be improperly initialized (perhaps because another thread is currently in the process of updating it) the method will fall back down the slower "take the lock" code path. This failsafe also shipped in 5.0 RTM.