### PR TITLE
Remove all other signing off crossdac leg

### DIFF
--- a/eng/build-crossdac-job.yml
+++ b/eng/build-crossdac-job.yml
@@ -103,16 +103,13 @@ jobs:
         - script: set __TestIntermediateDir=int&&build.cmd -alpinedac $(buildConfig) $(archType) $(officialBuildIdArg)
           displayName: Build Alpine dac
 
-      # Sign with the DAC cert
-      - template: /eng/sign-diagnostic-files.yml
-        parameters:
-          basePath: $(Build.SourcesDirectory)/bin/Product
-          timeoutInMinutes: 30
 
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-        # Sign
-        - powershell: eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0 /p:ArcadeBuild=true /p:OfficialBuild=true /p:BuildOS=$(osGroup) /p:BuildArch=$(archType) /p:BuildType=$(_BuildConfig) /p:CrossDac=true /p:DotNetSignType=$env:_SignType -projects $(Build.SourcesDirectory)\eng\empty.csproj
-          displayName: Sign Linux Binaries
+        # Sign with the DAC cert
+        - template: /eng/sign-diagnostic-files.yml
+          parameters:
+            basePath: $(Build.SourcesDirectory)/bin/Product
+            timeoutInMinutes: 30
 
         - task: PublishBuildArtifacts@1
           displayName: Publish Signing Logs


### PR DESCRIPTION
The crossdac legs sign diagnostic binaries separately. Remove all other signing steps as unnecessary.﻿
