### PR TITLE
[release/3.1] Fix build with Clang 13 (#63314)

### DIFF
--- a/src/inc/corhlpr.h
+++ b/src/inc/corhlpr.h
@@ -335,7 +335,7 @@ struct COR_ILMETHOD_SECT
     const COR_ILMETHOD_SECT* Next() const   
     {
         if (!More()) return(0);
-        return ((COR_ILMETHOD_SECT*)(((BYTE *)this) + DataSize()))->Align();
+        return ((COR_ILMETHOD_SECT*)Align(((BYTE *)this) + DataSize()));
     }
 
     const BYTE* Data() const 
@@ -373,9 +373,9 @@ struct COR_ILMETHOD_SECT
         return((AsSmall()->Kind & CorILMethod_Sect_FatFormat) != 0); 
     }
 
-    const COR_ILMETHOD_SECT* Align() const        
+    static const void* Align(const void* p)
     { 
-        return((COR_ILMETHOD_SECT*) ((((UINT_PTR) this) + 3) & ~3));  
+        return((void*) ((((UINT_PTR) p) + 3) & ~3));
     }
 
 protected:
@@ -578,7 +578,7 @@ typedef struct tagCOR_ILMETHOD_FAT : IMAGE_COR_ILMETHOD_FAT
 
     const COR_ILMETHOD_SECT* GetSect() const {
         if (!More()) return (0);
-        return(((COR_ILMETHOD_SECT*) (GetCode() + GetCodeSize()))->Align());
+        return(((COR_ILMETHOD_SECT*) COR_ILMETHOD_SECT::Align(GetCode() + GetCodeSize())));
     }
 } COR_ILMETHOD_FAT;
 

--- a/src/jit/bitsetasshortlong.h
+++ b/src/jit/bitsetasshortlong.h
@@ -346,7 +346,7 @@ public:
     {
         if (IsShort(env))
         {
-            (size_t&)out = (size_t)out & ((size_t)gen | (size_t)in);
+            out = (BitSetShortLongRep)((size_t)out & ((size_t)gen | (size_t)in));
         }
         else
         {
@@ -362,7 +362,7 @@ public:
     {
         if (IsShort(env))
         {
-            (size_t&)in = (size_t)use | ((size_t)out & ~(size_t)def);
+            in = (BitSetShortLongRep)((size_t)use | ((size_t)out & ~(size_t)def));
         }
         else
         {


### PR DESCRIPTION
Port fix of build using Clang 13 to release/3.1. Backport of https://github.com/dotnet/runtime/pull/63314

# Customer Impact

The recently released Clang 13 has started to apply assumption that this pointer is always aligned to the natural alignment of the object. These break compilation of .NET Core 3.1 e.g. on Fedora 35 where Clang 13 is the one installed. This issue was reported by Red Hat developers.

# Testing

Local builds of release and debug versions using clang 9 and clang 13

# Risk

Low, there are no functional changes and the fix has been in main and release/6.0 branches for about 2 months.

---

Original commit message:

* Fix clang 13 induced runtime issues (#62170)

The clang 13 optimizer started to assume that "this" pointer is always
properly aligned. That lead to elimination of some code that was actually
needed.
It also takes pointer aliasing rules more strictly in one place in jit.
That caused the optimizer to falsely assume that a callee with an argument
passed by reference is not modifying that argument and used a stale
copy of the original value at the caller site.

This change fixes both of the issues. With this fix, runtime compiled
using clang 13 seems to be fully functional.

cc @janvorli 