### PR TITLE
[release/3.1] Stop leaking atoll in pal and fix unicode header lookup

### DIFF
--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -7,9 +7,14 @@ add_definitions(-DBIT64)
 
 set(ICU_HOMEBREW_INC_PATH "/usr/local/opt/icu4c/include")
 
-find_path(UTYPES_H "unicode/utypes.h" PATHS ${ICU_HOMEBREW_INC_PATH})
-if(UTYPES_H STREQUAL UTYPES_H-NOTFOUND)
-    message(FATAL_ERROR "Cannot find utypes.h, try installing libicu-dev (or the appropriate package for your platform)")
+if (CLR_CMAKE_PLATFORM_DARWIN)
+  execute_process(COMMAND  brew --prefix OUTPUT_VARIABLE brew_prefix OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(ICU_HOMEBREW_INC_PATH "${brew_prefix}/opt/icu4c/include")
+endif()
+
+find_path(UCURR_H "unicode/ucurr.h" PATHS ${ICU_HOMEBREW_INC_PATH})
+if(UCURR_H STREQUAL UCURR_H-NOTFOUND)
+    message(FATAL_ERROR "Cannot find ucurr.h, try installing libicu-dev (or the appropriate package for your platform)")
     return()
 endif()
 
@@ -44,7 +49,7 @@ set(NATIVEGLOBALIZATION_SOURCES
     pal_icushim.c
 )
 
-include_directories(${UTYPES_H})
+include_directories(${UCURR_H})
 
 _add_library(System.Globalization.Native
     SHARED

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -206,6 +206,7 @@ function_name() to call the system's implementation
 #define srand DUMMY_srand
 #define atoi DUMMY_atoi
 #define atof DUMMY_atof
+#define atoll DUMMY_atoll
 #define tm PAL_tm
 #define size_t DUMMY_size_t
 #define time_t PAL_time_t
@@ -413,6 +414,7 @@ function_name() to call the system's implementation
 #undef wint_t
 #undef atoi
 #undef atol
+#undef atoll
 #undef atof
 #undef malloc
 #undef realloc


### PR DESCRIPTION
This fixes the build in newer OSX SDKs. @vseanreesermsft reported the following issue under SDK 11.3:

```
2021-11-17T17:14:20.3631480Z Executing make install -j 4
2021-11-17T17:14:20.4256230Z [  0%] Generating dummy/eventprovdotnetruntime.cpp, dummy/eventprovdotnetruntimerundown.cpp, dummy/eventprovdotnetruntimestress.cpp, dummy/eventprovdotnetruntimeprivate.cpp
2021-11-17T17:14:20.4529460Z [  0%] Building C object src/corefx/System.Globalization.Native/CMakeFiles/System.Globalization.Native.dir/pal_calendarData.c.o
2021-11-17T17:14:20.4707690Z [  0%] Building C object src/corefx/System.Globalization.Native/CMakeFiles/System.Globalization.Native_Static.dir/pal_calendarData.c.o
2021-11-17T17:14:20.4710540Z Scanning dependencies of target coreclrpal
2021-11-17T17:14:20.5081520Z [  0%] Building CXX object src/pal/src/CMakeFiles/coreclrpal.dir/cruntime/file.cpp.o
2021-11-17T17:14:20.7220520Z In file included from /Users/runner/work/1/s/src/pal/src/cruntime/file.cpp:22:
2021-11-17T17:14:20.7322630Z In file included from /Users/runner/work/1/s/src/pal/src/include/pal/palinternal.h:620:
2021-11-17T17:14:20.7422970Z In file included from /Applications/Xcode_13.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/stdlib.h:93:
2021-11-17T17:14:20.7526650Z /Applications/Xcode_13.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/stdlib.h:139:3: error: 'atoll' is missing exception specification 'throw()'
2021-11-17T17:14:20.7625410Z          atoll(const char *);
2021-11-17T17:14:20.7727310Z          ^
2021-11-17T17:14:20.7829290Z /Users/runner/work/1/s/src/pal/inc/pal.h:4224:33: note: previous declaration is here
2021-11-17T17:14:20.7930400Z PALIMPORT long long int __cdecl atoll(const char *) THROW_DECL;
```