### PR TITLE
Update branding to 3.1.22

### DIFF
--- a/dir.common.props
+++ b/dir.common.props
@@ -65,7 +65,7 @@
 
   <PropertyGroup>
     <!-- Central place to set the versions of all nuget packages produced in the repo -->
-    <PackageVersion Condition="'$(PackageVersion)' == ''">3.1.21</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">3.1.22</PackageVersion>
     <PreReleaseLabel>servicing</PreReleaseLabel>
   </PropertyGroup>
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET Core product branding version -->
-    <ProductVersion>3.1.21</ProductVersion>
+    <ProductVersion>3.1.22</ProductVersion>
     <!-- File version numbers -->
     <MajorVersion>4</MajorVersion>
     <MinorVersion>7</MinorVersion>


### PR DESCRIPTION
Prepare branch for 3.1.22 release. After merge, the servising branch is considered open.