### PR TITLE
[release/3.1] Enable System.Diagnostics.Tracing.EventSouce.AllowDuplicateSourceNames for partner

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -2936,7 +2936,7 @@ namespace System.Diagnostics.Tracing
                     m_rawManifest = manifest;
                 }
                 // TODO Enforce singleton pattern 
-                if (!AllowDiplicateSourceNames)
+                if (!AllowDuplicateSourceNames)
                 {
                     Debug.Assert(EventListener.s_EventSources != null, "should be called within lock on EventListener.EventListenersLock which ensures s_EventSources to be initialized");
                     foreach (WeakReference eventSourceRef in EventListener.s_EventSources)


### PR DESCRIPTION
This change is easier to view if you toggle "ignore whitespace changes" on in the GitHub UI.

This change backports the opt-in, off-by-default flag, `System.Diagnostics.Tracing.EventSouce.AllowDuplicateSourceNames`.

This flag, if enabled, will bypass the check for whether an EventSource already exists with a given name or GUID. This is a release valve only intended for users who make heavy use of AssemblyLoadContext and are experiencing exceptions from this code path. It does not solve any of the issues that may arise from enabling this configuration.

## Risk

There is negligible risk involved with this change for most users. It is off-by-default and requires conscious action on the user's part to enable.

When enabled, there _is_ a moderate amount of risk, as it is not a rigorously tested or previously supported scenario. Partner team validation and local testing of various scenarios showed that for specific use cases, it is sufficient.

Below is a collection of sample scenarios and the results of the traces when viewed in PerfView:

### Multiple manifest `EventSource`s with the _same_ layouts
```csharp
	[EventSource(Name="AA")]
    public sealed class A : EventSource
    {
        public void MyEvent() => WriteEvent(1);
    }

    [EventSource(Name="AA")]
    public sealed class AA : EventSource
    {
        public void MyEvent() => WriteEvent(1);
    }
```

Result: All events are received and correctly parsed

### Multiple manifest `EventSource`s with _different_ layouts
```csharp
	[EventSource(Name="AA")]
    public sealed class A : EventSource
    {
        public void MyEvent(int foo = 1) => WriteEvent(1, foo);
    }

    [EventSource(Name="AA")]
    public sealed class AA : EventSource
    {
        public void MyEvent(string foo = "foo") => WriteEvent(1, foo);
    }
```

Results: The last manifest received by PerfView is the one that gets used, so the `int` version of `MyEvent` gets parsed as the `string` version. I expected this kind of behavior.

### Multiple self-describing `EventSource`s with the _same_ events
```csharp
EventSource a = new("a");
EventSource aa = new("a");

// ...

a.Write("MyEvent");
aa.Write("MyEvent");
```

Results: All events are received and parsed correctly.

### Multiple self-describing `EventSource`s with _different_ events
```csharp
EventSource a = new("a");
EventSource aa = new("a");

// ...

a.Write("MyEvent", new { a = 1 });
aa.Write("MyEvent", new { b = 2 });
```

Results: All events are received and parsed correctly.

I ran into issues building release/3.1 locally on macOS that seem unrelated to these changes.