### PR TITLE
[release/3.1] Add signing infrastructure for diagnostic binaries

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -19,9 +19,9 @@
 
   <ItemGroup>
     <!-- The DAC and the DBI must be signed separately. -->
-    <ItemsToSign Exclude="$(BinDir)/mscordaccore*.dll" />
-    <ItemsToSign Include="$(BinDir)$(CrossTargetComponentFolder)/mscordaccore*.dll" />
-    <ItemsToSign Exclude="$(BinDir)/mscordbi.dll" />
+    <ItemsToSign Remove="$(BinDir)/mscordaccore*.dll" />
+    <ItemsToSign Remove="$(BinDir)$(CrossTargetComponentFolder)/mscordaccore*.dll" />
+    <ItemsToSign Remove="$(BinDir)/mscordbi.dll" />
     <FileSignInfo Include="mscordaccore.dll" CertificateName="None" />
     <FileSignInfo Include="mscordbi.dll" CertificateName="None" />
   </ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -6,10 +6,6 @@
     <ItemsToSign Include="$(BinDir)*.exe" />
   </ItemGroup>
 
-  <ItemGroup>
-    <FileSignInfo Include="mscordaccore.dll" CertificateName="MicrosoftSHA2" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(BuildArch)' == 'x86'">
     <!-- Sign api-ms-win-core-xstate-l2-1-0 binary as it is only catalog signed in the current SDK. -->
     <ItemsToSign Condition="'$(BuildType)'=='Release'" Include="$(BinDir)Redist\ucrt\DLLs\$(BuildArch)\api-ms-win-core-xstate-l2-1-0.dll" />
@@ -19,6 +15,15 @@
   <ItemGroup Condition="'$(CrossTargetComponentFolder)' != ''">
     <ItemsToSign Include="$(BinDir)$(CrossTargetComponentFolder)/*.dll" />
     <ItemsToSign Include="$(BinDir)$(CrossTargetComponentFolder)/*.exe" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The DAC and the DBI must be signed separately. -->
+    <ItemsToSign Exclude="$(BinDir)/mscordaccore*.dll" />
+    <ItemsToSign Include="$(BinDir)$(CrossTargetComponentFolder)/mscordaccore*.dll" />
+    <ItemsToSign Exclude="$(BinDir)/mscordbi.dll" />
+    <FileSignInfo Include="mscordaccore.dll" CertificateName="None" />
+    <FileSignInfo Include="mscordbi.dll" CertificateName="None" />
   </ItemGroup>
 
   <Target Name="ValidateSignFileListIsNotEmpty" BeforeTargets="Sign">

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -134,6 +134,11 @@ jobs:
       - powershell: eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0 /p:ArcadeBuild=true /p:OfficialBuild=true /p:BuildOS=$(osGroup) /p:BuildArch=$(archType) /p:BuildType=$(_BuildConfig) /p:DotNetSignType=$env:_SignType -projects $(Build.SourcesDirectory)\eng\empty.csproj
         displayName: Sign Binaries
 
+      - template: /eng/sign-diagnostic-files.yml
+        parameters:
+          basePath: $(Build.SourcesDirectory)/bin/Product/$(osGroup).$(archType).$(_BuildConfig)
+          timeoutInMinutes: 30
+
       - task: PublishBuildArtifacts@1
         displayName: Publish Signing Logs
         inputs:

--- a/eng/sign-diagnostic-files.yml
+++ b/eng/sign-diagnostic-files.yml
@@ -1,0 +1,68 @@
+parameters:
+  basePath: ''
+  timeoutInMinutes: ''
+
+steps:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+  - task: EsrpCodeSigning@1
+    displayName: Sign Diagnostic Binaries
+    inputs:
+      ConnectedServiceName: 'dotnetesrp-diagnostics-dnceng'
+      FolderPath: ${{ parameters.basePath }}
+      Pattern: |
+        **/mscordaccore*.dll
+        **/mscordbi*.dll
+      UseMinimatch: true
+      signConfigType: 'inlineSignParams'
+      inlineOperation: >-
+        [
+          {
+            "keyCode": "CP-471322",
+            "operationCode": "SigntoolSign",
+            "parameters": {
+              "OpusName": "Microsoft",
+              "OpusInfo": "http://www.microsoft.com",
+              "PageHash": "/NPH",
+              "FileDigest": "/fd sha256",
+              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            },
+            "toolName": "sign",
+            "toolVersion": "1.0"
+          },
+          {
+            "KeyCode": "CP-471322",
+            "OperationCode": "SigntoolVerify",
+            "Parameters": {},
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          }
+        ]
+      SessionTimeout: ${{ parameters.timeoutInMinutes }}
+      MaxConcurrency: '50'
+      MaxRetryAttempts: '5'
+
+  - powershell: |
+      $filesToSign = $(Get-ChildItem -Recurse ${{ parameters.basePath }} -Include mscordaccore*.dll, mscordbi*.dll)
+      foreach ($file in $filesToSign) {
+        $signingCert = $(Get-AuthenticodeSignature $file).SignerCertificate
+        if ($signingCert -eq $null)
+        {
+          throw "File $file does not contain a signature."
+        }
+
+        if ($signingCert.Subject -ne "CN=.NET DAC, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" `
+            -or $signingCert.Issuer -ne "CN=Microsoft Code Signing PCA 2010, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")
+        {
+          throw "File $file not in expected trust chain."
+        }
+
+        $certEKU = $signingCert.Extensions.Where({ $_.Oid.FriendlyName -eq "Enhanced Key Usage" }) | Select -First 1
+
+        if ($certEKU.EnhancedKeyUsages.Where({ $_.Value -eq "1.3.6.1.4.1.311.84.4.1" }).Count -ne 1)
+        {
+          throw "Signature for $file does not contain expected EKU."
+        }
+
+        Write-Host "$file is correctly signed."
+      }
+    displayName: Validate diagnostic signatures

--- a/eng/sign-diagnostic-files.yml
+++ b/eng/sign-diagnostic-files.yml
@@ -3,7 +3,7 @@ parameters:
   timeoutInMinutes: ''
 
 steps:
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'), or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'))) }}:
   - task: EsrpCodeSigning@1
     displayName: Sign Diagnostic Binaries
     inputs:


### PR DESCRIPTION
Use a signing infrastructure orthogonal to microbuild to use other certs for diagnostic binaries.