### PR TITLE
Switch to 1ES servicing pools on release/3.1-crossdac

### DIFF
--- a/eng/finalize-publish.yml
+++ b/eng/finalize-publish.yml
@@ -16,8 +16,8 @@ jobs:
     parameters:
       configuration: Release
       pool:
-        name: NetCoreInternal-Pool
-        queue: BuildPool.Windows.10.Amd64.VS2017
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017
       dependsOn: ${{ parameters.dependsOn }}
       publishUsingPipelines: true
       enablePublishBuildArtifacts: true

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -43,13 +43,13 @@ jobs:
 
       # Public Linux Build Pool
       ${{ if and(eq(parameters.osGroup, 'Linux'), eq(variables['System.TeamProject'], 'public')) }}:
-        name:  NetCorePublic-Pool
-        queue: BuildPool.Ubuntu.1604.Amd64.Open
+        name:  NetCore1ESPool-Svc-Public
+        demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
 
       # Official Build Linux Pool
       ${{ if and(eq(parameters.osGroup, 'Linux'), ne(variables['System.TeamProject'], 'public')) }}:
-        name: NetCoreInternal-Pool
-        queue: BuildPool.Ubuntu.1604.Amd64
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals Build.Ubuntu.1604.Amd64
 
       # FreeBSD builds only in the internal project
       ${{ if and(eq(parameters.osGroup, 'FreeBSD'), ne(variables['System.TeamProject'], 'public')) }}:
@@ -65,13 +65,13 @@ jobs:
 
       # Official Build Windows Pool
       ${{ if and(eq(parameters.osGroup, 'Windows_NT'), ne(variables['System.TeamProject'], 'public')) }}:
-        name: NetCoreInternal-Pool
-        queue: BuildPool.Windows.10.Amd64.VS2017
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017
 
       # Public Windows Build Pool
       ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(variables['System.TeamProject'], 'public')) }}:
-        name: NetCorePublic-Pool
-        queue: BuildPool.Windows.10.Amd64.VS2017.Open
+        name: NetCore1ESPool-Svc-Public
+        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017.Open
 
     workspace:
       clean: all


### PR DESCRIPTION
Same as https://github.com/dotnet/coreclr/pull/28206 but for the `release/3.1-crossdac` branch.