### PR TITLE
[release/3.1] Reduce lock contentions in GetCultureInfoHelper

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureInfo.cs
@@ -1142,9 +1142,10 @@ namespace System.Globalization
                 {
                     Debug.Assert(name != null && (lcid != -1 || altName != null));
                     bool ret;
+                    string key = lcid == 0 ? name! : name! + '\xfffd' + altName!;
                     lock (_lock)
                     {
-                        ret = tempNameHT.TryGetValue(lcid == 0 ? name! : name! + '\xfffd' + altName!, out retval);
+                        ret = tempNameHT.TryGetValue(key, out retval);
                     }
 
                     if (ret && retval != null)
@@ -1211,10 +1212,11 @@ namespace System.Globalization
 
             if (lcid == -1)
             {
+                string key = name + '\xfffd' + altName;
                 lock (_lock)
                 {
                     // This new culture will be added only to the name hash table.
-                    tempNameHT[name + '\xfffd' + altName] = retval;
+                    tempNameHT[key] = retval;
                 }
                 // when lcid == -1 then TextInfo object is already get created and we need to set it as read only.
                 retval.TextInfo.SetReadOnlyState(true);


### PR DESCRIPTION
Reduces lock contentions in `CultureInfo.GetCulture` and related APIs when many threads are calling this API simultaneously.

## Customer impact

The method family `CultureInfo.GetCulture` takes a global lock when searching for already-created CultureInfo instances. This can cause lock contention in high-traffic applications if multiple threads call these methods concurrently. We discovered this contention issue while investigating the contention issue described in https://github.com/dotnet/coreclr/pull/28201.

This fix does not remove the lock outright, but it shrinks the window in which any given thread holds the lock. Previously, the logic was:

1. Acquire the lock.
2. Compute the key which will be used to query the dictionary. (Computing the key is string concatenation.)
3. Query the dictionary.
4. Release the lock.

With this change, the key is computed (2) _before_ the lock is taken (1). This means that the only operation which takes place within the lock is a dictionary lookup - not a string concatenation - and such lookups are expected to be very fast.

## Regression

No. This is a perf improvement compared to 3.1 RTM. Aside from the perf improvement, no behavioral changes should be observed.

## Risk

Low. This does not change the logical flow of this method, as all string components are already floating around within the method as locals. We're not introducing any new method calls (aside from the string allocation itself) outside the lock.

Another alternative is to port https://github.com/dotnet/coreclr/pull/26567 in its entirety. That PR fixes some race conditions in this code in addition to moving the string concatenation before the lock acquisition. That PR has been baking in the product since 5.0 RTM and we have not received any complaints about it, so it should be considered stable if we'd instead prefer to bring that along. However, it is larger than the absolute minimum necessary to solve the lock contention issue the customer is seeing.